### PR TITLE
Replace plugin list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Discord client mod that does things differently
 -   Works on Discord's latest update that breaks all other mods
 -   Browser Support (experimental): Run Vencord in your Browser instead of the desktop app
 -   Custom Css and Themes: Manually edit `%appdata%/Vencord/settings/quickCss.css` / `~/.config/Vencord/settings/quickCss.css` with your favourite editor and the client will automatically apply your changes. To import BetterDiscord themes, just add `@import url(theUrl)` on the top of this file. (Make sure the url is a github raw URL or similar and only contains plain text, and NOT a nice looking website)
--   Many Useful™ plugins - [List](https://gist.github.com/somerandomcloud/3287ceee0813c2aa4972a4defe0a2d82)
+-   Many Useful™ plugins - [List](plugins.md)
 -   Experiments
 -   Proper context isolation -> Works in newer Electron versions (Confirmed working on versions 13-22)
 -   Inline patches: Patch Discord's code with regex replacements! See [the experiments plugin](src/plugins/experiments.ts) for an example. While being more complex, this is more powerful than monkey patching since you can patch only small parts of functions instead of fully replacing them, access non exported/local variables and even replace constants (like in the aforementioned experiments patch!)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Discord client mod that does things differently
 -   Works on Discord's latest update that breaks all other mods
 -   Browser Support (experimental): Run Vencord in your Browser instead of the desktop app
 -   Custom Css and Themes: Manually edit `%appdata%/Vencord/settings/quickCss.css` / `~/.config/Vencord/settings/quickCss.css` with your favourite editor and the client will automatically apply your changes. To import BetterDiscord themes, just add `@import url(theUrl)` on the top of this file. (Make sure the url is a github raw URL or similar and only contains plain text, and NOT a nice looking website)
--   Many Useful™ plugins - [List](https://github.com/Vendicated/Vencord/tree/main/src/plugins)
+-   Many Useful™ plugins - [List](https://gist.github.com/somerandomcloud/3287ceee0813c2aa4972a4defe0a2d82)
 -   Experiments
 -   Proper context isolation -> Works in newer Electron versions (Confirmed working on versions 13-22)
 -   Inline patches: Patch Discord's code with regex replacements! See [the experiments plugin](src/plugins/experiments.ts) for an example. While being more complex, this is more powerful than monkey patching since you can patch only small parts of functions instead of fully replacing them, access non exported/local variables and even replace constants (like in the aforementioned experiments patch!)

--- a/plugins.md
+++ b/plugins.md
@@ -1,0 +1,175 @@
+# Vencord Plugins
+
+A list of all of Vencords built-in plugins.
+
+## STFU
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Disables the 'HOLD UP' banner in the console
+
+## AnonymiseFileNames
+#### [obscurity](https://discord.com/users/336678828233588736)
+Anonymise uploaded file names
+
+## CommandsAPI
+#### [ArjixWasTaken](https://discord.com/users/674710789138939916)
+Api required by anything that uses commands
+
+## MessageAccessoriesAPI
+#### [Cynosphere](https://discord.com/users/150745989836308480)
+API to add message accessories.
+
+## MessageEventsAPI
+#### [ArjixWasTaken](https://discord.com/users/674710789138939916)
+Api required by anything using message events.
+
+## ApiNotices
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Fixes notices being automatically dismissed
+
+## BANger
+#### [Xinto](https://discord.com/users/423915768191647755), [Glitchy](https://discord.com/users/269567451199569920)
+Replaces the GIF in the ban dialogue with a custom one.
+
+## BetterGifAltText
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Change GIF alt text from simply being 'GIF' to containing the gif tags / filename
+
+## BetterUploadButton
+#### [obscurity](https://discord.com/users/336678828233588736)
+Upload with a single click, open menu with right click
+
+## clearURLs
+#### [adryd](https://discord.com/users/0)
+Removes tracking garbage from URLs
+
+## ClickableRoleDot
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Makes RoleDots (Accessibility Feature) copy colour to clipboard on click
+
+## ConsoleShortcuts
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Adds shorter Aliases for many things on the window. Run `shortcutList` for a list.
+
+## Experiments
+#### [Megumin](https://discord.com/users/545581357812678656), [Vendicated](https://discord.com/users/343383572805058560), [Nickyux](https://discord.com/users/427146305651998721), [BanTheNons](https://discord.com/users/460478012794863637)
+Enable Access to Experiments in Discord!
+
+## Fart2
+#### [Animal](https://discord.com/users/118437263754395652)
+Enable farting v2, a slash command that allows you to perform or request that someone perform a little toot.
+
+## FxTwitter
+#### [Samu](https://discord.com/users/702973430449832038)
+Uses FxTwitter to improve embeds from twitter on send
+
+## iLoveSpam
+#### [botato](https://discord.com/users/440990343899643943), [Animal](https://discord.com/users/118437263754395652)
+Do not hide messages from 'likely spammers'
+
+## Ify
+#### [Cynosphere](https://discord.com/users/150745989836308480), [Nuckyz](https://discord.com/users/235834946571337729)
+Disables Spotify auto-pausing, allows activity to continue playing when idling and bypasses premium checks, allowing you to listen along with others.
+
+## InteractionKeybinds
+#### [obscurity](https://discord.com/users/336678828233588736), [Vendicated](https://discord.com/users/343383572805058560)
+Reply to (ctrl + up/down) and edit (ctrl + shift + up/down) messages via keybinds
+
+## MessageQuickActions
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Quick Delete, Quick edit
+
+## MoreCommands
+#### [ArjixWasTaken](https://discord.com/users/674710789138939916), [ECHO](https://discord.com/users/712639419785412668), [ICodeInAssembly](https://discord.com/users/702973430449832038)
+echo, lenny, mock
+
+## Moyai
+#### [Megumin](https://discord.com/users/545581357812678656), [Nuckyz](https://discord.com/users/235834946571337729)
+🗿🗿🗿🗿🗿🗿🗿🗿
+
+## MuteNewGuild
+#### [Glitchy](https://discord.com/users/269567451199569920)
+Mutes newly joined guilds
+
+## NitroBypass
+#### [ArjixWasTaken](https://discord.com/users/674710789138939916)
+Allows you to stream in nitro quality and send fake emojis.
+
+## NoBlockedMessages
+#### [rushii](https://discord.com/users/295190422244950017)
+Hides all blocked messages from chat completely.
+
+## NoCanaryMessageLinks
+#### [Samu](https://discord.com/users/702973430449832038), [nea](https://discord.com/users/310702108997320705)
+Allows you to change/remove the subdomain of discord message and channel links
+
+## No F1
+#### [Cynosphere](https://discord.com/users/150745989836308480)
+Disables F1 help bind.
+
+## No RPC
+#### [Cynosphere](https://discord.com/users/150745989836308480)
+Disables Discord's RPC server.
+
+## NoReplyMention
+#### [DustyAngel47](https://discord.com/users/714583473804935238)
+Disables reply pings by default
+
+## NoSystemBadge
+#### [rushii](https://discord.com/users/295190422244950017)
+Disables the taskbar and system tray unread count badge.
+
+## NoTrack
+#### [Cynosphere](https://discord.com/users/150745989836308480)
+Disable Discord's tracking and crash reporting
+
+## petpet
+#### [Vendicated](https://discord.com/users/343383572805058560)
+headpet a cutie
+
+## PlainFolderIcon
+#### [botato](https://discord.com/users/440990343899643943)
+Doesn't show the small guild icons in folders
+
+## PronounDB
+#### [Tyman](https://discord.com/users/487443883127472129)
+Adds pronouns to user messages using pronoundb
+
+## Sendify
+#### [katlyn](https://discord.com/users/250322741406859265)
+Send your current Spotify music to chat
+
+## Settings
+#### [Vendicated](https://discord.com/users/343383572805058560), [Megumin](https://discord.com/users/545581357812678656)
+Adds Settings UI and debug info
+
+## ShowHiddenChannels
+#### [BigDuck](https://discord.com/users/1024588272623681609), [AverageReactEnjoyer](https://discord.com/users/1004904120056029256)
+Show hidden channels
+
+## SilentTyping
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Hide that you are typing
+
+## Unindent
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Trims leading indentation from codeblocks
+
+## ReactErrorDecoder
+#### [Cynosphere](https://discord.com/users/150745989836308480)
+Replaces "Minifed React Error" with the actual error.
+
+## UwUifier
+#### [ECHO](https://discord.com/users/712639419785412668)
+Simply uwuify commands
+
+## vcDoubleClick
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Join VCs via DoubleClick instead of single click
+
+## ViewIcons
+#### [Vendicated](https://discord.com/users/343383572805058560)
+Makes Avatars/Banners in user profiles clickable, and adds Guild Context Menu Entries to View Banner/Icon.
+
+## Webhook Tags
+#### [Cynosphere](https://discord.com/users/150745989836308480)
+Changes the bot tag to say webhook for webhooks


### PR DESCRIPTION
Replaces plugin list link with a gist with a list of all plugins with authors and descriptions instead of having to go into each file