### PR TITLE
chore: extend description of NoDevtoolsWarning plugin

### DIFF
--- a/src/plugins/noDevtoolsWarning.ts
+++ b/src/plugins/noDevtoolsWarning.ts
@@ -24,7 +24,7 @@ migratePluginSettings("NoDevtoolsWarning", "STFU");
 
 export default definePlugin({
     name: "NoDevtoolsWarning",
-    description: "Disables the 'HOLD UP' banner in the console",
+    description: "Disables the 'HOLD UP' banner in the console. As a side effect, also prevents Discord from hiding your token, which prevents random logouts.",
     authors: [Devs.Ven],
     patches: [{
         find: "setDevtoolsCallbacks",


### PR DESCRIPTION
Extends the description of the NoDevtoolsWarning plugin to also document a side effect