### PR TITLE
Add support for DevBuild extensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
             - name: Clean up obsolete files
               run: |
-                rm -rf dist/extension* Vencord.user.css
+                rm -rf dist/extension-unpacked* Vencord.user.css
 
             - name: Get some values needed for the release
               id: release_values

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -6,6 +6,7 @@
     "description": "The cutest Discord mod now in your browser",
     "author": "Vendicated",
     "homepage_url": "https://github.com/Vendicated/Vencord",
+    "update_url": "https://vencord.github.io/builds/manifest.json",
     "icons": {
         "128": "icon.png"
     },


### PR DESCRIPTION
Needs `manifest.json` to be pushed to the builds repo and for the builds repo to have GH Pages enabled. Will it work? idk build environments scare me

~~please feel free to push to fix what ive inevitably missed~~
~~i wont delete it this time~~