### PR TITLE
typings for defaultless settings

### DIFF
--- a/src/plugins/customRPC.tsx
+++ b/src/plugins/customRPC.tsx
@@ -19,6 +19,7 @@
 import { definePluginSettings } from "@api/settings";
 import { Link } from "@components/Link";
 import { Devs } from "@utils/constants";
+import { isTruthy } from "@utils/guards";
 import { useAwaiter } from "@utils/misc";
 import definePlugin, { OptionType } from "@utils/types";
 import { filters, findByCodeLazy, findByPropsLazy, mapMangledModuleLazy } from "@webpack";
@@ -173,13 +174,13 @@ async function createActivity(): Promise<Activity | undefined> {
         activity.buttons = [
             buttonOneText,
             buttonTwoText
-        ].filter((s): s is string => !!s);
+        ].filter(isTruthy);
 
         activity.metadata = {
             button_urls: [
                 buttonOneURL,
                 buttonTwoURL
-            ].filter((s): s is string => !!s)
+            ].filter(isTruthy)
         };
     }
 
@@ -206,8 +207,6 @@ async function createActivity(): Promise<Activity | undefined> {
             delete activity[k];
     }
 
-    // WHAT DO YOU WANT FROM ME
-    // eslint-disable-next-line consistent-return
     return activity;
 }
 

--- a/src/plugins/customRPC.tsx
+++ b/src/plugins/customRPC.tsx
@@ -56,7 +56,7 @@ interface ActivityAssets {
 }
 
 interface Activity {
-    state: string;
+    state?: string;
     details?: string;
     timestamps?: {
         start?: Number;
@@ -93,13 +93,13 @@ const numOpt = (description: string) => ({
     onChange: setRpc
 }) as const;
 
-const choice = (label: string, value: any, _default?: Boolean) => ({
+const choice = (label: string, value: any, _default?: boolean) => ({
     label,
     value,
     default: _default
 }) as const;
 
-const choiceOpt = (description: string, options) => ({
+const choiceOpt = <T,>(description: string, options: T) => ({
     type: OptionType.SELECT,
     description,
     onChange: setRpc,
@@ -173,13 +173,13 @@ async function createActivity(): Promise<Activity | undefined> {
         activity.buttons = [
             buttonOneText,
             buttonTwoText
-        ].filter(Boolean);
+        ].filter((s): s is string => !!s);
 
         activity.metadata = {
             button_urls: [
                 buttonOneURL,
                 buttonTwoURL
-            ].filter(Boolean)
+            ].filter((s): s is string => !!s)
         };
     }
 

--- a/src/plugins/customRPC.tsx
+++ b/src/plugins/customRPC.tsx
@@ -59,8 +59,8 @@ interface Activity {
     state?: string;
     details?: string;
     timestamps?: {
-        start?: Number;
-        end?: Number;
+        start?: number;
+        end?: number;
     };
     assets?: ActivityAssets;
     buttons?: Array<string>;
@@ -70,7 +70,7 @@ interface Activity {
         button_urls?: Array<string>;
     };
     type: ActivityType;
-    flags: Number;
+    flags: number;
 }
 
 enum ActivityType {
@@ -211,7 +211,7 @@ async function createActivity(): Promise<Activity | undefined> {
     return activity;
 }
 
-async function setRpc(disable?: Boolean) {
+async function setRpc(disable?: boolean) {
     const activity: Activity | undefined = await createActivity();
 
     FluxDispatcher.dispatch({

--- a/src/plugins/lastfm.tsx
+++ b/src/plugins/lastfm.tsx
@@ -34,7 +34,7 @@ interface Activity {
     state: string;
     details?: string;
     timestamps?: {
-        start?: Number;
+        start?: number;
     };
     assets?: ActivityAssets;
     buttons?: Array<string>;
@@ -43,8 +43,8 @@ interface Activity {
     metadata?: {
         button_urls?: Array<string>;
     };
-    type: Number;
-    flags: Number;
+    type: number;
+    flags: number;
 }
 
 interface TrackData {

--- a/src/utils/guards.ts
+++ b/src/utils/guards.ts
@@ -1,0 +1,25 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export function isTruthy<T>(item: T): item is Exclude<T, 0 | "" | false | null | undefined> {
+    return Boolean(item);
+}
+
+export function isNonNullish<T>(item: T): item is Exclude<T, null | undefined> {
+    return item != null;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -229,9 +229,12 @@ type PluginSettingType<O extends PluginSettingDef> = O extends PluginSettingStri
     O extends PluginSettingSliderDef ? number :
     O extends PluginSettingComponentDef ? any :
     never;
+type PluginSettingDefaultType<O extends PluginSettingDef> = O extends PluginSettingSelectDef ? (
+    O["options"] extends { default?: boolean; }[] ? O["options"][number]["value"] : undefined
+) : O extends { default: infer T; } ? T : undefined;
 
 type SettingsStore<D extends SettingsDefinition> = {
-    [K in keyof D]: PluginSettingType<D[K]>;
+    [K in keyof D]: PluginSettingType<D[K]> | PluginSettingDefaultType<D[K]>;
 };
 
 /** An instance of defined plugin settings */


### PR DESCRIPTION
this adds real typings for settings definitions that dont have a `default` field:
- `COMPONENT` types are still always `any`
- `SELECT` types are `T | undefined` if there are no `{ default: boolean }` elements
- everything else is `T | undefined` if there is no default field
