### PR TITLE
fix: emojis with duplicate names failing to clone

### DIFF
--- a/src/plugins/emoteCloner.tsx
+++ b/src/plugins/emoteCloner.tsx
@@ -57,7 +57,7 @@ async function doClone(guildId: string, id: string, name: string, isAnimated: bo
     reader.onload = () => {
         uploadEmoji({
             guildId,
-            name,
+            name: name.split("~")[0],
             image: reader.result
         }).then(() => {
             Toasts.show({


### PR DESCRIPTION
Emojis with duplicate names are locally called `emojiName~n`. The `~` is invalid in emoji names and causes the cloner to break.