### PR TITLE
messageLogger deleted attachment hover transition now smoother

### DIFF
--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -4,11 +4,11 @@
 
 .messagelogger-deleted-attachment {
     filter: grayscale(1);
+    transition: 150ms filter ease-in-out;
 }
 
 .messagelogger-deleted-attachment:hover {
     filter: grayscale(0);
-    transition: 250ms filter linear;
 }
 
 .theme-dark .messagelogger-edited {


### PR DESCRIPTION
Moved the transition from :hover to the actual class, 
because if you moved your mouse off the attachment the transition would be instant.
Additionally did it a 150ms ease-in-out, because it looks smoother than linear.
