### PR TITLE
feat(plugin): PreserveToken

### DIFF
--- a/src/plugins/preserveToken.ts
+++ b/src/plugins/preserveToken.ts
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "PreserveToken",
+    authors: [Devs.Marvin],
+    description: "Stops Discord from hiding your token when you open the devtools",
+
+    patches: [
+        {
+            find: "hideToken:function",
+            replacement: {
+                match: /hideToken:function\(\){/,
+                replace: "$&return;"
+            }
+        }
+    ],
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -205,5 +205,9 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     cloudburst: {
         name: "cloudburst",
         id: 892128204150685769n
+    },
+    Marvin: {
+        name: "Marvin",
+        id: 562415519454461962n
     }
 });


### PR DESCRIPTION
Discord hides your user token in the local storage of an iframe, whenever you open the devtools. This is mostly meant to help prevent token grabbing through social engineering but has the side effect that you sometimes get logged out of Discord when Discord gets closed whilst you still have your dev tools open. This plugin basically just early-returns the `hideToken` function that usually takes care of the hiding. 