### PR TITLE
feat: CSS Snippet Manager

### DIFF
--- a/src/plugins/cssSnippetManager.tsx
+++ b/src/plugins/cssSnippetManager.tsx
@@ -94,15 +94,15 @@ export default definePlugin({
     },
     SnippetManager(props) {
         const { message }: { message: Message; } = props;
+
+        // TODO: Possibly make this configurable?
         if (message.channel_id !== "1028106818368589824") return <></>;
 
         const codeBlocks = parseCodeBlocks(message.content);
         if (codeBlocks.length !== 1) return <></>;
 
         const [code] = codeBlocks;
-        if (code.lang !== "css" && code.lang !== undefined) return <></>;
-
-        // console.log("ayo", { message, code, time: moment(message.timestamp).unix() });
+        if (code.lang !== "css") return <></>;
 
         const snippet = (Settings.plugins.CssSnippetManager?.cssSnippets as Snippet[] | undefined || [])
             .find(snippet => (

--- a/src/plugins/cssSnippetManager.tsx
+++ b/src/plugins/cssSnippetManager.tsx
@@ -1,0 +1,176 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { addAccessory, removeAccessory } from "@api/MessageAccessories";
+import { Settings } from "@api/settings";
+import { Devs } from "@utils/constants.js";
+import { makeLazy } from "@utils/misc";
+import definePlugin, { OptionType } from "@utils/types";
+import { findByProps } from "@webpack";
+import { Button, moment, React } from "@webpack/common";
+import { Message } from "discord-types/general";
+
+// regex for the win
+const parseCodeBlocks = (text: string) => Array.from(text.matchAll(/```(\w+)?((?:.|\s)*?)```/g)).map(([_, lang, code]) => ({ lang, code }));
+const useEffect = (...args: Parameters<typeof React.useEffect>) => React.useEffect(...args);
+const useState = makeLazy(() => React.useState);
+const getCssClassNames = makeLazy(() => findByProps("colorRed"));
+
+interface Snippet {
+    authorId: string;
+    messageId: string;
+    editedTimestamp: number;
+    code: string;
+}
+
+const SnippetMgrSettings = ({ setValue }: { setValue: (newValue: Snippet[]) => void; }) => {
+    const [snippets, setSnippets] = useState()<Snippet[]>([]);
+
+    useEffect(() => {
+        // TODO: Make the UI for this, maybe use code blocks to show the css of each snippet?
+    }, []);
+
+    return <>hi</>;
+};
+
+
+export default definePlugin({
+    name: "CssSnippetManager",
+    description: "todo()",
+    authors: [Devs.Arjix],
+    dependencies: ["MessageAccessoriesAPI"],
+    options: {
+        cssSnippets: {
+            type: OptionType.COMPONENT,
+            description: "",
+            component: SnippetMgrSettings,
+        }
+    },
+    styles: [] as HTMLStyleElement[],
+    start() {
+        addAccessory("cssSnippetMgr", this.SnippetManager, 0);
+
+        this.addStyles();
+    },
+    stop() {
+        removeAccessory("cssSnippetMgr");
+
+        this.styles.forEach(style => style.remove());
+        while (this.styles.length) this.styles.pop(); // couldn't be bothered to get .clear() to work
+    },
+    addStyles() {
+        const snippets = (Settings.plugins.CssSnippetManager?.cssSnippets as Snippet[] | undefined || []);
+        for (const snippet of snippets) {
+            let style;
+            if (!(style = document.getElementById(`css_snippet_${snippet.authorId}_${snippet.messageId}`))) {
+                style = document.createElement("style");
+                style.id = `css_snippet_${snippet.authorId}_${snippet.messageId}`;
+                document.head.appendChild(style);
+            }
+            style.innerHTML = snippet.code;
+
+            if (!this.styles.includes(style)) this.styles.push(style);
+        }
+    },
+    removeStyle(snippet: Snippet) {
+        const style = document.getElementById(`css_snippet_${snippet.authorId}_${snippet.messageId}`);
+        if (style) this.styles = this.styles.filter(st => st.id !== style.id);
+        style?.remove();
+    },
+    SnippetManager(props) {
+        const { message }: { message: Message; } = props;
+        if (message.channel_id !== "1028106818368589824") return <></>;
+
+        const codeBlocks = parseCodeBlocks(message.content);
+        if (codeBlocks.length !== 1) return <></>;
+
+        const [code] = codeBlocks;
+        if (code.lang !== "css" && code.lang !== undefined) return <></>;
+
+        // console.log("ayo", { message, code, time: moment(message.timestamp).unix() });
+
+        const snippet = (Settings.plugins.CssSnippetManager?.cssSnippets as Snippet[] | undefined || [])
+            .find(snippet => (
+                snippet.messageId === message.id &&
+                snippet.authorId === message.author.id
+            ));
+
+        const timestamp = moment(message.editedTimestamp || message.timestamp).unix();
+
+        const applyOrUpdate = () => {
+            const snippets = (Settings.plugins.CssSnippetManager?.cssSnippets as Snippet[] | undefined || []);
+            if (snippet !== undefined) {
+                for (const snip of snippets) {
+                    if (snip.messageId === message.id) {
+                        snip.code = code.code;
+                        snip.editedTimestamp = timestamp;
+                    }
+                }
+            } else {
+                snippets.push({
+                    authorId: message.author.id,
+                    messageId: message.id,
+                    editedTimestamp: timestamp,
+                    code: code.code
+                });
+            }
+
+            Settings.plugins.CssSnippetManager.cssSnippets = snippets;
+            (Vencord.Plugins.plugins.CssSnippetManager as any)?.addStyles();
+        };
+        const removeSnippet = () => {
+            snippet && (Vencord.Plugins.plugins.CssSnippetManager as any)?.removeStyle(snippet);
+
+            const snippets = (Settings.plugins.CssSnippetManager?.cssSnippets as Snippet[] | undefined || []);
+            Settings.plugins.CssSnippetManager.cssSnippets = snippets.filter(snip => snip.messageId !== message.id);
+        };
+
+        return (
+            <>{
+                snippet !== undefined ? (
+                    <div style={{ display: "flex", flexDirection: "row", columnGap: "4%" }}>
+                        {timestamp !== snippet.editedTimestamp &&
+                            <Button
+                                className={getCssClassNames().colorGreen}
+                                onClick={applyOrUpdate}
+                                size={Button.Sizes.SMALL}
+                                style={{ paddingInline: "0" }} // Discord bad, the text does not fit due to the padding ;-;
+                            >
+                                Update
+                            </Button>}
+                        <Button
+                            className={getCssClassNames().colorRed}
+                            onClick={removeSnippet}
+                            size={Button.Sizes.SMALL}
+                            style={{ paddingInline: "0" }} // Discord bad, the text does not fit due to the padding ;-;
+                        >
+                            Remove
+                        </Button>
+                    </div>
+                ) : (
+                    <Button
+                        onClick={applyOrUpdate}
+                        size={Button.Sizes.SMALL}
+                    >
+                        Apply
+                    </Button>
+                )
+            }</>
+        );
+    },
+});

--- a/src/plugins/cssSnippetManager.tsx
+++ b/src/plugins/cssSnippetManager.tsx
@@ -48,7 +48,7 @@ interface Snippet {
 }
 
 // This should ensure that I am dealing with a copy, and not a proxy.
-const getSnippets = () => (PlainSettings.plugins.CssSnippetManager?.cssSnippets as Snippet[] ?? []).map(e => Object.assign({}, e) as Snippet);
+const getSnippets = () => window._.cloneDeep(PlainSettings.plugins.CssSnippetManager?.cssSnippets as Snippet[] ?? []);
 
 function CodeBlock(props: { content: string, lang: string; }) {
     return (
@@ -77,8 +77,8 @@ const SnippetMgrSettings = ({ setValue }: { setValue: (newValue: Snippet[]) => v
 
             if (!guilds[snippet.guildId]) {
                 const guild = window._.cloneDeep(GuildStore.getGuild(snippet.guildId));
-const channels = GuildChannelStore.getChannels(snippet.guildId).SELECTABLE.map(c => c.channel);
-guilds[snippet.guildId] = { ...guild, channels };
+                const channels = GuildChannelStore.getChannels(snippet.guildId).SELECTABLE.map(c => c.channel);
+                guilds[snippet.guildId] = { ...guild, channels };
             }
         }
 

--- a/src/plugins/cssSnippetManager.tsx
+++ b/src/plugins/cssSnippetManager.tsx
@@ -358,6 +358,6 @@ export default definePlugin({
             `Last Modified at: ${snippet.editedTimestamp}`,
             `Guild ID: ${snippet.guildId}`,
             `Channel ID: ${snippet.channelId}`,
-        ].join("\n* ")) + `*/\n${snippet.code}`);
+        ].join("\n* ")) + `*/\n${snippet.code}`).join("\n\n");
     }
 });

--- a/src/plugins/cssSnippetManager.tsx
+++ b/src/plugins/cssSnippetManager.tsx
@@ -77,8 +77,8 @@ const SnippetMgrSettings = ({ setValue }: { setValue: (newValue: Snippet[]) => v
 
             if (!guilds[snippet.guildId]) {
                 const guild = window._.cloneDeep(GuildStore.getGuild(snippet.guildId));
-                guild.channels = GuildChannelStore.getChannels(snippet.guildId).SELECTABLE.map(c => c.channel);
-                guilds[snippet.guildId] = guild;
+const channels = GuildChannelStore.getChannels(snippet.guildId).SELECTABLE.map(c => c.channel);
+guilds[snippet.guildId] = { ...guild, channels };
             }
         }
 

--- a/src/plugins/cssSnippetManager.tsx
+++ b/src/plugins/cssSnippetManager.tsx
@@ -22,8 +22,8 @@ import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants.js";
 import { makeLazy, useForceUpdater } from "@utils/misc";
 import definePlugin, { OptionType } from "@utils/types";
-import { findByProps, useEffect, useState } from "@webpack";
-import { Button, ChannelStore, Forms, GuildChannelStore, GuildStore, moment, NavigationRouter, Parser, React, SelectedGuildStore, Toasts } from "@webpack/common";
+import { findByProps } from "@webpack";
+import { Button, ChannelStore, Forms, GuildChannelStore, GuildStore, moment, NavigationRouter, Parser, React, SelectedGuildStore, Toasts, useEffect, useState } from "@webpack/common";
 import { Channel, Guild, Message } from "discord-types/general";
 
 /*
@@ -60,8 +60,8 @@ function CodeBlock(props: { content: string, lang: string; }) {
 }
 
 const SnippetMgrSettings = ({ setValue }: { setValue: (newValue: Snippet[]) => void; }) => {
-    const [snippetsGrouped, setSnippetsGrouped] = useState()<{ [guild_id: string]: { [channel_id: string]: Snippet[]; }; }>({});
-    const [guilds, setGuilds] = useState()<{ [guild_id: string]: Guild & { channels: Channel[]; }; }>({});
+    const [snippetsGrouped, setSnippetsGrouped] = useState<{ [guild_id: string]: { [channel_id: string]: Snippet[]; }; }>({});
+    const [guilds, setGuilds] = useState<{ [guild_id: string]: Guild & { channels: Channel[]; }; }>({});
     const forceUpdate = useForceUpdater();
 
     useEffect(() => {
@@ -107,7 +107,7 @@ const SnippetMgrSettings = ({ setValue }: { setValue: (newValue: Snippet[]) => v
                                     <Forms.FormText tag="h2">{guilds[guild_id].name}</Forms.FormText>
                                 </div>
 
-                                {Object.entries(channels).map(([channel_id, snippets]) => {
+                                {Object.entries(channels as {}).map(([channel_id, snippets]) => {
                                     return (
                                         <div style={{ marginLeft: "5%" }}>
                                             <div style={{ marginBottom: "2%" }}>
@@ -128,7 +128,7 @@ const SnippetMgrSettings = ({ setValue }: { setValue: (newValue: Snippet[]) => v
                                                 </span>
                                             </div>
                                             <ul style={{ marginLeft: "5%" }}>
-                                                {snippets.map(s => (
+                                                {(snippets as Snippet[]).map(s => (
                                                     <li>
                                                         <div style={{
                                                             marginBottom: "1%",
@@ -172,7 +172,7 @@ const SnippetMgrSettings = ({ setValue }: { setValue: (newValue: Snippet[]) => v
                                                                         }
 
                                                                         forceUpdate();
-                                                                        setValue(Object.values(snippets).map(channels => Object.values(channels)).flat(2));
+                                                                        setValue(Object.values(snippets).map(channels => Object.values(channels as {})).flat(2) as Snippet[]);
                                                                         return snippets;
                                                                     });
                                                                 }}
@@ -358,6 +358,6 @@ export default definePlugin({
             `Last Modified at: ${snippet.editedTimestamp}`,
             `Guild ID: ${snippet.guildId}`,
             `Channel ID: ${snippet.channelId}`,
-        ].join("\n* ")) + `*/\n${snippet.code}`).join("\n\n");
+        ].join("\n* ").trimEnd()) + `\n*/\n${snippet.code.trim()}`).join("\n\n");
     }
 });


### PR DESCRIPTION
## About
Uses the message accessories API to add the following buttons `Apply`, `Update`, `Remove`.

- Apply: Saves the code snippet in the plugin settings and appends it to the head.
- Update: Appears when a message (of an installed snippet) has been edited, clicking it would simply use the new code.
- Remove: Removes the snippet from the plugin settings and from the head.

<details>
  <summary>Screenshots</summary>
  
  <p align="center">
    <img src="https://user-images.githubusercontent.com/53124886/208208964-88d12bc2-dab6-4eda-9faf-bf412d8e49a0.png">
    <img src="https://user-images.githubusercontent.com/53124886/208208977-c5ce0d10-5195-43e8-9a5f-85bf75431368.png">
    <img src="https://user-images.githubusercontent.com/53124886/208208985-d7555230-7f23-4c0d-a602-ed064eea0bbe.png">
  </p>

</details>

## TODO:
- [x] Implement the settings UI
- [x] Figure out why the elements do not re-render until the mouse cursor does not intersect with it.
