### PR TITLE
ImageZoom: Fix not being able to close carousels on sides

### DIFF
--- a/src/plugins/imageZoom/styles.css
+++ b/src/plugins/imageZoom/styles.css
@@ -30,7 +30,7 @@
     transform: translateY(-50%);
 }
 
-[class^="focusLock"] > [class^="carouselModal"] > [class*="modalCarouselWrapper"] > [class^="wrapper"] {
+#magnify-modal {
     position: absolute;
     left: 50%;
     top: 50%;

--- a/src/plugins/imageZoom/styles.css
+++ b/src/plugins/imageZoom/styles.css
@@ -29,3 +29,10 @@
     top: 50%;
     transform: translateY(-50%);
 }
+
+[class^="focusLock"] > [class^="carouselModal"] > [class*="modalCarouselWrapper"] > [class^="wrapper"] {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
man naming things is hard.


basically allows you to close the image when you click the backdrop. before you could only do that if you click top or bottom parts of the backdrop but now you can click any part of the backdrop and it will close it
it fixes this:
https://discord.com/channels/1015060230222131221/1015063227299811479/1094745672944726107

thanks aaaz#0001