### PR TITLE
 UserPlugins: Add clickable badges to external user plugins

### DIFF
--- a/scripts/build/common.mjs
+++ b/scripts/build/common.mjs
@@ -60,19 +60,23 @@ export const globPlugins = {
         });
 
         build.onLoad({ filter, namespace: "import-plugins" }, async () => {
-            const pluginDirs = ["plugins", "userplugins"];
+            const pluginDirs = [
+                { dir: "plugins", official: true },
+                { dir: "userplugins", official: false },
+            ];
             let code = "";
             let plugins = "\n";
             let i = 0;
-            for (const dir of pluginDirs) {
-                if (!existsSync(`./src/${dir}`)) continue;
-                const files = await readdir(`./src/${dir}`);
-                for (const file of files) {
+            for (const pluginDirectory of pluginDirs) {
+                const pluginPath = `./src/${pluginDirectory.dir}`;
+                if (!existsSync(pluginPath)) continue;
+                for (const file of await readdir(pluginPath)) {
                     if (file === "index.ts") {
                         continue;
                     }
                     const mod = `p${i}`;
-                    code += `import ${mod} from "./${dir}/${file.replace(/.tsx?$/, "")}";\n`;
+                    code += `import ${mod} from "./${pluginDirectory.dir}/${file.replace(/.tsx?$/, "")}";\n`;
+                    code += `${mod}['isUserPlugin'] = ${!pluginDirectory.official};`;
                     plugins += `[${mod}.name]:${mod},\n`;
                     i++;
                 }

--- a/src/components/PluginSettings/components/BadgeComponent.tsx
+++ b/src/components/PluginSettings/components/BadgeComponent.tsx
@@ -16,10 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Badge } from "../styles";
+import { BadgeStyle } from "../styles";
 
-export function NewBadge(): JSX.Element {
+export function Badge({ text, color }): JSX.Element {
     return (
-        <div style={{ backgroundColor: "#ED4245", justifySelf: "flex-end", marginLeft: "auto", ...Badge }}>New</div>
+        <div style={{ backgroundColor: color, justifySelf: "flex-end", marginLeft: "auto", ...BadgeStyle }}>{text}</div>
     );
 }

--- a/src/components/PluginSettings/components/NewBadgeComponent.tsx
+++ b/src/components/PluginSettings/components/NewBadgeComponent.tsx
@@ -16,23 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { PluginOptionBase } from "../../../utils/types";
+import { Badge } from "../styles";
 
-export interface ISettingElementProps<T extends PluginOptionBase> {
-    option: T;
-    onChange(newValue: any): void;
-    pluginSettings: {
-        [setting: string]: any;
-        enabled: boolean;
-    };
-    id: string;
-    onError(hasError: boolean): void;
+export function NewBadge(): JSX.Element {
+    return (
+        <div style={{ backgroundColor: "#ED4245", justifySelf: "flex-end", marginLeft: "auto", ...Badge }}>New</div>
+    );
 }
-
-export * from "./SettingBooleanComponent";
-export * from "./SettingCustomComponent";
-export * from "./SettingNumericComponent";
-export * from "./SettingSelectComponent";
-export * from "./SettingSliderComponent";
-export * from "./SettingTextComponent";
-export * from "./NewBadgeComponent";

--- a/src/components/PluginSettings/components/UserPluginBadge.tsx
+++ b/src/components/PluginSettings/components/UserPluginBadge.tsx
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Linnea Gräf
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { PluginDef } from "../../../utils/types";
+import { Badge } from ".";
+
+export interface Props {
+    plugin: PluginDef;
+}
+export default function UserPluginBadge({ plugin }: Props) {
+    const badge = <Badge color={"rgb(88 101 242)"} text={"User"} />;
+    return plugin.externalLink
+        ? (
+            <a href={plugin.externalLink} target={"_blank"}>
+                {badge}
+            </a>
+        )
+        : badge;
+}
+
+

--- a/src/components/PluginSettings/components/index.ts
+++ b/src/components/PluginSettings/components/index.ts
@@ -29,7 +29,7 @@ export interface ISettingElementProps<T extends PluginOptionBase> {
     onError(hasError: boolean): void;
 }
 
-export * from "./NewBadgeComponent";
+export * from "./BadgeComponent";
 export * from "./SettingBooleanComponent";
 export * from "./SettingCustomComponent";
 export * from "./SettingNumericComponent";

--- a/src/components/PluginSettings/components/index.ts
+++ b/src/components/PluginSettings/components/index.ts
@@ -29,10 +29,10 @@ export interface ISettingElementProps<T extends PluginOptionBase> {
     onError(hasError: boolean): void;
 }
 
+export * from "./NewBadgeComponent";
 export * from "./SettingBooleanComponent";
 export * from "./SettingCustomComponent";
 export * from "./SettingNumericComponent";
 export * from "./SettingSelectComponent";
 export * from "./SettingSliderComponent";
 export * from "./SettingTextComponent";
-export * from "./NewBadgeComponent";

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -33,7 +33,7 @@ import ErrorBoundary from "../ErrorBoundary";
 import { ErrorCard } from "../ErrorCard";
 import { Flex } from "../Flex";
 import { handleComponentFailed } from "../handleComponentFailed";
-import { NewBadge } from "./components";
+import { Badge } from "./components";
 import PluginModal from "./PluginModal";
 import * as styles from "./styles";
 
@@ -165,7 +165,7 @@ function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLe
                 hideBorder={true}
             >
                 <Flex style={{ marginTop: "auto", width: "100%", height: "100%", alignItems: "center", gap: "8px" }}>
-                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1", gap: "8px" }}>{plugin.name}{(isNew) && <NewBadge />}</Text>
+                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1", gap: "8px" }}>{plugin.name}{(isNew) && <Badge text="New" color="#ED4245" />}</Text>
                     <button role="switch" onClick={() => openModal()} style={styles.SettingsIcon} className="button-12Fmur">
                         {plugin.options
                             ? <CogWheel

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -246,7 +246,7 @@ export default ErrorBoundary.wrap(function Settings() {
         );
     };
 
-    let [newPlugins, error, newPluginsLoading] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((existingPlugins: Record<string, number>) => {
+    let [newPlugins] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((existingPlugins: Record<string, number>) => {
         const dateNow: number = Date.now() / 1000;
         const Vencord_existingPlugins: Record<string, number> = {};
         const newPlugins: Array<string> = [];

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -17,12 +17,11 @@
 */
 
 import Plugins from "~plugins";
-import { DataStore } from "../../api";
 
+import { DataStore } from "../../api";
 import { showNotice } from "../../api/Notices";
 import { Settings, useSettings } from "../../api/settings";
 import { startDependenciesRecursive, startPlugin, stopPlugin } from "../../plugins";
-import consoleShortcuts from "../../plugins/consoleShortcuts";
 import { ChangeList } from "../../utils/ChangeList";
 import Logger from "../../utils/Logger";
 import { classes, LazyComponent, lazyWebpack, useAwaiter } from "../../utils/misc";
@@ -249,10 +248,10 @@ export default ErrorBoundary.wrap(function Settings() {
 
     const [newPlugins, error, newPluginsLoading] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((existingPlugins: Record<string, number>) => {
         const dateNow: number = Date.now() / 1000;
-        let Vencord_existingPlugins: Record<string, number> = {};
-        let newPlugins: Array<string> = [];
+        const Vencord_existingPlugins: Record<string, number> = {};
+        const newPlugins: Array<string> = [];
         sortedPlugins.forEach(plugin => {
-            Vencord_existingPlugins[plugin.name] = Object.keys(existingPlugins ? existingPlugins : []).includes(plugin.name) ? existingPlugins[plugin.name] : dateNow;
+            Vencord_existingPlugins[plugin.name] = Object.keys(existingPlugins || []).includes(plugin.name) ? existingPlugins[plugin.name] : dateNow;
             if ((Vencord_existingPlugins[plugin.name] + 172800) > dateNow) {
                 newPlugins.push(plugin.name);
             }

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -248,28 +248,18 @@ export default ErrorBoundary.wrap(function Settings() {
     };
 
     const [newPlugins, error, newPluginsLoading] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((existingPlugins: Record<string, number>) => {
-        logger.info("called func");
         const dateNow: number = Date.now() / 1000;
-        logger.debug("dateNow", dateNow);
         let Vencord_existingPlugins: Record<string, number> = {};
         let newPlugins: Array<string> = [];
-        logger.info("sortedPlugins", sortedPlugins);
-        logger.info("existingPlugins (or list)", existingPlugins ? existingPlugins : []);
-        logger.info("Object.keys(existingPlugins ? existingPlugins : [])", Object.keys(existingPlugins ? existingPlugins : []));
         sortedPlugins.forEach(plugin => {
-            logger.debug(plugin.name);
             Vencord_existingPlugins[plugin.name] = Object.keys(existingPlugins ? existingPlugins : []).includes(plugin.name) ? existingPlugins[plugin.name] : dateNow;
-            logger.debug("1");
             if ((Vencord_existingPlugins[plugin.name] + 172800) > dateNow) {
                 newPlugins.push(plugin.name);
             }
         });
-        DataStore.set("Vencord_existingPlugins", Vencord_existingPlugins).then(() => { logger.info("set Vencord_existingPlugins"); }).catch((err) => { logger.info("set Vencord_existingPlugins raised", err); });
+        DataStore.set("Vencord_existingPlugins", Vencord_existingPlugins);
         return newPlugins;
     }));
-
-    logger.debug("newPlugins", newPlugins);
-    logger.debug("error", error);
 
     return (
         <Forms.FormSection tag="h1" title="Vencord">

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -34,6 +34,7 @@ import { ErrorCard } from "../ErrorCard";
 import { Flex } from "../Flex";
 import { handleComponentFailed } from "../handleComponentFailed";
 import { Badge } from "./components";
+import UserPluginBadge from "./components/UserPluginBadge";
 import PluginModal from "./PluginModal";
 import * as styles from "./styles";
 
@@ -165,7 +166,9 @@ function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLe
                 hideBorder={true}
             >
                 <Flex style={{ marginTop: "auto", width: "100%", height: "100%", alignItems: "center", gap: "8px" }}>
-                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1", gap: "8px" }}>{plugin.name}{(isNew) && <Badge text="New" color="#ED4245" />}</Text>
+                    <Text variant="text-md/bold" style={{ display: "flex", width: "100%", alignItems: "center", flexGrow: "1", gap: "8px" }}>
+                        {plugin.name}{isNew && <Badge text="New" color="#ed4245" />}{plugin.isUserPlugin && <UserPluginBadge plugin={plugin} />}
+                    </Text>
                     <button role="switch" onClick={() => openModal()} style={styles.SettingsIcon} className="button-12Fmur">
                         {plugin.options
                             ? <CogWheel

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -247,7 +247,7 @@ export default ErrorBoundary.wrap(function Settings() {
         );
     };
 
-    const [newPlugins, error, newPluginsLoading] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((existingPlugins: Record<string, number> | null) => {
+    const [newPlugins, error, newPluginsLoading] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((existingPlugins: Record<string, number>) => {
         logger.info("called func");
         const dateNow: number = Date.now() / 1000;
         logger.debug("dateNow", dateNow);
@@ -260,7 +260,7 @@ export default ErrorBoundary.wrap(function Settings() {
             logger.debug(plugin.name);
             Vencord_existingPlugins[plugin.name] = Object.keys(existingPlugins ? existingPlugins : []).includes(plugin.name) ? existingPlugins[plugin.name] : dateNow;
             logger.debug("1");
-            if (Vencord_existingPlugins[plugin.name] < (dateNow + 172800)) {
+            if ((Vencord_existingPlugins[plugin.name] + 172800) > dateNow) {
                 newPlugins.push(plugin.name);
             }
         });

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -246,7 +246,7 @@ export default ErrorBoundary.wrap(function Settings() {
         );
     };
 
-    const [newPlugins, error, newPluginsLoading] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((existingPlugins: Record<string, number>) => {
+    let [newPlugins, error, newPluginsLoading] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((existingPlugins: Record<string, number>) => {
         const dateNow: number = Date.now() / 1000;
         const Vencord_existingPlugins: Record<string, number> = {};
         const newPlugins: Array<string> = [];
@@ -259,6 +259,10 @@ export default ErrorBoundary.wrap(function Settings() {
         DataStore.set("Vencord_existingPlugins", Vencord_existingPlugins);
         return newPlugins;
     }));
+
+    if (JSON.stringify(newPlugins) === JSON.stringify(sortedPluginNames)) {
+        newPlugins = [];
+    }
 
     return (
         <Forms.FormSection tag="h1" title="Vencord">

--- a/src/components/PluginSettings/styles.ts
+++ b/src/components/PluginSettings/styles.ts
@@ -49,7 +49,7 @@ export const SettingsIcon: React.CSSProperties = {
     marginRight: 8
 };
 
-export const Badge: React.CSSProperties = {
+export const BadgeStyle: React.CSSProperties = {
     paddingTop: "0",
     paddingBottom: "0",
     paddingRight: "6px",

--- a/src/components/PluginSettings/styles.ts
+++ b/src/components/PluginSettings/styles.ts
@@ -48,3 +48,23 @@ export const SettingsIcon: React.CSSProperties = {
     background: "transparent",
     marginRight: 8
 };
+
+export const Badge: React.CSSProperties = {
+    paddingTop: "0",
+    paddingBottom: "0",
+    paddingRight: "6px",
+    paddingLeft: "6px",
+    fontFamily: "var(--font-display)",
+    fontWeight: "500px",
+    textTransform: "uppercase",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+    borderRadius: "8px",
+    height: "16px",
+    minWidth: "16px",
+    minHeight: "16px",
+    fontSize: "12px",
+    lineHeight: "16px",
+    color: "white",
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -91,6 +91,18 @@ export interface PluginDef {
      * plugin's settings page
      */
     settingsAboutComponent?: React.ComponentType;
+    /**
+     * If this plugin is an external / user plugin, this link will point to
+     * the external webpage responsible for this plugin. Local plugins should
+     * not have this set, however, not every UserPlugin will have this set to
+     * a link.
+     */
+    externalLink?: string;
+    /**
+     * Signifies whether this plugin is a UserPlugin or not.
+     * This value is set using a build time script in globPlugins.
+     */
+    isUserPlugin?: boolean;
 }
 
 export enum OptionType {


### PR DESCRIPTION
This patch adds a button to each user plugin (this is determined by the
plugin directory). Additionally user plugins can specify an
`externalLink` in their plugin definition to have their badge be
clickable and link to an external website.

Note that this incorporates one file from #234 for the badge colors, but i can also just copy those styles over manually.
