### PR TITLE
MuteNewGuilds: add toggles for guild, everyone, and roles.

### DIFF
--- a/src/plugins/muteNewGuild.tsx
+++ b/src/plugins/muteNewGuild.tsx
@@ -18,9 +18,10 @@
 
 import { Devs } from "@utils/constants";
 import { ModalContent, ModalFooter, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
-import definePlugin from "@utils/types";
+import definePlugin, { OptionType } from "@utils/types";
 import { findByProps, findStoreLazy } from "@webpack";
 import { Button, Text } from "@webpack/common";
+import { definePluginSettings } from "@api/settings";
 
 const UserGuildSettingsStore = findStoreLazy("UserGuildSettingsStore");
 
@@ -49,6 +50,24 @@ function NoDMNotificationsModal({ modalProps }: { modalProps: ModalProps; }) {
     );
 }
 
+const settings = definePluginSettings({
+    guild: {
+        description: "Suppress Guild",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    everyone: {
+        description: "Suppress @everyone and @here",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    role: {
+        description: "Suppress All Role @mentions",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+});
+
 export default definePlugin({
     name: "MuteNewGuild",
     description: "Mutes newly joined guilds",
@@ -62,10 +81,17 @@ export default definePlugin({
             }
         }
     ],
+    settings,
 
     handleMute(guildId: string | null) {
         if (guildId === "@me" || guildId === "null" || guildId == null) return;
-        findByProps("updateGuildNotificationSettings").updateGuildNotificationSettings(guildId, { muted: true, suppress_everyone: true, suppress_roles: true });
+        findByProps("updateGuildNotificationSettings").updateGuildNotificationSettings(guildId,
+            {
+                muted: settings.store.guild,
+                suppress_everyone: settings.store.everyone,
+                suppress_roles: settings.store.role
+            }
+        );
     },
 
     start() {

--- a/src/plugins/muteNewGuild.tsx
+++ b/src/plugins/muteNewGuild.tsx
@@ -52,7 +52,7 @@ function NoDMNotificationsModal({ modalProps }: { modalProps: ModalProps; }) {
 
 const settings = definePluginSettings({
     guild: {
-        description: "Suppress Guild",
+        description: "Mute Guild",
         type: OptionType.BOOLEAN,
         default: true
     },

--- a/src/plugins/muteNewGuild.tsx
+++ b/src/plugins/muteNewGuild.tsx
@@ -71,7 +71,7 @@ const settings = definePluginSettings({
 export default definePlugin({
     name: "MuteNewGuild",
     description: "Mutes newly joined guilds",
-    authors: [Devs.Glitch, Devs.Nuckyz],
+    authors: [Devs.Glitch, Devs.Nuckyz, Devs.carince],
     patches: [
         {
             find: ",acceptInvite:function",

--- a/src/plugins/muteNewGuild.tsx
+++ b/src/plugins/muteNewGuild.tsx
@@ -16,12 +16,12 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { definePluginSettings } from "@api/settings";
 import { Devs } from "@utils/constants";
 import { ModalContent, ModalFooter, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByProps, findStoreLazy } from "@webpack";
 import { Button, Text } from "@webpack/common";
-import { definePluginSettings } from "@api/settings";
 
 const UserGuildSettingsStore = findStoreLazy("UserGuildSettingsStore");
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -277,5 +277,9 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     KannaDev: {
         name: "Kanna",
         id: 317728561106518019n
+    },
+    carince: {
+        name: "carince",
+        id: 818323528755314698n
     }
 });


### PR DESCRIPTION
Gives the user the ability to toggle which notification should be suppressed or not.