### PR TITLE
Spotify Premium plugin.

### DIFF
--- a/src/plugins/spotifyPremium.ts
+++ b/src/plugins/spotifyPremium.ts
@@ -1,0 +1,39 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import definePlugin from "../../utils/types";
+
+export default definePlugin({
+	name: "Spotify Premium",
+	description: "Enables Spotify Premium features.",
+	authors: [
+		{
+			id: 619284841187246090n,
+			name: "Polar",
+		},
+	],
+	patches: [
+		{
+			find: "l.Z.getActiveSocketAndDevice();",
+			replacement: {
+				match: /:\w{1,3}\.socket\.isPremium/,
+				replace: ":true",
+			},
+		},
+	],
+});

--- a/src/plugins/spotifyPremium.ts
+++ b/src/plugins/spotifyPremium.ts
@@ -16,7 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import definePlugin from "../../utils/types";
+import { Devs } from "../utils/constants";
+import definePlugin from "../utils/types";
 
 export default definePlugin({
 	name: "Spotify Premium",
@@ -26,6 +27,7 @@ export default definePlugin({
 			id: 619284841187246090n,
 			name: "Polar",
 		},
+		Devs.Megu
 	],
 	patches: [
 		{


### PR DESCRIPTION
I've created a plugin to bypass Discord's clientside check for whether or not you have Spotify Premium. Thus, you can use Spotify Premium-only features such as group listening for free.