### PR TITLE
fix: vcDoubleClick and revealAllSpoilers patch

### DIFF
--- a/src/plugins/revealAllSpoilers.ts
+++ b/src/plugins/revealAllSpoilers.ts
@@ -30,10 +30,10 @@ export default definePlugin({
 
     patches: [
         {
-            find: ".revealSpoiler=function",
+            find: ".removeObscurity=function",
             replacement: {
-                match: /\.revealSpoiler=function\((.{1,2})\){/,
-                replace: ".revealSpoiler=function($1){$self.reveal($1);"
+                match: /\.removeObscurity=function\((\i)\){/,
+                replace: ".removeObscurity=function($1){$self.reveal($1);"
             }
         }
     ],

--- a/src/plugins/vcDoubleClick.ts
+++ b/src/plugins/vcDoubleClick.ts
@@ -50,8 +50,8 @@ export default definePlugin({
             // channel mentions
             find: ".shouldCloseDefaultModals",
             replacement: {
-                match: /onClick:(\w+),/,
-                replace: "onClick:(_vcEv)=>(_vcEv.detail>=2)&&($1)(_vcEv),"
+                match: /onClick:(\w+),(.{0,30}className:"channelMention",)/,
+                replace: "onClick:(_vcEv)=>(_vcEv.detail>=2)&&($1)(_vcEv),$2"
             }
         }
     ],

--- a/src/plugins/vcDoubleClick.ts
+++ b/src/plugins/vcDoubleClick.ts
@@ -48,10 +48,10 @@ export default definePlugin({
         },
         {
             // channel mentions
-            find: ".EMOJI_IN_MESSAGE_HOVER",
+            find: ".shouldCloseDefaultModals",
             replacement: {
-                match: /onClick:(\i)(?=,.{0,30}className:"channelMention")/,
-                replace: "onClick:(_vcEv)=>(_vcEv.detail>=2||_vcEv.target.className.includes('MentionText'))&&($1)()",
+                match: /onClick:(\w+),/,
+                replace: "onClick:(_vcEv)=>(_vcEv.detail>=2)&&($1)(_vcEv),"
             }
         }
     ],

--- a/src/plugins/vcDoubleClick.ts
+++ b/src/plugins/vcDoubleClick.ts
@@ -50,8 +50,8 @@ export default definePlugin({
             // channel mentions
             find: ".shouldCloseDefaultModals",
             replacement: {
-                match: /onClick:(\w+),(.{0,30}className:"channelMention",)/,
-                replace: "onClick:(_vcEv)=>(_vcEv.detail>=2)&&($1)(_vcEv),$2"
+                match: /onClick:(\i)(?=,.{0,30}className:"channelMention")/,
+                replace: "onClick:(_vcEv)=>(_vcEv.detail>=2||_vcEv.target.className.includes('MentionText'))&&($1)()",
             }
         }
     ],


### PR DESCRIPTION
~~Currently, that's the only `onClick` in that module. I could add back the `className: "channelMention"` check if so desired.~~
See second commit