### PR TITLE
Ignore dotfiles in plugin dirs

### DIFF
--- a/scripts/build/common.mjs
+++ b/scripts/build/common.mjs
@@ -68,6 +68,7 @@ export const globPlugins = {
                 if (!existsSync(`./src/${dir}`)) continue;
                 const files = await readdir(`./src/${dir}`);
                 for (const file of files) {
+                    if (file.startsWith(".")) continue;
                     if (file === "index.ts") {
                         continue;
                     }


### PR DESCRIPTION
Skip dot files in root of plugin dirs.

Which previously would cause build to fail if say, `.git/` existed in `src/userplugins/`.