### PR TITLE
refactor: in plugins that use querySelector(All), use getElementsByClassName instead

### DIFF
--- a/src/plugins/betterFolders/FolderSideBar.tsx
+++ b/src/plugins/betterFolders/FolderSideBar.tsx
@@ -49,7 +49,7 @@ export default ErrorBoundary.wrap(() => {
     const expandedFolders = useStateFromStores([ExpandedGuildFolderStore], () => ExpandedGuildFolderStore.getExpandedFolders());
     const fullscreen = useStateFromStores([ChannelRTCStore], () => ChannelRTCStore.isFullscreenInContext());
 
-    const guilds = document.querySelector(`.${classes.guilds}`);
+    const guilds = document.getElementsByClassName(classes.guilds)[0];
 
     const visible = !!expandedFolders.size;
     const className = cl("folder-sidebar", { fullscreen });

--- a/src/plugins/revealAllSpoilers.ts
+++ b/src/plugins/revealAllSpoilers.ts
@@ -47,10 +47,10 @@ export default definePlugin({
         const { messagesWrapper } = MessagesClasses;
 
         const parent = shiftKey
-            ? document.querySelector(`div.${messagesWrapper}`)
+            ? document.getElementsByClassName(messagesWrapper)[0]
             : (target as HTMLSpanElement).parentElement;
 
-        for (const spoiler of parent!.querySelectorAll(`span.${spoilerText}.${hidden}`)) {
+        for (const spoiler of parent!.getElementsByClassName(`${spoilerText} ${hidden}`)) {
             (spoiler as HTMLSpanElement).click();
         }
     }


### PR DESCRIPTION
use getElementsByClassName instead of querySelector(All) because (in current plugins) elements are only selected by class name
\+ it's very<sup>very</sup> slightly faster