### PR TITLE
fix: settings input validation and error handling

### DIFF
--- a/src/components/PluginSettings/components/SettingNumericComponent.tsx
+++ b/src/components/PluginSettings/components/SettingNumericComponent.tsx
@@ -38,9 +38,12 @@ export function SettingNumericComponent({ option, pluginSettings, definedSetting
 
     function handleChange(newValue) {
         const isValid = option.isValid?.call(definedSettings, newValue) ?? true;
+
+        setError(null);
         if (typeof isValid === "string") setError(isValid);
         else if (!isValid) setError("Invalid input provided.");
-        else if (option.type === OptionType.NUMBER && BigInt(newValue) >= MAX_SAFE_NUMBER) {
+
+        if (option.type === OptionType.NUMBER && BigInt(newValue) >= MAX_SAFE_NUMBER) {
             setState(`${Number.MAX_SAFE_INTEGER}`);
             onChange(serialize(newValue));
         } else {

--- a/src/components/PluginSettings/components/SettingSelectComponent.tsx
+++ b/src/components/PluginSettings/components/SettingSelectComponent.tsx
@@ -36,6 +36,7 @@ export function SettingSelectComponent({ option, pluginSettings, definedSettings
         if (typeof isValid === "string") setError(isValid);
         else if (!isValid) setError("Invalid input provided.");
         else {
+            setError(null);
             setState(newValue);
             onChange(newValue);
         }

--- a/src/components/PluginSettings/components/SettingTextComponent.tsx
+++ b/src/components/PluginSettings/components/SettingTextComponent.tsx
@@ -34,6 +34,7 @@ export function SettingTextComponent({ option, pluginSettings, definedSettings, 
         if (typeof isValid === "string") setError(isValid);
         else if (!isValid) setError("Invalid input provided.");
         else {
+            setError(null);
             setState(newValue);
             onChange(newValue);
         }


### PR DESCRIPTION
This PR fixes setting component input validation and error handling.

When input validation marks an input as an error in numeric, select and text settings fields, the error state is never cleared and so the settings modal can no longer be saved.

When a numeric settings field is invalid, the previous behavior of throwing away the invalid input makes editing the field awkward and unpleasant.  This PR improves that by allowing invalid values to be set but the form cannot be saved until the error is corrected.