### PR TITLE
fix(plugins): update sentry patch

### DIFF
--- a/src/plugins/noTrack.ts
+++ b/src/plugins/noTrack.ts
@@ -35,7 +35,7 @@ export default definePlugin({
         {
             find: "window.DiscordSentry=",
             replacement: {
-                match: /window\.DiscordSentry=function.+\}\(\)/,
+                match: /window\.DiscordSentry=\([^)]+\)\(\)/,
                 replace: "",
             }
         },


### PR DESCRIPTION
![fear](https://cdn.discordapp.com/emojis/1033854064758362252.png)
this is a good example of when AST patching would be useful, also maybe a plugin option to disable the enforcing of concurrent patches 