### PR TITLE
fix: hljs fallback

### DIFF
--- a/src/plugins/shikiCodeblocks/components/Code.tsx
+++ b/src/plugins/shikiCodeblocks/components/Code.tsx
@@ -17,6 +17,7 @@
 */
 
 import type { IThemedToken } from "@vap/shiki";
+import { hljs } from "@webpack/common";
 
 import { cl } from "../utils/misc";
 import { ThemeBase } from "./Highlighter";


### PR DESCRIPTION
hljs wasnt working as a fallback because the `highlight.js` package does this:
```ts
declare const hljs : HLJSApi;
```
: D : DD: DD: D: D

maybe we *should* use a separate type-only package..