### PR TITLE
fix: no more theme box obliteration

### DIFF
--- a/src/components/VencordSettings/ThemesTab.tsx
+++ b/src/components/VencordSettings/ThemesTab.tsx
@@ -116,13 +116,9 @@ export default ErrorBoundary.wrap(function () {
             </Card>
             <Forms.FormTitle tag="h5">Themes</Forms.FormTitle>
             <TextArea
-                style={{
-                    padding: ".5em",
-                    border: "1px solid var(--background-modifier-accent)"
-                }}
                 value={themeText}
                 onChange={e => setThemeText(e.currentTarget.value)}
-                className={TextAreaProps.textarea}
+                className={`${TextAreaProps.textarea} vc-settings-theme-links`}
                 placeholder="Theme Links"
                 spellCheck={false}
                 onBlur={onBlur}

--- a/src/components/VencordSettings/settingsStyles.css
+++ b/src/components/VencordSettings/settingsStyles.css
@@ -38,3 +38,11 @@
     color: var(--info-warning-text);
     margin-top: 0;
 }
+
+/* Needed to fix bad themes that hide certain textarea elements for whatever eldritch reason */
+.vc-settings-theme-links {
+    display: inline-block !important;
+    color: var(--text-normal) !important;
+    padding: 0.5em;
+    border: 1px solid var(--background-modifier-accent);
+}

--- a/src/components/VencordSettings/settingsStyles.css
+++ b/src/components/VencordSettings/settingsStyles.css
@@ -39,8 +39,8 @@
     margin-top: 0;
 }
 
-/* Needed to fix bad themes that hide certain textarea elements for whatever eldritch reason */
 .vc-settings-theme-links {
+    /* Needed to fix bad themes that hide certain textarea elements for whatever eldritch reason */
     display: inline-block !important;
     color: var(--text-normal) !important;
     padding: 0.5em;


### PR DESCRIPTION
Primarily fixes bad themes like Spoticord sending the theme links box to the Naughty Corner:tm: and also moves the inline styles to a dedicated class.