### PR TITLE
Add pronoundb plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
         "typescript": "^4.8.4",
         "yazl": "^2.5.1"
     },
-    "packageManager": "pnpm@7.12.2"
+    "packageManager": "pnpm@7.13.4"
 }

--- a/src/plugins/pronoundb/PronounComponent.tsx
+++ b/src/plugins/pronoundb/PronounComponent.tsx
@@ -1,0 +1,23 @@
+import { fetchPronouns } from "./utils";
+import { useAwaiter } from "../../utils/misc";
+import { MessageHeaderProps, PronounMapping } from "./types";
+import { findByProps } from "../../webpack";
+import { proxyLazy } from "../../utils";
+
+const styles: Record<string, string> = proxyLazy(() => findByProps("timestampInline"));
+
+export default function PronounComponent({ message }: MessageHeaderProps) {
+    // Don't bother fetching bot or system users
+    if (message.author.bot && message.author.system) return null;
+
+    const [result, error, isPending] = useAwaiter(() => fetchPronouns(message.author.id));
+
+    // If the fetching completed successfully and the result was not "unspecified", then return a span with the pronouns
+    if (!isPending && result && result !== "unspecified") return (
+        <span className={`${styles.timestampInline} ${styles.timestamp}`}>• {PronounMapping[result]}</span>
+    );
+    // If there was an error, log it
+    if (error) console.error("Error fetching pronouns: ", error);
+    // Return null so nothing else is rendered
+    return null;
+}

--- a/src/plugins/pronoundb/index.ts
+++ b/src/plugins/pronoundb/index.ts
@@ -13,7 +13,7 @@ export default definePlugin({
         {
             find: "showCommunicationDisabledStyles",
             replacement: {
-                match: /(?<=return\s+\w{1,3}\.createElement\(\w{1,3}\.Fragment.+\w{1,3}&&!\w{1,3}&&)(\w{1,3}.createElement\((?:\w{1,3}|\.)+,\{.+?\}\))/,
+                match: /(?<=return\s+\w{1,3}\.createElement\(.+!\w{1,3}&&)(\w{1,3}.createElement\(.+?\{.+?\}\))/,
                 replace: "[$1, Vencord.Plugins.plugins.PronounDB.PronounComponent(e)]"
             }
         }

--- a/src/plugins/pronoundb/index.ts
+++ b/src/plugins/pronoundb/index.ts
@@ -1,0 +1,23 @@
+import definePlugin from "../../utils/types";
+import PronounComponent from "./PronounComponent";
+import { fetchPronouns } from "./utils";
+
+export default definePlugin({
+    name: "PronounDB",
+    authors: [{
+        name: "Tyman",
+        id: 487443883127472129n
+    }],
+    description: "Adds pronouns to user messages using pronoundb",
+    patches: [
+        {
+            find: "showCommunicationDisabledStyles",
+            replacement: {
+                match: /(?<=return\s+\w{1,3}\.createElement\(\w{1,3}\.Fragment.+\w{1,3}&&!\w{1,3}&&)(\w{1,3}.createElement\((?:\w{1,3}|\.)+,\{.+?\}\))/,
+                replace: "[$1, Vencord.Plugins.plugins.PronounDB.PronounComponent(e)]"
+            }
+        }
+    ],
+    // Re-export the component on the plugin object so it is easily accessible in patches
+    PronounComponent
+});

--- a/src/plugins/pronoundb/types.ts
+++ b/src/plugins/pronoundb/types.ts
@@ -1,0 +1,40 @@
+// Not the full props, only what is necessary for pronoundb plugin to work
+export interface MessageHeaderProps {
+    message: {
+        author: {
+            id: string;
+            bot: boolean;
+            system: boolean;
+        },
+    };
+}
+
+export interface PronounsResponse {
+    [id: string]: PronounCode;
+}
+
+export type PronounCode = keyof typeof PronounMapping;
+
+export const PronounMapping = {
+    unspecified: "Unspecified",
+    hh: "He/Him",
+    hi: "He/It",
+    hs: "He/She",
+    ht: "He/They",
+    ih: "It/Him",
+    ii: "It/Its",
+    is: "It/She",
+    it: "It/They",
+    shh: "She/He",
+    sh: "She/Her",
+    si: "She/It",
+    st: "She/They",
+    th: "They/He",
+    ti: "They/It",
+    ts: "They/She",
+    tt: "They/Them",
+    any: "Any pronouns",
+    other: "Other pronouns",
+    ask: "Ask me my pronouns",
+    avoid: "Avoid pronouns, use my name"
+} as const;

--- a/src/plugins/pronoundb/types.ts
+++ b/src/plugins/pronoundb/types.ts
@@ -1,14 +1,3 @@
-// Not the full props, only what is necessary for pronoundb plugin to work
-export interface MessageHeaderProps {
-    message: {
-        author: {
-            id: string;
-            bot: boolean;
-            system: boolean;
-        },
-    };
-}
-
 export interface PronounsResponse {
     [id: string]: PronounCode;
 }

--- a/src/plugins/pronoundb/utils.ts
+++ b/src/plugins/pronoundb/utils.ts
@@ -1,0 +1,56 @@
+import { debounce } from "../../utils";
+import { PronounCode, PronounsResponse } from "./types";
+
+// A map of cached pronouns so the same request isn't sent twice
+const cache: Record<string, PronounCode> = {};
+// A map of ids and callbacks that should be triggered on fetch
+const requestQueue: Record<string, ((pronouns: PronounCode) => void)[]> = {};
+
+// Executes all queued requests and calls their callbacks
+const bulkFetch = debounce(async () => {
+    const ids = Object.keys(requestQueue);
+    const pronouns = await bulkFetchPronouns(ids);
+    for (const [id, callbacks] of Object.entries(requestQueue)) {
+        // Call all callbacks for the id
+        callbacks.forEach(c => c(pronouns[id]));
+    }
+});
+
+// Fetches the pronouns for one id, returning a promise that resolves if it was cached, or once the request is completed
+export function fetchPronouns(id: string): Promise<PronounCode> {
+    return new Promise(res => {
+        // If cached, return the cached pronouns
+        if (id in cache) res(cache[id]);
+        // If there is already a request added, then just add this callback to it
+        else if (id in requestQueue) requestQueue[id].push(res);
+        // If not already added, then add it and call the debounced function to make sure the request gets executed
+        else {
+            requestQueue[id] = [res];
+            bulkFetch();
+        }
+    });
+}
+
+async function bulkFetchPronouns(ids: string[]): Promise<PronounsResponse> {
+    const params = new URLSearchParams();
+    params.append("platform", "discord");
+    params.append("ids", ids.join(","));
+    const req = await fetch("https://pronoundb.org/api/v1/lookup-bulk?" + params, {
+        method: "GET",
+        headers: {
+            "Accept": "application/json"
+        }
+    });
+    return await req.json()
+        .then((res: PronounsResponse) => {
+            for (const [id, pronouns] of Object.entries(res)) {
+                cache[id] = pronouns;
+            }
+            return res;
+        })
+        .catch(e => {
+            // If the request errors, treat it as if no pronouns were found for all ids
+            for (const id of ids) cache[id] = "unspecified";
+            return Object.fromEntries(ids.map(id => [id, "unspecified"]));
+        });
+}

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -30,10 +30,11 @@ export function lazyWebpack<T = any>(filter: FilterFn): T {
  */
 export function useAwaiter<T>(factory: () => Promise<T>): [T | null, any, boolean];
 export function useAwaiter<T>(factory: () => Promise<T>, fallbackValue: T): [T, any, boolean];
-export function useAwaiter<T>(factory: () => Promise<T>, fallbackValue: T | null = null): [T | null, any, boolean] {
+export function useAwaiter<T>(factory: () => Promise<T>, fallbackValue: null, onError: (e: unknown) => unknown): [T, any, boolean];
+export function useAwaiter<T>(factory: () => Promise<T>, fallbackValue: T | null = null, onError?: (e: unknown) => unknown): [T | null, any, boolean] {
     const [state, setState] = React.useState({
         value: fallbackValue,
-        error: null as any,
+        error: null,
         pending: true
     });
 
@@ -41,7 +42,7 @@ export function useAwaiter<T>(factory: () => Promise<T>, fallbackValue: T | null
         let isAlive = true;
         factory()
             .then(value => isAlive && setState({ value, error: null, pending: false }))
-            .catch(error => isAlive && setState({ value: null, error, pending: false }));
+            .catch(error => isAlive && setState({ value: null, error, pending: false }) || onError?.(error));
 
         return () => void (isAlive = false);
     }, []);

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -42,7 +42,7 @@ export function useAwaiter<T>(factory: () => Promise<T>, fallbackValue: T | null
         let isAlive = true;
         factory()
             .then(value => isAlive && setState({ value, error: null, pending: false }))
-            .catch(error => isAlive && setState({ value: null, error, pending: false }) || onError?.(error));
+            .catch(error => isAlive && (setState({ value: null, error, pending: false }), onError?.(error)));
 
         return () => void (isAlive = false);
     }, []);


### PR DESCRIPTION
Uses bulk requests to request all queued users every 300ms (can be changed), and caches all fetched pronouns (even if the request fails, it will not try to fetch it again)
This uses capitalized pronouns (`They/Them` as opposed to `they/them`) right now, but that can be changed

Also updated pnpm because it was being annoying about it