### PR TITLE
show only the required plugins that are enabled

### DIFF
--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -230,5 +230,6 @@ function makeDependencyList(deps: string[]) {
 }
 
 function dependencyCheck(pluginName: string, depMap: Record<string, string[]>): string[] {
-    return depMap[pluginName] || [];
+    const settings = useSettings();
+    return depMap[pluginName]?.filter(d => settings.plugins[d].enabled) || [];
 }

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -230,6 +230,5 @@ function makeDependencyList(deps: string[]) {
 }
 
 function dependencyCheck(pluginName: string, depMap: Record<string, string[]>): string[] {
-    const settings = useSettings();
-    return depMap[pluginName]?.filter(d => settings.plugins[d].enabled) || [];
+    return depMap[pluginName]?.filter(d => Settings.plugins[d].enabled) || [];
 }


### PR DESCRIPTION
At the moment, all plugins that need the required plugins are shown, instead of only the enabled plugins.