### PR TITLE
fix(RoleColorEverywhere): MessageLinkEmbeds DM error

### DIFF
--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -96,7 +96,6 @@ export default definePlugin({
     settings,
 
     getColor(userId: string, { channelId, guildId }: { channelId?: string; guildId?: string; }) {
-        if (!guildId && !channelId) return null;
         if (!(guildId ??= ChannelStore.getChannel(channelId!)?.guild_id)) return null;
         return GuildMemberStore.getMember(guildId, userId)?.colorString ?? null;
     },

--- a/src/plugins/roleColorEverywhere.tsx
+++ b/src/plugins/roleColorEverywhere.tsx
@@ -53,7 +53,7 @@ export default definePlugin({
             replacement: [
                 {
                     match: /user:(\i),channel:(\i).{0,300}?"@"\.concat\(.+?\)/,
-                    replace: "$&,color:$self.getUserColor($1.id,{channelId:$2.id})"
+                    replace: "$&,color:$self.getUserColor($1.id,{channelId:$2?.id})"
                 }
             ],
             predicate: () => settings.store.chatMentions,
@@ -65,7 +65,7 @@ export default definePlugin({
             replacement: [
                 {
                     match: /function \i\((\i)\).{5,20}id.{5,20}guildId.{5,10}channelId.{100,150}hidePersonalInformation.{5,50}jsx.{5,20},{/,
-                    replace: "$&color:$self.getUserColor($1.id,{guildId:$1.guildId}),"
+                    replace: "$&color:$self.getUserColor($1.id,{guildId:$1?.guildId}),"
                 }
             ],
             predicate: () => settings.store.chatMentions,
@@ -96,6 +96,7 @@ export default definePlugin({
     settings,
 
     getColor(userId: string, { channelId, guildId }: { channelId?: string; guildId?: string; }) {
+        if (!guildId && !channelId) return null;
         if (!(guildId ??= ChannelStore.getChannel(channelId!)?.guild_id)) return null;
         return GuildMemberStore.getMember(guildId, userId)?.colorString ?? null;
     },


### PR DESCRIPTION
Adds null checks for both channel and guild ID, and short circuits both of them being undefined when getting a color.

Fixes #646.