### PR TITLE
CloudSync: fix accidently applying stale settings (#915

### DIFF
--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -27,14 +27,13 @@ export { PlainSettings, Settings };
 import "./utils/quickCss";
 import "./webpack/patchWebpack";
 
-import { relaunch } from "@utils/native";
-
 import { showNotification } from "./api/Notifications";
 import { PlainSettings, Settings } from "./api/settings";
 import { patches, PMLogger, startAllPlugins } from "./plugins";
 import { localStorage } from "./utils/localStorage";
+import { relaunch } from "./utils/native";
 import { getCloudSettings, putCloudSettings } from "./utils/settingsSync";
-import { checkForUpdates, rebuild, update,UpdateLogger } from "./utils/updater";
+import { checkForUpdates, rebuild, update, UpdateLogger } from "./utils/updater";
 import { onceReady } from "./webpack";
 import { SettingsRouter } from "./webpack/common";
 
@@ -57,7 +56,7 @@ async function syncSettings() {
                 title: "Cloud Settings",
                 body: "Your settings have been updated! Click here to restart to fully apply changes!",
                 color: "var(--green-360)",
-                onClick: () => window.DiscordNative.app.relaunch()
+                onClick: () => relaunch()
             });
         }
     }

--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -56,7 +56,7 @@ async function syncSettings() {
                 title: "Cloud Settings",
                 body: "Your settings have been updated! Click here to restart to fully apply changes!",
                 color: "var(--green-360)",
-                onClick: () => relaunch()
+                onClick: relaunch
             });
         }
     }


### PR DESCRIPTION
Fixes a bug where settings didn't actually import (QuickCSS worked fine) since we were overwriting the settings object after importing.