### PR TITLE
feat(settings): add beforeSave check

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { Promisable } from "type-fest";
+
 import { Command } from "../api/Commands";
 
 // exists to export default definePlugin({...})
@@ -79,7 +81,7 @@ interface PluginDef {
      * Check that this returns true before allowing a save to complete.
      * If a string is returned, show the error to the user.
      */
-    beforeSave?(options: Record<string, any>): (true | string) | Promise<true | string>;
+    beforeSave?(options: Record<string, any>): Promisable<true | string>;
     /**
      * Allows you to specify a custom Component that will be rendered in your
      * plugin's settings page

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -76,6 +76,11 @@ interface PluginDef {
      */
     options?: Record<string, PluginOptionsItem>;
     /**
+     * Check that this returns true before allowing a save to complete.
+     * If a string is returned, show the error to the user.
+     */
+    beforeSave?(options: Record<string, any>): (true | string) | Promise<true | string>;
+    /**
      * Allows you to specify a custom Component that will be rendered in your
      * plugin's settings page
      */


### PR DESCRIPTION
This PR adds support for a `beforeSave` method that accepts synchronous and asynchronous functions. If `beforeSave` returns true, then the plugin will save & close the modal. If it returns a string, it will display this string to the user and not save.