### PR TITLE
feat(plugin): FxAll to fix Instagram, Reddit, Twitter and TikTok links!

### DIFF
--- a/src/plugins/fxAll.ts
+++ b/src/plugins/fxAll.ts
@@ -1,0 +1,66 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { addPreSendListener, MessageObject, removePreSendListener } from "@api/MessageEvents";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+const regexList = [
+    {
+        test: /https?:\/\/twitter\.com(?=\/\w+?\/status\/)/g,
+        replace: "https://fxtwitter.com"
+    },
+    {
+        test: /https?:\/\/(?:www|vm)\.tiktok\.com/g,
+        replace: "https://vm.tiktxk.com"
+    },
+    {
+        test: /https?:\/\/(?:www\.)?instagram\.com(?=\/p\/)/g,
+        replace: "https://ddinstagram.com"
+    },
+    {
+        test: /https?:\/\/(?:www\.)?reddit\.com(?=\/r\/\w+?\/comments\/)/g,
+        replace: "https://rxyddit.com"
+    }
+];
+
+
+export default definePlugin({
+    name: "FxAll",
+    description: "Replaces Instagram, TikTok, Reddit and Twitter links to proxy websites (e.g. fxtwitter, ddinstagram) to display better embeds.",
+    authors: [Devs.eggsy],
+    dependencies: ["MessageEventsAPI"],
+
+    addPrefix(msg: MessageObject) {
+        let newString = msg.content;
+
+        for (const item of regexList) {
+            newString = newString.replace(item.test, item.replace);
+        }
+
+        msg.content = newString;
+    },
+
+    start() {
+        this.preSend = addPreSendListener((_, msg) => this.addPrefix(msg));
+    },
+
+    stop() {
+        removePreSendListener(this.preSend);
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -205,5 +205,9 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     cloudburst: {
         name: "cloudburst",
         id: 892128204150685769n
+    },
+    eggsy: {
+        name: "EGGSY",
+        id: 162969778699501569n
     }
 });


### PR DESCRIPTION
This is a plugin inspired from the existing [`FxTwitter`](https://github.com/Vendicated/Vencord/blob/main/src/plugins/fxTwitter.ts) plugin by @somerandomcloud and @CanCodes' [`LinkFixer`](https://github.com/CanCodes/LinkFixer) bot. It replaces the following services with proxy services:

- [x] Twitter: `fxtwitter.com`
- [x] Reddit: `rxyddit.com`
- [x] Instagram: `ddinstagram.com`
- [x] TikTok: `tiktxk.com`

so you get better Discord embeds, check out the GIF to see it working 🔥 

![fxall-vencord](https://user-images.githubusercontent.com/13917975/222710449-8796d081-90b3-4ac5-83b9-f70d8691fee7.gif)
