### PR TITLE
Add a "NEW" Badge for New Plugins

### DIFF
--- a/scripts/build/common.mjs
+++ b/scripts/build/common.mjs
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import esbuild from "esbuild";
-import { existsSync, statSync } from "fs";
-import { readdir } from "fs/promises";
+import { existsSync } from "fs";
+import { readdir, stat } from "fs/promises";
 
 const watch = process.argv.includes("--watch");
 
@@ -57,8 +57,8 @@ export const globPlugins = {
                     const files = await readdir(`./src/${dir}`);
                     for (const file of files) {
                         let isNew = false;
-                        let stats = statSync(`./src/${dir}/${file}`);
-                        let dirStats = statSync(`./src/${dir}`);
+                        let stats = await stat(`./src/${dir}/${file}`);
+                        let dirStats = await stat(`./src/${dir}`);
                         if (
                             // File is younger than a week old
                             (new Date(stats.birthtime.valueOf()).setDate(

--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -29,8 +29,8 @@ import { Button, FluxDispatcher, Forms, React, Text, Tooltip, UserStore, UserUti
 import ErrorBoundary from "../ErrorBoundary";
 import { Flex } from "../Flex";
 import {
-    NewBadge,
     ISettingElementProps,
+    NewBadge,
     SettingBooleanComponent,
     SettingCustomComponent,
     SettingNumericComponent,

--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -29,13 +29,12 @@ import { Button, FluxDispatcher, Forms, React, Text, Tooltip, UserStore, UserUti
 import ErrorBoundary from "../ErrorBoundary";
 import { Flex } from "../Flex";
 import {
+    NewBadge,
     SettingBooleanComponent,
     SettingInputComponent,
     SettingNumericComponent,
     SettingSelectComponent,
-    SettingSliderComponent,
-    NewBadge
-} from "./components";
+    SettingSliderComponent } from "./components";
 
 const UserSummaryItem = lazyWebpack(filters.byCode("defaultRenderUser", "showDefaultAvatarsForNullUsers"));
 const AvatarStyles = lazyWebpack(filters.byProps(["moreUsers", "emptyUser", "avatarContainer", "clickableAvatar"]));

--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -16,6 +16,7 @@ import {
     SettingNumericComponent,
     SettingSelectComponent,
     SettingSliderComponent,
+    NewBadge
 } from "./components";
 
 const UserSummaryItem = lazyWebpack(filters.byCode("defaultRenderUser", "showDefaultAvatarsForNullUsers"));
@@ -143,7 +144,7 @@ export default function PluginModal({ plugin, onRestartNeeded, onClose, transiti
     return (
         <ModalRoot transitionState={transitionState} size={ModalSize.MEDIUM}>
             <ModalHeader>
-                <Text variant="heading-md/bold">{plugin.name}</Text>
+                <Text variant="heading-md/bold" style={{ display: "flex", width: "100%", alignItems: "center" }}>{plugin.name} {(plugin.new) && <NewBadge />}</Text>
             </ModalHeader>
             <ModalContent style={{ marginBottom: 8, marginTop: 8 }}>
                 <Forms.FormSection>

--- a/src/components/PluginSettings/components/NewBadge.tsx
+++ b/src/components/PluginSettings/components/NewBadge.tsx
@@ -1,5 +1,5 @@
 export function NewBadge(): JSX.Element {
     return (
-        <div style={{ backgroundColor: "#5865F2", justifySelf: "flex-end", marginLeft: "auto" }} className="textBadge-1fdDPJ base-3IDx3L baseShapeRound-3epLEv">New</div>
+        <div style={{ backgroundColor: "#ED4245", justifySelf: "flex-end", marginLeft: "auto" }} className="textBadge-1fdDPJ base-3IDx3L baseShapeRound-3epLEv">New</div>
     );
 }

--- a/src/components/PluginSettings/components/NewBadge.tsx
+++ b/src/components/PluginSettings/components/NewBadge.tsx
@@ -1,0 +1,5 @@
+export function NewBadge(): JSX.Element {
+    return (
+        <div style={{ backgroundColor: "#5865F2", justifySelf: "flex-end", marginLeft: "auto" }} className="textBadge-1fdDPJ base-3IDx3L baseShapeRound-3epLEv">New</div>
+    );
+}

--- a/src/components/PluginSettings/components/NewBadge.tsx
+++ b/src/components/PluginSettings/components/NewBadge.tsx
@@ -1,3 +1,21 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 export function NewBadge(): JSX.Element {
     return (
         <div style={{ backgroundColor: "#ED4245", justifySelf: "flex-end", marginLeft: "auto" }} className="textBadge-1fdDPJ base-3IDx3L baseShapeRound-3epLEv">New</div>

--- a/src/components/PluginSettings/components/NewBadge.tsx
+++ b/src/components/PluginSettings/components/NewBadge.tsx
@@ -16,8 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { Badge } from "../styles";
+
 export function NewBadge(): JSX.Element {
     return (
-        <div style={{ backgroundColor: "#ED4245", justifySelf: "flex-end", marginLeft: "auto" }} className="textBadge-1fdDPJ base-3IDx3L baseShapeRound-3epLEv">New</div>
+        <div style={{ backgroundColor: "#ED4245", justifySelf: "flex-end", marginLeft: "auto", ...Badge }}>New</div>
     );
 }

--- a/src/components/PluginSettings/components/index.ts
+++ b/src/components/PluginSettings/components/index.ts
@@ -29,9 +29,9 @@ export interface ISettingElementProps<T extends PluginOptionBase> {
     onError(hasError: boolean): void;
 }
 
+export * from "./NewBadge";
 export * from "./SettingBooleanComponent";
 export * from "./SettingNumericComponent";
 export * from "./SettingSelectComponent";
 export * from "./SettingSliderComponent";
-export * from "./NewBadge";
 export * from "./SettingTextComponent";

--- a/src/components/PluginSettings/components/index.ts
+++ b/src/components/PluginSettings/components/index.ts
@@ -16,3 +16,4 @@ export * from "./SettingNumericComponent";
 export * from "./SettingSelectComponent";
 export * from "./SettingTextComponent";
 export * from "./SettingSliderComponent";
+export * from "./NewBadge";

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -16,6 +16,13 @@ import * as styles from "./styles";
 const Select = lazyWebpack(filters.byCode("optionClassName", "popoutPosition", "autoFocus", "maxVisibleItems"));
 const InputStyles = lazyWebpack(filters.byProps(["inputDefault", "inputWrapper"]));
 
+// Not sure where to put this lol
+function NewBadge(): JSX.Element {
+    return (
+        <div style={{ backgroundColor: "#5865F2", justifySelf: "flex-end", marginLeft: "auto" }} className="textBadge-1fdDPJ base-3IDx3L baseShapeRound-3epLEv">New</div>
+    );
+}
+
 function showErrorToast(message: string) {
     Toasts.show({
         message,
@@ -62,7 +69,7 @@ function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLe
 
     return (
         <Flex style={styles.PluginsGridItem} flexDirection="column" onClick={() => openModal()} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-            <Text variant="text-md/bold">{plugin.name}</Text>
+            <Text variant="text-md/bold" style={{ display: "flex" }}>{plugin.name} {(plugin.new) && <NewBadge />}</Text>
             <Text variant="text-md/normal" style={{ height: 40, overflow: "hidden" }}>{plugin.description}</Text>
             <Flex flexDirection="row-reverse" style={{ marginTop: "auto", width: "100%", justifyContent: "space-between" }}>
                 <Button

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -149,8 +149,8 @@ function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLe
                 note={<Text variant="text-md/normal" style={{ height: 40, overflow: "hidden" }}>{plugin.description}</Text>}
                 hideBorder={true}
             >
-                <Flex style={{ marginTop: "auto", width: "100%", height: "100%", alignItems: "center" }}>
-                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1", gap: "1em" }}>{plugin.name}{(plugin.new) && <NewBadge />}</Text>
+                <Flex style={{ marginTop: "auto", width: "100%", height: "100%", alignItems: "center", gap: "8px" }}>
+                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1", gap: "8px" }}>{plugin.name}{(plugin.new) && <NewBadge />}</Text>
                     <button role="switch" onClick={() => openModal()} style={styles.SettingsIcon} className="button-12Fmur">
                         {plugin.options
                             ? <CogWheel

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -92,7 +92,7 @@ function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLe
                 hideBorder={true}
             >
                 <Flex style={{ marginTop: "auto", width: "100%", height: "100%", alignItems: "center" }}>
-                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1" }}>{plugin.name} {(plugin.new) && <NewBadge />}</Text>
+                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1" }}><span style={{ marginRight: "10px" }}>{plugin.name}</span>{(plugin.new) && <NewBadge />}</Text>
                     <button role="switch" onClick={() => openModal()} style={styles.SettingsIcon} className="button-12Fmur">
                         {plugin.options ? <CogWheel /> : <InfoIcon width="24" height="24" />}
                     </button>
@@ -167,7 +167,7 @@ export default ErrorBoundary.wrap(function Settings() {
     };
 
     return (
-        <Forms.FormSection tag="h1" title="Vencord">
+        <Forms.FormSection tag="h1" title="Vencord Plugins">
             <Forms.FormTitle tag="h5" className={classes(Margins.marginTop20, Margins.marginBottom8)}>
                 Plugins
             </Forms.FormTitle>

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -28,9 +28,9 @@ import { filters } from "../../webpack";
 import { Alerts, Button, Forms, Margins, Parser, React, Text, TextInput, Toasts, Tooltip } from "../../webpack/common";
 import ErrorBoundary from "../ErrorBoundary";
 import { Flex } from "../Flex";
+import { NewBadge } from "./components";
 import PluginModal from "./PluginModal";
 import * as styles from "./styles";
-import { NewBadge } from "./components";
 
 const Select = lazyWebpack(filters.byCode("optionClassName", "popoutPosition", "autoFocus", "maxVisibleItems"));
 const InputStyles = lazyWebpack(filters.byProps(["inputDefault", "inputWrapper"]));

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -12,16 +12,10 @@ import ErrorBoundary from "../ErrorBoundary";
 import { Flex } from "../Flex";
 import PluginModal from "./PluginModal";
 import * as styles from "./styles";
+import { NewBadge } from "./components";
 
 const Select = lazyWebpack(filters.byCode("optionClassName", "popoutPosition", "autoFocus", "maxVisibleItems"));
 const InputStyles = lazyWebpack(filters.byProps(["inputDefault", "inputWrapper"]));
-
-// Not sure where to put this lol
-function NewBadge(): JSX.Element {
-    return (
-        <div style={{ backgroundColor: "#5865F2", justifySelf: "flex-end", marginLeft: "auto" }} className="textBadge-1fdDPJ base-3IDx3L baseShapeRound-3epLEv">New</div>
-    );
-}
 
 function showErrorToast(message: string) {
     Toasts.show({
@@ -69,7 +63,7 @@ function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLe
 
     return (
         <Flex style={styles.PluginsGridItem} flexDirection="column" onClick={() => openModal()} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-            <Text variant="text-md/bold" style={{ display: "flex" }}>{plugin.name} {(plugin.new) && <NewBadge />}</Text>
+            <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center" }}>{plugin.name} {(plugin.new) && <NewBadge />}</Text>
             <Text variant="text-md/normal" style={{ height: 40, overflow: "hidden" }}>{plugin.description}</Text>
             <Flex flexDirection="row-reverse" style={{ marginTop: "auto", width: "100%", justifyContent: "space-between" }}>
                 <Button

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -150,7 +150,7 @@ function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLe
                 hideBorder={true}
             >
                 <Flex style={{ marginTop: "auto", width: "100%", height: "100%", alignItems: "center" }}>
-                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1" }}><span style={{ marginRight: "10px" }}>{plugin.name}</span>{(plugin.new) && <NewBadge />}</Text>
+                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1", gap: "1em" }}>{plugin.name}{(plugin.new) && <NewBadge />}</Text>
                     <button role="switch" onClick={() => openModal()} style={styles.SettingsIcon} className="button-12Fmur">
                         {plugin.options
                             ? <CogWheel

--- a/src/components/PluginSettings/styles.ts
+++ b/src/components/PluginSettings/styles.ts
@@ -48,3 +48,23 @@ export const SettingsIcon: React.CSSProperties = {
     background: "transparent",
     marginRight: 8
 };
+
+export const Badge: React.CSSProperties = {
+    paddingTop: "0",
+    paddingBottom: "0",
+    paddingRight: "6px",
+    paddingLeft: "6px",
+    fontFamily: "var(--font-display)",
+    fontWeight: "500px",
+    textTransform: "uppercase",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+    borderRadius: "8px",
+    height: "16px",
+    minWidth: "16px",
+    minHeight: "16px",
+    fontSize: "12px",
+    lineHeight: "16px",
+    color: "white",
+};

--- a/src/components/PluginSettings/styles.ts
+++ b/src/components/PluginSettings/styles.ts
@@ -29,7 +29,7 @@ export const PluginsGridItem: React.CSSProperties = {
     borderRadius: 3,
     cursor: "pointer",
     display: "block",
-    height: "min-content",
+    height: "100%",
     padding: 10,
     width: "100%",
 };

--- a/src/ipcMain/index.ts
+++ b/src/ipcMain/index.ts
@@ -20,7 +20,7 @@ import "./updater";
 
 import monacoHtml from "@fileContent/../components/monacoWin.html;base64";
 import { app, BrowserWindow, desktopCapturer, ipcMain, shell } from "electron";
-import { mkdirSync, readFileSync, watch, statSync } from "fs";
+import { mkdirSync, readFileSync, watch } from "fs";
 import { open, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 

--- a/src/ipcMain/index.ts
+++ b/src/ipcMain/index.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, desktopCapturer, ipcMain, shell } from "electron";
-import { mkdirSync, readFileSync, watch } from "fs";
+import { mkdirSync, readFileSync, watch, statSync } from "fs";
 import { open, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { debounce } from "../utils/debounce";
@@ -52,7 +52,6 @@ ipcMain.handle(IpcEvents.OPEN_EXTERNAL, (_, url) => {
 
     shell.openExternal(url);
 });
-
 
 ipcMain.handle(IpcEvents.GET_QUICK_CSS, () => readCss());
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,6 +26,7 @@ export interface PluginAuthor {
 export interface Plugin extends PluginDef {
     patches?: Patch[];
     started: boolean;
+    new?: boolean;
 }
 
 interface PluginDef {


### PR DESCRIPTION
People don't have to look through commits anymore, they can just see the **NEW** Badge on recently added plugins and activate the new features Vencord brings!

> *Note: [common.mjs](/Vendicated/Vencord/tree/main/scripts/build/common.mjs) has been reformatted (automatically) by my formatter, I assume it previously didn't meet styleguide in the [Contribution Guide](/Vendicated/Vencord/tree/main/CONTRIBUTING.md)*

*Ps. Feel free to bully and correct my ~~horrendous~~ code*

![image](https://user-images.githubusercontent.com/30734036/197359709-91f664ca-060f-4adc-af07-d6b851915e9a.png)

![image](https://user-images.githubusercontent.com/30734036/197359706-549283bd-a8a1-4562-92c6-81d70738fc13.png)
