### PR TITLE
Make NitroBypass only add spaces when there are none

### DIFF
--- a/src/plugins/nitroBypass.ts
+++ b/src/plugins/nitroBypass.ts
@@ -56,7 +56,9 @@ export default definePlugin({
 
                 const emojiString = `<${emoji.animated ? 'a' : ''}:${emoji.originalName || emoji.name}:${emoji.id}>`;
                 const url = emoji.url.replace(/\?size=[0-9]+/, `?size=48`);
-                messageObj.content = messageObj.content.replace(emojiString, ` ${url} `);
+                messageObj.content = messageObj.content.replace(emojiString, (match, offset, string) => {
+                    return `${string[offset-1] === " " ? "" : " "}${url}${string[offset+length] === " " ? "" : " "}`
+                });
             }
         });
 
@@ -68,7 +70,9 @@ export default definePlugin({
                 if (emoji == null || (emoji.guildId === guildId && !emoji.animated)) continue;
 
                 const url = emoji.url.replace(/\?size=[0-9]+/, `?size=48`);
-                messageObj.content = messageObj.content.replace(emojiStr, ` ${url} `);
+                messageObj.content = messageObj.content.replace(emojiStr, (match, offset, string) => {
+                    return `${string[offset-1] === " " ? "" : " "}${url}${string[offset+length] === " " ? "" : " "}`
+                });
             }
         });
     },

--- a/src/plugins/nitroBypass.ts
+++ b/src/plugins/nitroBypass.ts
@@ -48,7 +48,7 @@ export default definePlugin({
 
         const { getCustomEmojiById } = findByProps("getCustomEmojiById");
 
-        function whitespaceCheck(origStr, offset) {
+        function getWordBoundary(origStr, offset) {
             return (!origStr[offset] || /\s/.test(origStr[offset])) ? "" : " ";
         }
 
@@ -61,7 +61,7 @@ export default definePlugin({
                 const emojiString = `<${emoji.animated ? 'a' : ''}:${emoji.originalName || emoji.name}:${emoji.id}>`;
                 const url = emoji.url.replace(/\?size=[0-9]+/, `?size=48`);
                 messageObj.content = messageObj.content.replace(emojiString, (match, offset, origStr) => {
-                    return `${whitespaceCheck(origStr, offset-1)}${url}${whitespaceCheck(origStr, offset+match.length)}`;
+                    return `${getWordBoundary(origStr, offset-1)}${url}${getWordBoundary(origStr, offset+match.length)}`;
                 });
             }
         });
@@ -76,7 +76,7 @@ export default definePlugin({
 
                 const url = emoji.url.replace(/\?size=[0-9]+/, `?size=48`);
                 messageObj.content = messageObj.content.replace(emojiStr, (match, offset, origStr) => {
-                    return `${whitespaceCheck(origStr, offset-1)}${url}${whitespaceCheck(origStr, offset+match.length)}`;
+                    return `${getWordBoundary(origStr, offset-1)}${url}${getWordBoundary(origStr, offset+match.length)}`;
                 });
             }
         });

--- a/src/plugins/nitroBypass.ts
+++ b/src/plugins/nitroBypass.ts
@@ -49,7 +49,7 @@ export default definePlugin({
         const { getCustomEmojiById } = findByProps("getCustomEmojiById");
 
         function whitespaceCheck(origStr, offset) {
-            return !origStr[offset] || /\s/.test(origStr[offset]);
+            return (!origStr[offset] || /\s/.test(origStr[offset])) ? "" : " ";
         }
 
         this.preSend = addPreSendListener((_, messageObj) => {
@@ -61,7 +61,7 @@ export default definePlugin({
                 const emojiString = `<${emoji.animated ? 'a' : ''}:${emoji.originalName || emoji.name}:${emoji.id}>`;
                 const url = emoji.url.replace(/\?size=[0-9]+/, `?size=48`);
                 messageObj.content = messageObj.content.replace(emojiString, (match, offset, origStr) => {
-                    return `${whitespaceCheck(origStr, offset-1) ? "" : " "}${url}${whitespaceCheck(origStr, offset+match.length) ? "" : " "}`;
+                    return `${whitespaceCheck(origStr, offset-1)}${url}${whitespaceCheck(origStr, offset+match.length)}`;
                 });
             }
         });
@@ -76,7 +76,7 @@ export default definePlugin({
 
                 const url = emoji.url.replace(/\?size=[0-9]+/, `?size=48`);
                 messageObj.content = messageObj.content.replace(emojiStr, (match, offset, origStr) => {
-                    return `${whitespaceCheck(origStr, offset-1) ? "" : " "}${url}${whitespaceCheck(origStr, offset+match.length) ? "" : " "}`;
+                    return `${whitespaceCheck(origStr, offset-1)}${url}${whitespaceCheck(origStr, offset+match.length)}`;
                 });
             }
         });

--- a/src/plugins/nitroBypass.ts
+++ b/src/plugins/nitroBypass.ts
@@ -71,7 +71,7 @@ export default definePlugin({
 
                 const url = emoji.url.replace(/\?size=[0-9]+/, `?size=48`);
                 messageObj.content = messageObj.content.replace(emojiStr, (match, offset, string) => {
-                    return `${string[offset-1] === " " ? "" : " "}${url}${string[offset+length] === " " ? "" : " "}`
+                    return `${(!string[offset-1]?.match(/\s/)) ? "" : " "}${url}${!string[offset+length]?.match(/\s/) ? "" : " "}`
                 });
             }
         });


### PR DESCRIPTION
IE, `test:emoji:` turns into `test https://discord[blahblahbla]`, but `test :emoji:` becomes   
`test https://discord[blahblah]` and *not* `test  https://discord[blah]` (which was the prior behaviour)