### PR TITLE
spotifyControls: make title/artists of local tracks unclickable

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -18,21 +18,18 @@
 
 import { React } from "../webpack/common";
 
-interface Props {
-    href: string;
+interface Props extends React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
     disabled?: boolean;
-    style?: React.CSSProperties;
-    className?: string;
-    title?: string;
 }
 
 export function Link(props: React.PropsWithChildren<Props>) {
     if (props.disabled) {
         props.style ??= {};
         props.style.pointerEvents = "none";
+        props["aria-disabled"] = true;
     }
     return (
-        <a href={props.href} target="_blank" style={props.style} className={props.className} title={props.title}>
+        <a role="link" target="_blank" {...props}>
             {props.children}
         </a>
     );

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -22,6 +22,8 @@ interface Props {
     href: string;
     disabled?: boolean;
     style?: React.CSSProperties;
+    className?: string;
+    title?: string;
 }
 
 export function Link(props: React.PropsWithChildren<Props>) {
@@ -30,7 +32,7 @@ export function Link(props: React.PropsWithChildren<Props>) {
         props.style.pointerEvents = "none";
     }
     return (
-        <a href={props.href} target="_blank" style={props.style}>
+        <a href={props.href} target="_blank" style={props.style} className={props.className} title={props.title}>
             {props.children}
         </a>
     );

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -262,27 +262,41 @@ function Info({ track }: { track: Track; }) {
                     variant="text-sm/semibold"
                     id={cl("song-title")}
                     className={cl("ellipoverflow")}
+                    data-track-id={track.id}
                     title={track.name}
-                    onClick={() => SpotifyStore.openExternal(`/track/${track.id}`)}
+                    onClick={() => {
+                        if (track.id) SpotifyStore.openExternal(`/track/${track.id}`);
+                    }}
                 >
                     {track.name}
                 </Forms.FormText>
                 <Forms.FormText variant="text-sm/normal" className={cl("ellipoverflow")}>
                     by&nbsp;
-                    {track.artists.map((a, i) => (
-                        <React.Fragment key={a.id}>
-                            <a
-                                className={cl("artist")}
-                                href={`https://open.spotify.com/artist/${a.id}`}
-                                target="_blank"
-                                style={{ fontSize: "inherit" }}
-                                title={a.name}
-                            >
-                                {a.name}
-                            </a>
+                    {track.artists.map((a, i) =>
+                        // id can be null for local tracks
+                        (<React.Fragment key={a.name}>
+                            {a.id ? (
+                                <a
+                                    className={cl("artist")}
+                                    href={`https://open.spotify.com/artist/${a.id}`}
+                                    target="_blank"
+                                    style={{ fontSize: "inherit" }}
+                                    title={a.name}
+                                >
+                                    {a.name}
+                                </a>
+                            ) : (
+                                <span
+                                    className={cl("artist")}
+                                    style={{ fontSize: "inherit" }}
+                                    title={a.name}
+                                >
+                                    {a.name}
+                                </span>
+                            )}
                             {i !== track.artists.length - 1 && <span className={cl("comma")}>{", "}</span>}
                         </React.Fragment>
-                    ))}
+                        ))}
                 </Forms.FormText>
                 {track.album.name && (
                     <Forms.FormText variant="text-sm/normal" className={cl("ellipoverflow")}>

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -18,6 +18,7 @@
 
 import ErrorBoundary from "../../components/ErrorBoundary";
 import { Flex } from "../../components/Flex";
+import { Link } from "../../components/Link";
 import { debounce } from "../../utils/debounce";
 import { classes, LazyComponent, lazyWebpack } from "../../utils/misc";
 import { ContextMenu, FluxDispatcher, Forms, Menu, React } from "../../webpack/common";
@@ -275,25 +276,13 @@ function Info({ track }: { track: Track; }) {
                     {track.artists.map((a, i) =>
                         // id can be null for local tracks
                         (<React.Fragment key={a.name}>
-                            {a.id ? (
-                                <a
-                                    className={cl("artist")}
-                                    href={`https://open.spotify.com/artist/${a.id}`}
-                                    target="_blank"
-                                    style={{ fontSize: "inherit" }}
-                                    title={a.name}
-                                >
-                                    {a.name}
-                                </a>
-                            ) : (
-                                <span
-                                    className={cl("artist")}
-                                    style={{ fontSize: "inherit" }}
-                                    title={a.name}
-                                >
-                                    {a.name}
-                                </span>
-                            )}
+                            <Link className={cl("artist")}
+                                disabled={!a.id}
+                                href={`https://open.spotify.com/artist/${a.id}`}
+                                style={{ fontSize: "inherit" }}
+                                title={a.name}>
+                                {a.name}
+                            </Link>
                             {i !== track.artists.length - 1 && <span className={cl("comma")}>{", "}</span>}
                         </React.Fragment>
                         ))}

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -263,33 +263,36 @@ function Info({ track }: { track: Track; }) {
                     variant="text-sm/semibold"
                     id={cl("song-title")}
                     className={cl("ellipoverflow")}
-                    data-track-id={track.id}
+                    role={track.id ? "link" : undefined}
                     title={track.name}
-                    onClick={() => {
-                        if (track.id) SpotifyStore.openExternal(`/track/${track.id}`);
-                    }}
+                    onClick={track.id ? () => {
+                        SpotifyStore.openExternal(`/track/${track.id}`);
+                    } : void 0}
                 >
                     {track.name}
                 </Forms.FormText>
-                <Forms.FormText variant="text-sm/normal" className={cl("ellipoverflow")}>
-                    by&nbsp;
-                    {track.artists.map((a, i) =>
-                        // id can be null for local tracks
-                        (<React.Fragment key={a.name}>
-                            <Link className={cl("artist")}
-                                disabled={!a.id}
-                                href={`https://open.spotify.com/artist/${a.id}`}
-                                style={{ fontSize: "inherit" }}
-                                title={a.name}>
-                                {a.name}
-                            </Link>
-                            {i !== track.artists.length - 1 && <span className={cl("comma")}>{", "}</span>}
-                        </React.Fragment>
+                {track.artists.some(a => a.name) && (
+                    <Forms.FormText variant="text-sm/normal" className={cl("ellipoverflow")}>
+                        by&nbsp;
+                        {track.artists.map((a, i) => (
+                            <React.Fragment key={a.name}>
+                                <Link
+                                    className={cl("artist")}
+                                    disabled={!a.id}
+                                    href={`https://open.spotify.com/artist/${a.id}`}
+                                    style={{ fontSize: "inherit" }}
+                                    title={a.name}
+                                >
+                                    {a.name}
+                                </Link>
+                                {i !== track.artists.length - 1 && <span className={cl("comma")}>{", "}</span>}
+                            </React.Fragment>
                         ))}
-                </Forms.FormText>
+                    </Forms.FormText>
+                )}
                 {track.album.name && (
                     <Forms.FormText variant="text-sm/normal" className={cl("ellipoverflow")}>
-                    on&nbsp;
+                        on&nbsp;
                         <a id={cl("album-title")}
                             href={`https://open.spotify.com/album/${track.album.id}`}
                             target="_blank"
@@ -311,7 +314,7 @@ export function Player() {
         [SpotifyStore],
         () => SpotifyStore.track,
         null,
-        (prev, next) => prev?.id === next?.id
+        (prev, next) => prev?.id ? (prev.id === next?.id) : prev?.name === next?.name
     );
 
     const device = useStateFromStores(

--- a/src/plugins/spotifyControls/styles.css
+++ b/src/plugins/spotifyControls/styles.css
@@ -119,7 +119,7 @@
     color: var(--header-secondary);
 }
 
-a.vc-spotify-artist:hover,
+.vc-spotify-artist:hover,
 #vc-spotify-album-title:hover,
 #vc-spotify-song-title[data-track-id]:hover {
     text-decoration: underline;

--- a/src/plugins/spotifyControls/styles.css
+++ b/src/plugins/spotifyControls/styles.css
@@ -119,9 +119,9 @@
     color: var(--header-secondary);
 }
 
-.vc-spotify-artist:hover,
+a.vc-spotify-artist:hover,
 #vc-spotify-album-title:hover,
-#vc-spotify-song-title:hover {
+#vc-spotify-song-title[data-track-id]:hover {
     text-decoration: underline;
     cursor: pointer;
 }

--- a/src/plugins/spotifyControls/styles.css
+++ b/src/plugins/spotifyControls/styles.css
@@ -121,7 +121,7 @@
 
 .vc-spotify-artist:hover,
 #vc-spotify-album-title:hover,
-#vc-spotify-song-title[data-track-id]:hover {
+#vc-spotify-song-title[role="link"]:hover {
     text-decoration: underline;
     cursor: pointer;
 }


### PR DESCRIPTION
It previously opened https://open.spotify.com/artist/null and https://open.spotify.com/track/null