### PR TITLE
add commas in member count

### DIFF
--- a/src/plugins/memberCount.tsx
+++ b/src/plugins/memberCount.tsx
@@ -35,10 +35,12 @@ function MemberCount() {
 
     if (!c) return null;
 
-    let total = String(c[0]);
+    let total = c[0].toLocaleString();
     if (total === "0" && c[1] > 0) {
         total = "Loading...";
     }
+    
+    let online = c[1].toLocaleString()
 
     return (
         <Flex id="vc-membercount" style={{
@@ -49,7 +51,7 @@ function MemberCount() {
             alignContent: "center",
             gap: 0
         }}>
-            <Tooltip text={`${c[1]} Online`} position="bottom">
+            <Tooltip text={`${online} Online`} position="bottom">
                 {props => (
                     <div {...props}>
                         <span
@@ -62,11 +64,11 @@ function MemberCount() {
                                 marginRight: "0.5em"
                             }}
                         />
-                        <span style={{ color: "var(--status-green-600)" }}>{c[1]}</span>
+                        <span style={{ color: "var(--status-green-600)" }}>{online}</span>
                     </div>
                 )}
             </Tooltip>
-            <Tooltip text={`${c[0] || "?"} Total Members`} position="bottom">
+            <Tooltip text={`${total} Total Members`} position="bottom">
                 {props => (
                     <div {...props}>
                         <span

--- a/src/plugins/memberCount.tsx
+++ b/src/plugins/memberCount.tsx
@@ -39,8 +39,8 @@ function MemberCount() {
     if (total === "0" && c[1] > 0) {
         total = "Loading...";
     }
-    
-    let online = c[1].toLocaleString();
+
+    const online = c[1].toLocaleString();
 
     return (
         <Flex id="vc-membercount" style={{

--- a/src/plugins/memberCount.tsx
+++ b/src/plugins/memberCount.tsx
@@ -40,7 +40,7 @@ function MemberCount() {
         total = "Loading...";
     }
     
-    let online = c[1].toLocaleString()
+    let online = c[1].toLocaleString();
 
     return (
         <Flex id="vc-membercount" style={{


### PR DESCRIPTION
a lot easier to read the member count, especially in large servers!

before

![image](https://user-images.githubusercontent.com/68407783/205463045-57559ff2-ca21-49f7-8702-72aeb0c61696.png)

after

![image](https://user-images.githubusercontent.com/68407783/205463085-bdd15f32-5d36-43d8-9db6-6d8025bd11f0.png)
