### PR TITLE
feat(spotifyControls): support saving songs

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -123,7 +123,6 @@ export default definePlugin({
         deleteStyle: {
             type: OptionType.SELECT,
             description: "The style of deleted messages",
-            default: "text",
             options: [
                 { label: "Red text", value: "text", default: true },
                 { label: "Red overlay", value: "overlay" }

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -81,10 +81,10 @@ function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
     );
 }
 
-function Controls() {
-    const [isPlaying, shuffle, repeat, track, savedTrackIds] = useStateFromStores(
+function Controls({ track }: { track: Track; }) {
+    const [isPlaying, shuffle, repeat, savedTrackIds] = useStateFromStores(
         [SpotifyStore],
-        () => [SpotifyStore.isPlaying, SpotifyStore.shuffle, SpotifyStore.repeat, SpotifyStore.track, SpotifyStore.savedTrackIds]
+        () => [SpotifyStore.isPlaying, SpotifyStore.shuffle, SpotifyStore.repeat, SpotifyStore.savedTrackIds]
     );
 
     const [nextRepeat, repeatClassName] = (() => {
@@ -375,7 +375,7 @@ export function Player() {
             <div id={cl("player")}>
                 <Info track={track} />
                 <SeekBar />
-                <Controls />
+                <Controls track={track} />
             </div>
         </ErrorBoundary>
     );

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -122,7 +122,7 @@ function Controls() {
                 {repeat === "track" && <span className={cl("repeat-1")}>1</span>}
                 <Repeat />
             </Button>
-            {Settings.plugins.SpotifyControls.manageSavedSongs === true && track?.id && savedTrackIds.has(track.id) && (
+            {Settings.plugins.SpotifyControls.manageSavedSongs === true && Settings.plugins.SpotifyControls.savedSongsDisplay === "icon" && track?.id && savedTrackIds.has(track.id) && (
                 <Button
                     className={classes(cl("button"), cl(savedTrackIds.get(track.id) ? "saved-on" : "saved-off"))}
                     onClick={() => SpotifyStore.saveTrack()}
@@ -199,6 +199,10 @@ function SeekBar() {
 
 function AlbumContextMenu({ track }: { track: Track; }) {
     const volume = useStateFromStores([SpotifyStore], () => SpotifyStore.volume);
+    const [savedTrackIds] = useStateFromStores(
+        [SpotifyStore],
+        () => [SpotifyStore.savedTrackIds]
+    );
 
     return (
         <Menu.ContextMenu
@@ -219,6 +223,16 @@ function AlbumContextMenu({ track }: { track: Track; }) {
                 // trolley
                 action={() => (Vencord.Plugins.plugins.ViewIcons as any).openImage(track.album.image.url)}
             />
+            {Settings.plugins.SpotifyControls.manageSavedSongs === true && Settings.plugins.SpotifyControls.savedSongsDisplay === "context" && savedTrackIds.has(track.id) && (
+                <Menu.MenuCheckboxItem
+                    key="like-song"
+                    id="like-song"
+                    label="Like Song"
+                    checked={savedTrackIds.get(track.id)}
+                    action={() => SpotifyStore.saveTrack()}
+                />
+            )}
+            <Menu.MenuSeparator />
             <Menu.MenuControlItem
                 id="spotify-volume"
                 key="spotify-volume"

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -196,6 +196,21 @@ function SeekBar() {
     );
 }
 
+function MyCustomItem({ saved }: {saved?: boolean}) {
+    return (
+        <Flex>
+            <Forms.FormText>Like song</Forms.FormText>
+            {/* <div className={classes(cl(saved ? "saved-on" : "saved-off"))}>
+                <Heart />
+            </div>*/}
+            <Button
+                className={classes(cl("button"), cl(saved ? "saved-on" : "saved-off"))}
+            >
+                <Heart />
+            </Button>
+        </Flex>
+    );
+}
 
 function AlbumContextMenu({ track }: { track: Track; }) {
     const volume = useStateFromStores([SpotifyStore], () => SpotifyStore.volume);
@@ -224,12 +239,14 @@ function AlbumContextMenu({ track }: { track: Track; }) {
                 action={() => (Vencord.Plugins.plugins.ViewIcons as any).openImage(track.album.image.url)}
             />
             {Settings.plugins.SpotifyControls.manageSavedSongs === true && Settings.plugins.SpotifyControls.savedSongsDisplay === "context" && savedTrackIds.has(track.id) && (
-                <Menu.MenuCheckboxItem
+                <Menu.MenuItem
+                // <Menu.MenuCheckboxItem
                     key="like-song"
                     id="like-song"
                     label="Like Song"
-                    checked={savedTrackIds.get(track.id)}
+                    // checked={savedTrackIds.get(track.id)}
                     action={() => SpotifyStore.saveTrack()}
+                    render={MyCustomItem}
                 />
             )}
             <Menu.MenuSeparator />

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { Settings } from "../../api/settings";
 import ErrorBoundary from "../../components/ErrorBoundary";
 import { Flex } from "../../components/Flex";
 import { Link } from "../../components/Link";
@@ -67,6 +68,7 @@ const SkipPrev = Svg("M7 6c.55 0 1 .45 1 1v10c0 .55-.45 1-1 1s-1-.45-1-1V7c0-.55
 const SkipNext = Svg("M7.58 16.89l5.77-4.07c.56-.4.56-1.24 0-1.63L7.58 7.11C6.91 6.65 6 7.12 6 7.93v8.14c0 .81.91 1.28 1.58.82zM16 7v10c0 .55.45 1 1 1s1-.45 1-1V7c0-.55-.45-1-1-1s-1 .45-1 1z", "next");
 const Repeat = Svg("M7 7h10v1.79c0 .45.54.67.85.35l2.79-2.79c.2-.2.2-.51 0-.71l-2.79-2.79c-.31-.31-.85-.09-.85.36V5H6c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1s1-.45 1-1V7zm10 10H7v-1.79c0-.45-.54-.67-.85-.35l-2.79 2.79c-.2.2-.2.51 0 .71l2.79 2.79c.31.31.85.09.85-.36V19h11c.55 0 1-.45 1-1v-4c0-.55-.45-1-1-1s-1 .45-1 1v3z", "repeat");
 const Shuffle = Svg("M10.59 9.17L6.12 4.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.46 4.46 1.42-1.4zm4.76-4.32l1.19 1.19L4.7 17.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L17.96 7.46l1.19 1.19c.31.31.85.09.85-.36V4.5c0-.28-.22-.5-.5-.5h-3.79c-.45 0-.67.54-.36.85zm-.52 8.56l-1.41 1.41 3.13 3.13-1.2 1.2c-.31.31-.09.85.36.85h3.79c.28 0 .5-.22.5-.5v-3.79c0-.45-.54-.67-.85-.35l-1.19 1.19-3.13-3.14z", "shuffle");
+const Heart = Svg("M13.35 20.13c-.76.69-1.93.69-2.69-.01l-.11-.1C5.3 15.27 1.87 12.16 2 8.28c.06-1.7.93-3.33 2.34-4.29 2.64-1.8 5.9-.96 7.66 1.1 1.76-2.06 5.02-2.91 7.66-1.1 1.41.96 2.28 2.59 2.34 4.29.14 3.88-3.3 6.99-8.55 11.76l-.1.09z", "heart");
 
 function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
     return (
@@ -80,9 +82,9 @@ function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
 }
 
 function Controls() {
-    const [isPlaying, shuffle, repeat] = useStateFromStores(
+    const [isPlaying, shuffle, repeat, track, savedTrackIds] = useStateFromStores(
         [SpotifyStore],
-        () => [SpotifyStore.isPlaying, SpotifyStore.shuffle, SpotifyStore.repeat]
+        () => [SpotifyStore.isPlaying, SpotifyStore.shuffle, SpotifyStore.repeat, SpotifyStore.track, SpotifyStore.savedTrackIds]
     );
 
     const [nextRepeat, repeatClassName] = (() => {
@@ -120,6 +122,14 @@ function Controls() {
                 {repeat === "track" && <span className={cl("repeat-1")}>1</span>}
                 <Repeat />
             </Button>
+            {Settings.plugins.SpotifyControls.manageSavedSongs === true && track?.id && savedTrackIds.has(track.id) && (
+                <Button
+                    className={classes(cl("button"), cl(savedTrackIds.get(track.id) ? "saved-on" : "saved-off"))}
+                    onClick={() => SpotifyStore.saveTrack()}
+                >
+                    <Heart />
+                </Button>
+            )}
         </Flex>
     );
 }

--- a/src/plugins/spotifyControls/SpotifyStore.ts
+++ b/src/plugins/spotifyControls/SpotifyStore.ts
@@ -184,7 +184,7 @@ export const SpotifyStore = proxyLazy(() => {
                 const { track } = this;
                 if (this.savedTrackIds.has(track.id)) {
                     const current = this.savedTrackIds.get(track.id);
-                    this.req(current ? "put" : "put", "/tracks", { // TODO: needs delete
+                    this.req(current ? "delete" : "put", "/tracks", {
                         query: {
                             ids: this.track.id
                         }
@@ -217,7 +217,7 @@ export const SpotifyStore = proxyLazy(() => {
             });
         }
 
-        private req(method: "post" | "get" | "put", route: string, data: any = {}) {
+        private req(method: "post" | "get" | "put" | "delete", route: string, data: any = {}) {
             if (this.device?.is_active && route.includes("/player"))
                 (data.query ??= {}).device_id = this.device.id;
 

--- a/src/plugins/spotifyControls/SpotifyStore.tsx
+++ b/src/plugins/spotifyControls/SpotifyStore.tsx
@@ -223,7 +223,7 @@ export const SpotifyStore = proxyLazy(() => {
                 (data.query ??= {}).device_id = this.device.id;
 
             const { socket } = SpotifySocket.getActiveSocketAndDevice();
-            const spotifyPromise = SpotifyAPI[method](socket.accountId, socket.accessToken, {
+            const spotifyPromise: Promise<any> = SpotifyAPI[method](socket.accountId, socket.accessToken, {
                 url: API_BASE + route,
                 ...data
             });

--- a/src/plugins/spotifyControls/SpotifyStore.tsx
+++ b/src/plugins/spotifyControls/SpotifyStore.tsx
@@ -163,16 +163,16 @@ export const SpotifyStore = proxyLazy(() => {
         }
 
         checkSaved() {
-            if (Settings.plugins.SpotifyControls.manageSavedSongs === true && SpotifySocket.getActiveSocketAndDevice() && this.track?.id) {
-                const { track } = this;
+            const { track } = this;
+            if (Settings.plugins.SpotifyControls.manageSavedSongs === true && SpotifySocket.getActiveSocketAndDevice() && track?.id) {
 
                 if (!this.savedTrackIds.has(track.id)) {
                     this.req("get", "/tracks/contains", {
                         query: {
-                            ids: this.track.id
+                            ids: track.id
                         }
                     }).then((res: any) => {
-                        if (res && res.body && Array.isArray(res.body)) {
+                        if (res?.body && Array.isArray(res.body)) {
                             this.savedTrackIds.set(track.id, res.body[0]);
                             this.emitChange();
                         }
@@ -182,16 +182,16 @@ export const SpotifyStore = proxyLazy(() => {
         }
 
         saveTrack() {
-            if (this.track?.id) {
-                const { track } = this;
+            const { track } = this;
+            if (track?.id) {
                 if (this.savedTrackIds.has(track.id)) {
                     const current = this.savedTrackIds.get(track.id);
                     this.req(current ? "delete" : "put", "/tracks", {
                         query: {
-                            ids: this.track.id
+                            ids: track.id
                         }
                     }).then((res: any) => {
-                        if (res.ok) {
+                        if (res?.ok) {
                             this.savedTrackIds.set(track.id, !current);
                             this.emitChange();
                         }

--- a/src/plugins/spotifyControls/SpotifyStore.tsx
+++ b/src/plugins/spotifyControls/SpotifyStore.tsx
@@ -244,6 +244,7 @@ export const SpotifyStore = proxyLazy(() => {
                                     <Text variant="text-md/normal">You need to re-authenticate your Spotify account with Discord!</Text>
                                     <Text variant="text-sm/normal">This is required for it to be able to read and modify your liked songs.</Text>
                                     <Text variant="text-sm/normal" style={{ marginTop: 8 }}>Go to Settings - Connections - Spotify</Text>
+                                    <Text variant="text-sm/normal" style={{ marginTop: 3 }}>Connect your account again, then reload Discord</Text>
                                 </ModalContent>
                                 <ModalFooter>
                                     <Flex>

--- a/src/plugins/spotifyControls/SpotifyStore.tsx
+++ b/src/plugins/spotifyControls/SpotifyStore.tsx
@@ -166,18 +166,19 @@ export const SpotifyStore = proxyLazy(() => {
             const { track } = this;
             if (Settings.plugins.SpotifyControls.manageSavedSongs === true && SpotifySocket.getActiveSocketAndDevice() && track?.id) {
 
-                if (!this.savedTrackIds.has(track.id)) {
-                    this.req("get", "/tracks/contains", {
-                        query: {
-                            ids: track.id
-                        }
-                    }).then((res: any) => {
-                        if (res?.body && Array.isArray(res.body)) {
-                            this.savedTrackIds.set(track.id, res.body[0]);
-                            this.emitChange();
-                        }
-                    });
-                }
+                // Always fetch again as the user might have changed the save status via Spotify
+                // if (!this.savedTrackIds.has(track.id)) {
+                this.req("get", "/tracks/contains", {
+                    query: {
+                        ids: track.id
+                    }
+                }).then((res: any) => {
+                    if (res?.body && Array.isArray(res.body)) {
+                        this.savedTrackIds.set(track.id, res.body[0]);
+                        this.emitChange();
+                    }
+                });
+                // }
             }
         }
 

--- a/src/plugins/spotifyControls/SpotifyStore.tsx
+++ b/src/plugins/spotifyControls/SpotifyStore.tsx
@@ -172,7 +172,6 @@ export const SpotifyStore = proxyLazy(() => {
                             ids: this.track.id
                         }
                     }).then((res: any) => {
-                        console.log("SPOTIFY IS SAVED", res);
                         if (res && res.body && Array.isArray(res.body)) {
                             this.savedTrackIds.set(track.id, res.body[0]);
                             this.emitChange();
@@ -192,7 +191,6 @@ export const SpotifyStore = proxyLazy(() => {
                             ids: this.track.id
                         }
                     }).then((res: any) => {
-                        console.log("SPOTIFY SAVED", res);
                         if (res.ok) {
                             this.savedTrackIds.set(track.id, !current);
                             this.emitChange();

--- a/src/plugins/spotifyControls/SpotifyStore.tsx
+++ b/src/plugins/spotifyControls/SpotifyStore.tsx
@@ -227,7 +227,7 @@ export const SpotifyStore = proxyLazy(() => {
                 url: API_BASE + route,
                 ...data
             });
-            if (Settings.plugins.SpotifyControls.manageSavedSongs === true && spotifyPromise.catch) {
+            if (Settings.plugins.SpotifyControls.manageSavedSongs === true && route.includes("/tracks") && spotifyPromise.catch) {
                 spotifyPromise.catch((e: any) => {
                     // insufficient client scope
                     if (this.showInsufficientPermissionsModal && e?.body?.error?.status === 403) {

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -72,6 +72,7 @@ export default definePlugin({
             restartNeeded: true,
         },
         savedSongsDisplay: {
+            disabled: () => Settings.plugins.SpotifyControls.manageSavedSongs === false,
             description: "Where to show the saved songs button",
             type: OptionType.SELECT,
             default: "context",

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -75,7 +75,6 @@ export default definePlugin({
             disabled: () => Settings.plugins.SpotifyControls.manageSavedSongs === false,
             description: "Where to show the saved songs button",
             type: OptionType.SELECT,
-            default: "context",
             options: [
                 { label: "Context menu", value: "context", default: true },
                 { label: "Extra icon", value: "icon" }

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -46,12 +46,12 @@ export default definePlugin({
                 replace: "return Vencord.Plugins.plugins.SpotifyControls.modifyAuthUrl($3,$1.$2.get({url:$3,oldFormErrors:!0}))"
             },
         },
-        // Adds POST and a Marker to the SpotifyAPI (so we can easily find it)
+        // Adds POST, DELETE and a Marker to the SpotifyAPI (so we can easily find it)
         {
             find: ".PLAYER_DEVICES",
             replacement: {
                 match: /get:(.{1,3})\.bind\(null,(.{1,6})\.get\)/,
-                replace: "SpotifyAPIMarker:1,post:$1.bind(null,$2.post),$&"
+                replace: "SpotifyAPIMarker:1,post:$1.bind(null,$2.post),delete:$1.bind(null,$2.delete),$&"
             }
         },
         // Discord doesn't give you the repeat kind, only a boolean

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -43,7 +43,7 @@ export default definePlugin({
             predicate: () => Settings.plugins.SpotifyControls.manageSavedSongs === true,
             replacement:{
                 match: /return (\w+)\.(\w+)\.get\(\{url:(\w+),oldFormErrors:!0\}\)/,
-                replace: "return Vencord.Plugins.plugins.SpotifyControls.modifyAuthUrl($3, $1.$2.get({url:$3,oldFormErrors:!0}))"
+                replace: "return Vencord.Plugins.plugins.SpotifyControls.modifyAuthUrl($3,$1.$2.get({url:$3,oldFormErrors:!0}))"
             },
         },
         // Adds POST and a Marker to the SpotifyAPI (so we can easily find it)

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -71,6 +71,15 @@ export default definePlugin({
             default: false,
             restartNeeded: true,
         },
+        savedSongsDisplay: {
+            description: "Where to show the saved songs button",
+            type: OptionType.SELECT,
+            default: "context",
+            options: [
+                { label: "Context menu", value: "context", default: true },
+                { label: "Extra icon", value: "icon" }
+            ],
+        },
     },
 
     async modifyAuthUrl(url: string, promise: Promise<any>) {

--- a/src/plugins/spotifyControls/spotifyStyles.css
+++ b/src/plugins/spotifyControls/spotifyStyles.css
@@ -40,9 +40,11 @@
 .vc-spotify-shuffle-on,
 .vc-spotify-repeat-context,
 .vc-spotify-repeat-track,
+.vc-spotify-saved-on,
 .vc-spotify-shuffle-on:hover,
 .vc-spotify-repeat-context:hover,
-.vc-spotify-repeat-track:hover {
+.vc-spotify-repeat-track:hover,
+.vc-spotify-saved-on:hover {
     color: var(--vc-spotify-green);
 }
 


### PR DESCRIPTION
TODO
- [x] Implement removing from saved tracks
- [x] Maybe prompt the user to re-authenticate when a request fails with status 403
- [x] Show in album context menu

Possible improvements

- [ ] Sync when updated save status via Spotify client (We could remove `if (!this.savedTrackIds.has(track.id)) {` but `SPOTIFY_PLAYER_STATE` is not called when the user clicks on the icon only after a seek/play/pause/etc..)
- [ ] Use heart icon in context menu instead of checkbox
- [ ] Find a better spot to call `checkSaved`
- [ ] Improve the patch regex?
- [ ] Make it prettier when showing as icon (Icons are no longer centered now)