### PR TITLE
fix: Check if custom theme link ends in `.css`

### DIFF
--- a/src/components/VencordSettings/ThemesTab.tsx
+++ b/src/components/VencordSettings/ThemesTab.tsx
@@ -30,9 +30,8 @@ function Validator({ link }: { link: string; }) {
     const [res, err, pending] = useAwaiter(() => fetch(link).then(res => {
         if (res.status > 300) throw `${res.status} ${res.statusText}`;
         const contentType = res.headers.get("Content-Type");
-        if (!contentType?.startsWith("text/css") && !contentType?.startsWith("text/plain"))
+        if (!contentType?.startsWith("text/css") && !link.endsWith(".css"))
             throw "Not a CSS file. Remember to use the raw link!";
-
         return "Okay!";
     }));
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66404074/227424278-a9695aae-8e6f-4ec9-b314-d9a88f7b9530.png)

Better safe then sorry I guess lol