### PR TITLE
feat(plugin): RoleColorEverywhere

### DIFF
--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -40,7 +40,7 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "RoleColorEverywhere",
-    authors: [Devs.KingFish],
+    authors: [Devs.KingFish, Devs.lewisakura],
     description: "Adds the top role color anywhere possible",
     patches: [
         // Chat Mentions

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -58,10 +58,6 @@ export default definePlugin({
                     match: /(function\((.)\).+?roleIcon.{5,20}null,).," \u2014 ",.\]/,
                     replace: "$1$self.roleGroupColor(e)]"
                 },
-                {
-                    match: /n\.isShown;/,
-                    replace: "$&$self.testing(e,n,f,h,c,s);"
-                }
             ],
             predicate: () => settings.store.memberList,
         },

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -55,7 +55,7 @@ export default definePlugin({
             find: ".memberGroupsPlaceholder",
             replacement: [
                 {
-                    match: /(memo\(\(function\((.)\).{0,500}CHANNEL_MEMBERS_A11Y_LABEL.+?roleIcon.{5,20}null,).," \u2014 ",.\]/,
+                    match: /(memo\(\(function\((.)\).{300,500}CHANNEL_MEMBERS_A11Y_LABEL.{100,200}roleIcon.{5,20}null,).," \u2014 ",.\]/,
                     replace: "$1$self.roleGroupColor($2)]"
                 },
             ],

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -70,7 +70,7 @@ export default definePlugin({
             find: ".memberGroupsPlaceholder",
             replacement: [
                 {
-                    match: /(function\((.)\).+?roleIcon.{5,20}null,).," ÔÇö ",.\]/,
+                    match: /(function\((.)\).+?roleIcon.{5,20}null,).," \u2014 ",.\]/,
                     replace: "$1$self.roleGroupColor(e)]"
                 },
                 {

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -19,10 +19,7 @@
 import { definePluginSettings } from "@api/settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
-import { findByPropsLazy } from "@webpack";
-import { GuildStore } from "@webpack/common";
-
-const MemberStore = findByPropsLazy("getMember");
+import { GuildMemberStore, GuildStore } from "@webpack/common";
 
 const settings = definePluginSettings({
     chatMentions: {
@@ -71,7 +68,7 @@ export default definePlugin({
             return null;
         }
 
-        const member = MemberStore.getMember(channel.guild_id, userId);
+        const member = GuildMemberStore.getMember(channel.guild_id, userId);
         if (!member) {
             return null;
         }

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -1,0 +1,119 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { findByProps, findByPropsLazy } from "@webpack";
+import { getCurrentChannel } from "@utils/discord";
+import { GuildStore, UserStore } from "@webpack/common";
+
+const MemberStore = findByPropsLazy("getMember");
+
+export default definePlugin({
+    name: "RoleColorEverywhere",
+    authors: [Devs.KingFish],
+    description: "Adds the top role color anywhere possible",
+    patches: [
+        // Chat Mentions
+        {
+            find: 'className:"mention"',
+            replacement: [
+                {
+                    match: /user:(.),channelId:(.).{0,300}?"@".concat\(.+?\)/,
+                    replace: "$&,color:Vencord.Plugins.plugins.RoleColorEverywhere.getUserColor($1, $2)"
+                }
+            ],
+        },
+        // Typing Users
+        {
+            find: 'Messages.ONE_USER_TYPING',
+            replacement: [
+                {
+                    match: /((\w)=\w\.typingUsers.+?)(\w),\w=(\w+?\(\w+?,\d+?\)).+?(\w\.\w\.Messages.SEVERAL_USERS_TYPING);/,
+                    replace: "$1$3=Vencord.Plugins.plugins.RoleColorEverywhere.typingUsers($4,$2,$5);"
+                }
+            ],
+        },
+        // Member List Role Names
+        {
+            find: '.memberGroupsPlaceholder',
+            replacement: [
+                {
+                    match: /(function\((.)\).+?roleIcon.{5,20}null,).," ÔÇö ",.\]/,
+                    replace: "$1Vencord.Plugins.plugins.RoleColorEverywhere.roleGroupColor(e)]"
+                },
+                {
+                    match: /n\.isShown;/,
+                    replace: "$&Vencord.Plugins.plugins.RoleColorEverywhere.testing(e,n,f,h,c,s);"
+                }
+            ],
+        },
+    ],
+    getColor(userId, channelId) {
+        const channel = Vencord.Webpack.Common.ChannelStore.getChannel(channelId);
+        if (!channel) {
+            return null;
+        }
+
+        const member = MemberStore.getMember(channel.guild_id, userId);
+        if (!member) {
+            return null;
+        }
+
+        return member?.colorString
+    },
+    getUserColor({ id: userId }, channelId) {
+        const colorString = this.getColor(userId, channelId);
+        return colorString && parseInt(colorString.slice(1), 16);
+    },
+    typingUsers(users, userIds, SEVERAL_USERS_TYPING) { // todo: work with i18n
+        const currentUser = UserStore.getCurrentUser();
+
+        const locale = findByProps("getLocale").getLocale();
+        const fmt = new Intl.ListFormat(locale, { style: 'long', type: 'conjunction' })
+
+        userIds = Object.keys(userIds).filter(m => m != currentUser.id);
+        const several = userIds.length > 3;
+        userIds = fmt.formatToParts(userIds.slice(0, 3));
+
+        const stuff = userIds.length === 0 ? null : (!several ? <>
+            {userIds.map(({ value: id, type }, i) => {
+                const channel = getCurrentChannel();
+                const member = MemberStore.getMember(channel.guild_id, id);
+
+                return type === 'element' ?
+                    <strong style={{color: member?.colorString}}>
+                        {member?.nick || UserStore.getUser(id).username}
+                    </strong>
+                : id
+            })} {users.length > 1 ? 'are' : 'is'} typing...
+        </> : SEVERAL_USERS_TYPING)
+
+        return stuff;
+    },
+    roleGroupColor({ id, count, title, guildId, ...args }) {
+        const guild = GuildStore.getGuild(guildId);
+        const role = guild?.roles[id]
+
+        return <span style={{
+            color: role?.colorString,
+            fontWeight: "unset",
+            letterSpacing: ".05em"
+        }}>{title} ÔÇö {count}</span>;
+    }
+});

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -29,12 +29,12 @@ const settings = definePluginSettings({
     chatMentions: {
         type: OptionType.BOOLEAN,
         default: true,
-        description: "Show role colors in chat mentions."
+        description: "Show role colors in chat mentions"
     },
     typingIndicator: {
         type: OptionType.BOOLEAN,
         default: true,
-        description: "Show colors in the typing indicator. Incompatible with TypingTweaks."
+        description: "Show colors in the typing indicator (incompatible with TypingTweaks)"
     },
 });
 

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -35,7 +35,7 @@ export default definePlugin({
             replacement: [
                 {
                     match: /user:(.),channelId:(.).{0,300}?"@".concat\(.+?\)/,
-                    replace: "$&,color:Vencord.Plugins.plugins.RoleColorEverywhere.getUserColor($1, $2)"
+                    replace: "$&,color:$self.getUserColor($1, $2)"
                 }
             ],
         },
@@ -45,7 +45,7 @@ export default definePlugin({
             replacement: [
                 {
                     match: /((\w)=\w\.typingUsers.+?)(\w),\w=(\w+?\(\w+?,\d+?\)).+?(\w\.\w\.Messages.SEVERAL_USERS_TYPING);/,
-                    replace: "$1$3=Vencord.Plugins.plugins.RoleColorEverywhere.typingUsers($4,$2,$5);"
+                    replace: "$1$3=$self.typingUsers($4,$2,$5);"
                 }
             ],
         },
@@ -55,11 +55,11 @@ export default definePlugin({
             replacement: [
                 {
                     match: /(function\((.)\).+?roleIcon.{5,20}null,).," ÔÇö ",.\]/,
-                    replace: "$1Vencord.Plugins.plugins.RoleColorEverywhere.roleGroupColor(e)]"
+                    replace: "$1$self.roleGroupColor(e)]"
                 },
                 {
                     match: /n\.isShown;/,
-                    replace: "$&Vencord.Plugins.plugins.RoleColorEverywhere.testing(e,n,f,h,c,s);"
+                    replace: "$&$self.testing(e,n,f,h,c,s);"
                 }
             ],
         },

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -25,12 +25,14 @@ const settings = definePluginSettings({
     chatMentions: {
         type: OptionType.BOOLEAN,
         default: true,
-        description: "Show role colors in chat mentions"
+        description: "Show role colors in chat mentions",
+        restartNeeded: true
     },
     memberList: {
         type: OptionType.BOOLEAN,
         default: true,
-        description: "Show role colors in member list role headers"
+        description: "Show role colors in member list role headers",
+        restartNeeded: true
     }
 });
 

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -30,7 +30,7 @@ const settings = definePluginSettings({
     memberList: {
         type: OptionType.BOOLEAN,
         default: true,
-        description: "Show role colors in member list roles"
+        description: "Show role colors in member list role headers"
     }
 });
 

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -47,7 +47,7 @@ export default definePlugin({
             replacement: [
                 {
                     match: /user:(\i),channelId:(\i).{0,300}?"@"\.concat\(.+?\)/,
-                    replace: "$&,color:$self.getUserColor($1, $2)"
+                    replace: "$&,color:$self.getUserColor($1.userId, $2)"
                 }
             ],
             predicate: () => settings.store.chatMentions,
@@ -58,8 +58,8 @@ export default definePlugin({
             find: ".source,children",
             replacement: [
                 {
-                    match: /function .{1,3}\((.)\).{5,20}id.{5,20}guildId.{5,10}channelId.{100,150}hidePersonalInformation.{5,50}jsx.{5,20},{/,
-                    replace: "$&color:$self.getUserColor({id:$1.id},$1.channelId),"
+                    match: /function \i\((\i)\).{5,20}id.{5,20}guildId.{5,10}channelId.{100,150}hidePersonalInformation.{5,50}jsx.{5,20},{/,
+                    replace: "$&color:$self.getUserColor($1.id,$1.channelId),"
                 }
             ],
             predicate: () => settings.store.chatMentions,
@@ -69,7 +69,7 @@ export default definePlugin({
             find: ".memberGroupsPlaceholder",
             replacement: [
                 {
-                    match: /(memo\(\(function\((.)\).{300,500}CHANNEL_MEMBERS_A11Y_LABEL.{100,200}roleIcon.{5,20}null,).," \u2014 ",.\]/,
+                    match: /(memo\(\(function\((\i)\).{300,500}CHANNEL_MEMBERS_A11Y_LABEL.{100,200}roleIcon.{5,20}null,).," \u2014 ",.\]/,
                     replace: "$1$self.roleGroupColor($2)]"
                 },
             ],
@@ -91,7 +91,7 @@ export default definePlugin({
 
         return member?.colorString;
     },
-    getUserColor({ id: userId }, channelId) {
+    getUserColor(userId, channelId) {
         const colorString = this.getColor(userId, channelId);
         return colorString && parseInt(colorString.slice(1), 16);
     },

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -110,7 +110,6 @@ export default definePlugin({
             guildId = channel.guild_id;
         }
 
-        logger.info(guildId);
         const member = GuildMemberStore.getMember(guildId, userId);
         if (!member) {
             return null;

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -114,6 +114,6 @@ export default definePlugin({
             color: role?.colorString,
             fontWeight: "unset",
             letterSpacing: ".05em"
-        }}>{title} ÔÇö {count}</span>;
+        }}>{title} &mdash; {count}</span>;
     }
 });

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -25,7 +25,7 @@ const settings = definePluginSettings({
     chatMentions: {
         type: OptionType.BOOLEAN,
         default: true,
-        description: "Show role colors in chat mentions",
+        description: "Show role colors in chat mentions (including in the message box)",
         restartNeeded: true
     },
     memberList: {
@@ -48,6 +48,18 @@ export default definePlugin({
                 {
                     match: /user:(\i),channelId:(\i).{0,300}?"@"\.concat\(.+?\)/,
                     replace: "$&,color:$self.getUserColor($1, $2)"
+                }
+            ],
+            predicate: () => settings.store.chatMentions,
+        },
+        // Slate
+        {
+            // taken from CommandsAPI
+            find: ".source,children",
+            replacement: [
+                {
+                    match: /function .{1,3}\((.)\).{5,20}id.{5,20}guildId.{5,10}channelId.{100,150}hidePersonalInformation.{5,50}jsx.{5,20},{/,
+                    replace: "$&color:$self.getUserColor({id:$1.id},$1.channelId),"
                 }
             ],
             predicate: () => settings.store.chatMentions,

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -19,7 +19,7 @@
 import { definePluginSettings } from "@api/settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
-import { GuildMemberStore, GuildStore } from "@webpack/common";
+import { ChannelStore, GuildMemberStore, GuildStore } from "@webpack/common";
 
 const settings = definePluginSettings({
     chatMentions: {
@@ -44,7 +44,7 @@ export default definePlugin({
             find: 'className:"mention"',
             replacement: [
                 {
-                    match: /user:(.),channelId:(.).{0,300}?"@".concat\(.+?\)/,
+                    match: /user:(\i),channelId:(\i).{0,300}?"@"\.concat\(.+?\)/,
                     replace: "$&,color:$self.getUserColor($1, $2)"
                 }
             ],
@@ -55,8 +55,8 @@ export default definePlugin({
             find: ".memberGroupsPlaceholder",
             replacement: [
                 {
-                    match: /(function\((.)\).+?roleIcon.{5,20}null,).," \u2014 ",.\]/,
-                    replace: "$1$self.roleGroupColor(e)]"
+                    match: /(memo\(\(function\((.)\).{0,500}CHANNEL_MEMBERS_A11Y_LABEL.+?roleIcon.{5,20}null,).," \u2014 ",.\]/,
+                    replace: "$1$self.roleGroupColor($2)]"
                 },
             ],
             predicate: () => settings.store.memberList,
@@ -65,7 +65,7 @@ export default definePlugin({
     settings,
 
     getColor(userId, channelId) {
-        const channel = Vencord.Webpack.Common.ChannelStore.getChannel(channelId);
+        const channel = ChannelStore.getChannel(channelId);
         if (!channel) {
             return null;
         }

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -27,6 +27,11 @@ const settings = definePluginSettings({
         default: true,
         description: "Show role colors in chat mentions"
     },
+    memberList: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Show role colors in member list roles"
+    }
 });
 
 export default definePlugin({
@@ -43,7 +48,7 @@ export default definePlugin({
                     replace: "$&,color:$self.getUserColor($1, $2)"
                 }
             ],
-            predicate: () => settings.store.chatMentions
+            predicate: () => settings.store.chatMentions,
         },
         // Member List Role Names
         {
@@ -58,6 +63,7 @@ export default definePlugin({
                     replace: "$&$self.testing(e,n,f,h,c,s);"
                 }
             ],
+            predicate: () => settings.store.memberList,
         },
     ],
     settings,

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -16,13 +16,27 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { definePluginSettings } from "@api/settings";
 import { Devs } from "@utils/constants";
 import { getCurrentChannel } from "@utils/discord";
-import definePlugin from "@utils/types";
+import definePlugin, { OptionType } from "@utils/types";
 import { findByProps, findByPropsLazy } from "@webpack";
 import { GuildStore, UserStore } from "@webpack/common";
 
 const MemberStore = findByPropsLazy("getMember");
+
+const settings = definePluginSettings({
+    chatMentions: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Show role colors in chat mentions."
+    },
+    typingIndicator: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Show colors in the typing indicator. Incompatible with TypingTweaks."
+    },
+});
 
 export default definePlugin({
     name: "RoleColorEverywhere",
@@ -38,6 +52,7 @@ export default definePlugin({
                     replace: "$&,color:$self.getUserColor($1, $2)"
                 }
             ],
+            predicate: () => settings.store.chatMentions
         },
         // Typing Users
         {
@@ -48,6 +63,7 @@ export default definePlugin({
                     replace: "$1$3=$self.typingUsers($4,$2,$5);"
                 }
             ],
+            predicate: () => settings.store.typingIndicator
         },
         // Member List Role Names
         {
@@ -64,6 +80,8 @@ export default definePlugin({
             ],
         },
     ],
+    settings,
+
     getColor(userId, channelId) {
         const channel = Vencord.Webpack.Common.ChannelStore.getChannel(channelId);
         if (!channel) {

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -17,9 +17,9 @@
 */
 
 import { Devs } from "@utils/constants";
+import { getCurrentChannel } from "@utils/discord";
 import definePlugin from "@utils/types";
 import { findByProps, findByPropsLazy } from "@webpack";
-import { getCurrentChannel } from "@utils/discord";
 import { GuildStore, UserStore } from "@webpack/common";
 
 const MemberStore = findByPropsLazy("getMember");
@@ -41,7 +41,7 @@ export default definePlugin({
         },
         // Typing Users
         {
-            find: 'Messages.ONE_USER_TYPING',
+            find: "Messages.ONE_USER_TYPING",
             replacement: [
                 {
                     match: /((\w)=\w\.typingUsers.+?)(\w),\w=(\w+?\(\w+?,\d+?\)).+?(\w\.\w\.Messages.SEVERAL_USERS_TYPING);/,
@@ -51,7 +51,7 @@ export default definePlugin({
         },
         // Member List Role Names
         {
-            find: '.memberGroupsPlaceholder',
+            find: ".memberGroupsPlaceholder",
             replacement: [
                 {
                     match: /(function\((.)\).+?roleIcon.{5,20}null,).," ÔÇö ",.\]/,
@@ -75,7 +75,7 @@ export default definePlugin({
             return null;
         }
 
-        return member?.colorString
+        return member?.colorString;
     },
     getUserColor({ id: userId }, channelId) {
         const colorString = this.getColor(userId, channelId);
@@ -85,9 +85,9 @@ export default definePlugin({
         const currentUser = UserStore.getCurrentUser();
 
         const locale = findByProps("getLocale").getLocale();
-        const fmt = new Intl.ListFormat(locale, { style: 'long', type: 'conjunction' })
+        const fmt = new Intl.ListFormat(locale, { style: "long", type: "conjunction" });
 
-        userIds = Object.keys(userIds).filter(m => m != currentUser.id);
+        userIds = Object.keys(userIds).filter(m => m !== currentUser.id);
         const several = userIds.length > 3;
         userIds = fmt.formatToParts(userIds.slice(0, 3));
 
@@ -96,19 +96,19 @@ export default definePlugin({
                 const channel = getCurrentChannel();
                 const member = MemberStore.getMember(channel.guild_id, id);
 
-                return type === 'element' ?
-                    <strong style={{color: member?.colorString}}>
+                return type === "element" ?
+                    <strong style={{ color: member?.colorString }}>
                         {member?.nick || UserStore.getUser(id).username}
                     </strong>
-                : id
-            })} {users.length > 1 ? 'are' : 'is'} typing...
-        </> : SEVERAL_USERS_TYPING)
+                    : id;
+            })} {users.length > 1 ? "are" : "is"} typing...
+        </> : SEVERAL_USERS_TYPING);
 
         return stuff;
     },
     roleGroupColor({ id, count, title, guildId, ...args }) {
         const guild = GuildStore.getGuild(guildId);
-        const role = guild?.roles[id]
+        const role = guild?.roles[id];
 
         return <span style={{
             color: role?.colorString,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -196,5 +196,9 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     whqwert: {
         name: "whqwert",
         id: 586239091520176128n
+    },
+    lewisakura: {
+        name: "lewisakura",
+        id: 96269247411400704n
     }
 });


### PR DESCRIPTION
supersedes #273

colors chat mentions (including in slate), member list role titles, and voice users. typing colors are handled by TypingTweaks so it's not included here to prevent duplicate functionality.

