### PR TITLE
fix(plugin): fix stream quality bypass in nitroBypass

### DIFF
--- a/src/plugins/nitroBypass.ts
+++ b/src/plugins/nitroBypass.ts
@@ -15,7 +15,9 @@ export default definePlugin({
             replacement: [
                 "canUseAnimatedEmojis",
                 "canUseEmojisEverywhere",
-                "canUseHigherFramerate"
+                "canUseHighVideoQuality",
+                "canStreamHighQuality",
+                "canStreamMidQuality"
             ].map(func => {
                 return {
                     match: new RegExp(`${func}:function\\(.+?}`),


### PR DESCRIPTION
it was broken by one of the latest discord updates which renamed some functions related to nitro