### PR TITLE
Fix Background Colour for Plugin Card & Settings

### DIFF
--- a/src/components/PluginSettings/styles.ts
+++ b/src/components/PluginSettings/styles.ts
@@ -24,7 +24,7 @@ export const PluginsGrid: React.CSSProperties = {
 };
 
 export const PluginsGridItem: React.CSSProperties = {
-    backgroundColor: "var(--background-modifier-selected)",
+    backgroundColor: "var(--primary-dark-530)",
     color: "var(--interactive-active)",
     borderRadius: 3,
     cursor: "pointer",

--- a/src/components/VencordSettings/VencordTab.tsx
+++ b/src/components/VencordSettings/VencordTab.tsx
@@ -121,7 +121,8 @@ function DonateCard({ image }: DonateCardProps) {
             display: "flex",
             flexDirection: "row",
             marginBottom: "1em",
-            marginTop: "1em"
+            marginTop: "1em",
+            backgroundColor: "var(--primary-dark-700)"
         }}>
             <div>
                 <Forms.FormTitle tag="h5">Support the Project</Forms.FormTitle>

--- a/src/components/VencordSettings/settingsStyles.css
+++ b/src/components/VencordSettings/settingsStyles.css
@@ -20,4 +20,5 @@
     flex-grow: 1;
     flex-direction: row;
     margin-bottom: 1em;
+    background-color: var(--primary-dark-700);
 }


### PR DESCRIPTION
Fix background colour for plugin card & settings when having a custom theme.

### Before
<img width="801" alt="image" src="https://user-images.githubusercontent.com/30734036/204393835-21a66b17-4300-4893-b41b-1df8565eb3b1.png">
<img width="811" alt="image" src="https://user-images.githubusercontent.com/30734036/204393854-d38d4188-7f49-44c4-a2e0-157b412c7712.png">


## After
<img width="631" alt="image" src="https://user-images.githubusercontent.com/30734036/204395759-efb2da17-ea80-4808-bcd1-8db64493b77c.png">
<img width="776" alt="image" src="https://user-images.githubusercontent.com/30734036/204393713-ca1411f6-1faf-4119-b8e2-70443b45c676.png">
