### PR TITLE
fix(experiments): Patch canUseOverrides variable

### DIFF
--- a/src/plugins/experiments.ts
+++ b/src/plugins/experiments.ts
@@ -10,5 +10,11 @@ export default definePlugin({
             match: /(?<={isDeveloper:\{[^}]+,get:function\(\)\{return )\w/,
             replace: "true"
         }
+    }, {
+        find: "canUseOverrides",
+        replacement: {
+            match: /(\w)\|\|"CONNECTION_OPEN".+?;/g,
+            replace: "$1=!0;"
+        }
     }]
 });


### PR DESCRIPTION
This patches the canUseOverrides variable to re-enable experiments on newer builds.