### PR TITLE
fix messagelogger deleted styles

### DIFF
--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -2,7 +2,7 @@
     color: #f04747;
 }
 
-.messagelogger-deleted div a {
+.messagelogger-deleted a {
     color: #be3535;
     text-decoration: underline;
 }

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,3 +1,8 @@
 .messagelogger-deleted div {
     color: #f04747;
 }
+
+.messagelogger-deleted div a {
+    color: #be3535;
+    text-decoration: underline;
+}

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -2,12 +2,12 @@
     display: none;
 }
 
-.messagelogger-deleted-attachment {
+.messagelogger-deleted-attachment, .messagelogger-deleted div iframe {
     filter: grayscale(1);
     transition: 150ms filter ease-in-out;
 }
 
-.messagelogger-deleted-attachment:hover {
+.messagelogger-deleted-attachment:hover, .messagelogger-deleted div iframe:hover {
     filter: grayscale(0);
 }
 

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -2,12 +2,14 @@
     display: none;
 }
 
-.messagelogger-deleted-attachment, .messagelogger-deleted div iframe {
+.messagelogger-deleted-attachment,
+.messagelogger-deleted div iframe {
     filter: grayscale(1);
     transition: 150ms filter ease-in-out;
 }
 
-.messagelogger-deleted-attachment:hover, .messagelogger-deleted div iframe:hover {
+.messagelogger-deleted-attachment:hover,
+.messagelogger-deleted div iframe:hover {
     filter: grayscale(0);
 }
 


### PR DESCRIPTION
hello! little pr that adds more styles to elements inside deleted messages:
- shows links in darker red (with underline to see they're links), instead of plain blue
- applies grayscale filter to iframes too (for example, spotify embeds)