### PR TITLE
fix forceOwnerCrown Plugin Spamming Errors in Console

### DIFF
--- a/src/plugins/experiments.tsx
+++ b/src/plugins/experiments.tsx
@@ -30,7 +30,7 @@ export default definePlugin({
     authors: [
         Devs.Megu,
         Devs.Ven,
-        { name: "Nickyux", id: 427146305651998721n },
+        Devs.Nickyux,
         { name: "BanTheNons", id: 460478012794863637n },
     ],
     description: "Enable Access to Experiments in Discord!",

--- a/src/plugins/forceOwnerCrown.ts
+++ b/src/plugins/forceOwnerCrown.ts
@@ -26,7 +26,7 @@ waitFor(["getGuild"], m => GuildStore = m);
 export default definePlugin({
     name: "ForceOwnerCrown",
     description: "Force the owner crown next to usernames even if the server is large.",
-    authors: [Devs.D3SOX],
+    authors: [Devs.D3SOX, Devs.Nickyux],
     patches: [
         {
             // This is the logic where it decides whether to render the owner crown or not

--- a/src/plugins/forceOwnerCrown.ts
+++ b/src/plugins/forceOwnerCrown.ts
@@ -39,7 +39,7 @@ export default definePlugin({
     ],
     isGuildOwner(props) {
         // Check if channel is a Group DM, if so return false
-        if (props.channel.type === 3) {
+        if (props?.channel?.type === 3) {
             return false;
         }
 

--- a/src/plugins/forceOwnerCrown.ts
+++ b/src/plugins/forceOwnerCrown.ts
@@ -47,9 +47,9 @@ export default definePlugin({
             if (guild) {
                 return guild.ownerId === userId;
             }
-            console.error("[ForceOwnerCrown] failed to get guild", { guildId, guild, props });
+            console.debug("[ForceOwnerCrown] failed to get guild", { guildId, guild, props });
         } else {
-            console.error("[ForceOwnerCrown] no guildId or userId", { guildId, userId, props });
+            console.debug("[ForceOwnerCrown] no guildId or userId", { guildId, userId, props });
         }
         return false;
     },

--- a/src/plugins/forceOwnerCrown.ts
+++ b/src/plugins/forceOwnerCrown.ts
@@ -38,6 +38,11 @@ export default definePlugin({
         },
     ],
     isGuildOwner(props) {
+        // Check if channel is a Group DM, if so return false
+        if (props.channel.type === 3) {
+            return false;
+        }
+
         // guild id is in props twice, fallback if the first is undefined
         const guildId = props?.guildId ?? props?.channel?.guild_id;
         const userId = props?.user?.id;
@@ -47,9 +52,9 @@ export default definePlugin({
             if (guild) {
                 return guild.ownerId === userId;
             }
-            console.debug("[ForceOwnerCrown] failed to get guild", { guildId, guild, props });
+            console.error("[ForceOwnerCrown] failed to get guild", { guildId, guild, props });
         } else {
-            console.debug("[ForceOwnerCrown] no guildId or userId", { guildId, userId, props });
+            console.error("[ForceOwnerCrown] no guildId or userId", { guildId, userId, props });
         }
         return false;
     },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -88,5 +88,9 @@ export const Devs = Object.freeze({
     D3SOX: {
         name: "D3SOX",
         id: 201052085641281538n
+    },
+    Nickyux: {
+        name: "Nickyux",
+        id: 427146305651998721n
     }
 });


### PR DESCRIPTION
Fix the plugin spamming errors in console when checking group chats, instead, log them as debugging for people to see if they want to enable verbose console logs.

![image](https://user-images.githubusercontent.com/30734036/198897155-e3c9f656-5b7e-449b-8e3e-685fc7287aa2.png)
