### PR TITLE
Plugin: ReturnUnicodeURLs

### DIFF
--- a/src/plugins/returnUnicodeURLs.ts
+++ b/src/plugins/returnUnicodeURLs.ts
@@ -1,0 +1,30 @@
+import definePlugin from "@utils/types";
+export default definePlugin({
+    name: "ReturnUnicodeURLs",
+    description: "This plugin brings back the old rendering of URLs which allows proper displaying of unicode URLs",
+    authors: [
+        {
+            id: 1011864559168012301n,
+            name: "EinTim",
+        },
+    ],
+    start() { 
+        globalThis.originalCreateElement = document.createElement;
+        document.createElement = function (tag, options = undefined) {
+            if(tag == "a"){
+                let element = globalThis.originalCreateElement.call(document, tag, options);
+                setTimeout(() => {
+                    if(element.className.includes("anchor-")){
+                        element.innerHTML = decodeURI(element.innerHTML);
+                    }
+                }, 0);
+                return element;
+            }
+            return globalThis.originalCreateElement.call(document, tag, options);
+        };
+
+    },
+    stop() {
+        document.createElement = globalThis.originalCreateElement;
+    },
+});


### PR DESCRIPTION
Recently discord pushed a new update to the discord app which urlencodes unicode urls before displaying them which destroys a lot of the custom url types of image uploading services like upload.systems. This plugin reverts this change(only visually, the link that is opened in the browser gets encoded as it should be).

Without plugin:
![grafik](https://user-images.githubusercontent.com/57799248/233790119-e2f4fe21-d460-41f3-9b5c-e6a10d6a4b3e.png)

With plugin(and how it was before the discord app update):
![grafik](https://user-images.githubusercontent.com/57799248/233790146-0fad5ef2-c7cf-46b0-8af6-9b15bb496945.png)
