### PR TITLE
fix: API plugins being force enabled

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -43,8 +43,8 @@ export function isPluginEnabled(p: string) {
 
 const pluginsValues = Object.values(Plugins);
 
-// First roundtrip to mark and force enable dependencies
-for (const p of pluginsValues) {
+// First roundtrip to mark and force enable dependencies (only for enabled plugins)
+for (const p of pluginsValues) if (settings[p.name]?.enabled) {
     p.dependencies?.forEach(d => {
         const dep = Plugins[d];
         if (dep) {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -44,6 +44,9 @@ export function isPluginEnabled(p: string) {
 const pluginsValues = Object.values(Plugins);
 
 // First roundtrip to mark and force enable dependencies (only for enabled plugins)
+//
+// FIXME: might need to revisit this if there's ever nested (dependencies of dependencies) dependencies since this only
+// goes for the top level and their children, but for now this works okay with the current API plugins
 for (const p of pluginsValues) if (settings[p.name]?.enabled) {
     p.dependencies?.forEach(d => {
         const dep = Plugins[d];


### PR DESCRIPTION
Adds an extra check into the plugin loader to fix a logic error where API plugins were force enabled even if their dependents weren't.