### PR TITLE
feat(plugins): add FixInbox plugin

### DIFF
--- a/src/plugins/FixInbox.tsx
+++ b/src/plugins/FixInbox.tsx
@@ -30,8 +30,8 @@ export default definePlugin({
         replacement: {
             // This function normally dispatches a subscribe event to every guild.
             // this is badbadbadbadbad so we just get rid of it.
-            match: /INBOX_OPEN:function.+?return!1},/,
-            replace: "INBOX_OPEN:function(){return true;},"
+            match: /INBOX_OPEN:function.+?\{/,
+            replace: "$&return true;"
         }
     }],
 

--- a/src/plugins/FixInbox.tsx
+++ b/src/plugins/FixInbox.tsx
@@ -1,0 +1,54 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { Forms } from "@webpack/common";
+
+export default definePlugin({
+    name: "FixInbox",
+    description: "Fixes the Unreads Inbox from crashing Discord when you're in lots of guilds.",
+    authors: [Devs.Megu],
+
+    patches: [{
+        find: "INBOX_OPEN:function",
+        replacement: {
+            // This function normally dispatches a subscribe event to every guild.
+            // this is badbadbadbadbad so we just get rid of it.
+            match: /INBOX_OPEN:function.+?return!1},/,
+            replace: "INBOX_OPEN:function(){return true;},"
+        }
+    }],
+
+    settingsAboutComponent() {
+        return <Forms.FormSection>
+            <Forms.FormTitle tag="h3">What's the problem?</Forms.FormTitle>
+            <Forms.FormText style={{ marginBottom: 8 }}>
+                By default, Discord emits a GUILD_SUBSCRIPTIONS event for every guild you're in.
+                When you're in a lot of guilds, this can cause the gateway to ratelimit you.
+                This causes the client to crash and get stuck in an infinite ratelimit loop as it tries to reconnect.
+            </Forms.FormText>
+
+            <Forms.FormTitle tag="h3">How does it work?</Forms.FormTitle>
+            <Forms.FormText>
+                This plugin works by stopping the client from sending GUILD_SUBSCRIPTIONS events to the gateway when you open the unreads inbox.
+                This means that not all unreads will be shown, instead only already-subscribed guilds' unreads will be shown, but your client won't crash anymore.
+            </Forms.FormText>
+        </Forms.FormSection>;
+    }
+});

--- a/src/plugins/FixInbox.tsx
+++ b/src/plugins/FixInbox.tsx
@@ -36,19 +36,21 @@ export default definePlugin({
     }],
 
     settingsAboutComponent() {
-        return <Forms.FormSection>
-            <Forms.FormTitle tag="h3">What's the problem?</Forms.FormTitle>
-            <Forms.FormText style={{ marginBottom: 8 }}>
-                By default, Discord emits a GUILD_SUBSCRIPTIONS event for every guild you're in.
-                When you're in a lot of guilds, this can cause the gateway to ratelimit you.
-                This causes the client to crash and get stuck in an infinite ratelimit loop as it tries to reconnect.
-            </Forms.FormText>
+        return (
+            <Forms.FormSection>
+                <Forms.FormTitle tag="h3">What's the problem?</Forms.FormTitle>
+                <Forms.FormText style={{ marginBottom: 8 }}>
+                    By default, Discord emits a GUILD_SUBSCRIPTIONS event for every guild you're in.
+                    When you're in a lot of guilds, this can cause the gateway to ratelimit you.
+                    This causes the client to crash and get stuck in an infinite ratelimit loop as it tries to reconnect.
+                </Forms.FormText>
 
-            <Forms.FormTitle tag="h3">How does it work?</Forms.FormTitle>
-            <Forms.FormText>
-                This plugin works by stopping the client from sending GUILD_SUBSCRIPTIONS events to the gateway when you open the unreads inbox.
-                This means that not all unreads will be shown, instead only already-subscribed guilds' unreads will be shown, but your client won't crash anymore.
-            </Forms.FormText>
-        </Forms.FormSection>;
+                <Forms.FormTitle tag="h3">How does it work?</Forms.FormTitle>
+                <Forms.FormText>
+                    This plugin works by stopping the client from sending GUILD_SUBSCRIPTIONS events to the gateway when you open the unreads inbox.
+                    This means that not all unreads will be shown, instead only already-subscribed guilds' unreads will be shown, but your client won't crash anymore.
+                </Forms.FormText>
+            </Forms.FormSection>
+        );
     }
 });


### PR DESCRIPTION
By default, when you open the Unread tab in the Inbox, discord spams a ton of GUILD_SUBSCRIPTIONS events to the gateway. If you're in a lot of servers, this can cause the gateway client to get ratelimited, leaving your client in an unfortunate crash-loop as the gateway attempts to reconnect but just gets ratelimited every time, until you CTRL+R or restart the client.

This plugin stops the client from emitting GUILD_SUBSCRIPTIONS events when you open the Unreads tab. This solves the crashes, but means only already-subscribed guilds will be shown. It seems that high-affinity guilds are already subscribed most of the time, so this doesn't really affect UX much. I think it's a good tradeoff compared to crashing your client :trollface:

![image](https://user-images.githubusercontent.com/27697325/222332171-f7e82734-043a-4f53-a770-a17c6def2b64.png)
