### PR TITLE
Improve FakeNitro emoji popup message

### DIFF
--- a/src/plugins/fakeNitro.tsx
+++ b/src/plugins/fakeNitro.tsx
@@ -534,7 +534,7 @@ export default definePlugin({
 
         switch (type) {
             case "STICKER": {
-                node.push(" Fake Nitro emoji renders like a real emoji only for you, appears as a link to non-plugin users.");
+                node.push(" Fake Nitro sticker renders like a real sticker only for you, appears as a link to non-plugin users.");
 
                 return node;
             }

--- a/src/plugins/fakeNitro.tsx
+++ b/src/plugins/fakeNitro.tsx
@@ -534,12 +534,12 @@ export default definePlugin({
 
         switch (type) {
             case "STICKER": {
-                node.push(" Fake Nitro emoji renders like real only for you, appears as a link to non-plugin users.");
+                node.push(" Fake Nitro emoji renders like a real emoji only for you, appears as a link to non-plugin users.");
 
                 return node;
             }
             case "EMOJI": {
-                node.push(" Fake Nitro emoji renders like real only for you, appears as a link to non-plugin users.");
+                node.push(" Fake Nitro emoji renders like a real emoji only for you, appears as a link to non-plugin users.");
 
                 return node;
             }

--- a/src/plugins/fakeNitro.tsx
+++ b/src/plugins/fakeNitro.tsx
@@ -534,12 +534,12 @@ export default definePlugin({
 
         switch (type) {
             case "STICKER": {
-                node.push(" This is a Fake Nitro sticker. Only you can see it rendered like a real one, for non Vencord users it will show as a link.");
+                node.push(" Fake Nitro emoji renders like real only for you, appears as a link to non-plugin users.");
 
                 return node;
             }
             case "EMOJI": {
-                node.push(" This is a Fake Nitro emoji. Only you can see it rendered like a real one, for non Vencord users it will show as a link.");
+                node.push(" Fake Nitro emoji renders like real only for you, appears as a link to non-plugin users.");
 
                 return node;
             }

--- a/src/plugins/fakeNitro.tsx
+++ b/src/plugins/fakeNitro.tsx
@@ -534,12 +534,12 @@ export default definePlugin({
 
         switch (type) {
             case "STICKER": {
-                node.push(" Fake Nitro sticker renders like a real sticker only for you, appears as a link to non-plugin users.");
+                node.push(" This is a FakeNitro sticker and renders like a real sticker only for you. Appears as a link to non-plugin users.");
 
                 return node;
             }
             case "EMOJI": {
-                node.push(" Fake Nitro emoji renders like a real emoji only for you, appears as a link to non-plugin users.");
+                node.push(" This is a FakeNitro emoji and renders like a real emoji only for you. Appears as a link to non-plugin users.");
 
                 return node;
             }


### PR DESCRIPTION
Changed the message that'll pop up when clicking on a fake emoji, to be shorter, to make the popup smaller. I also changed it so it doesn't sound like it will only look like actual emojis for Vencord users, instead of anyone any modded Discord using similar plugins.