### PR TITLE
style(Settings): Make the text about raw theme links bold

### DIFF
--- a/src/components/VencordSettings/ThemesTab.tsx
+++ b/src/components/VencordSettings/ThemesTab.tsx
@@ -93,7 +93,7 @@ export default ErrorBoundary.wrap(function () {
             <Card className="vc-settings-card vc-text-selectable">
                 <Forms.FormTitle tag="h5">Paste links to .theme.css files here</Forms.FormTitle>
                 <Forms.FormText>One link per line</Forms.FormText>
-                <Forms.FormText>Make sure to use the raw links or github.io links!</Forms.FormText>
+                <Forms.FormText><strong>Make sure to use the raw links or github.io links!</strong></Forms.FormText>
                 <Forms.FormDivider className={Margins.top8 + " " + Margins.bottom8} />
                 <Forms.FormTitle tag="h5">Find Themes:</Forms.FormTitle>
                 <div style={{ marginBottom: ".5em" }}>


### PR DESCRIPTION
Adds a `<strong>` tag around the reminder to use raw links for themes.
Should be at least a little helpful to users that tend to gloss over small text.

Preview:
![DiscordCanary_6FLmG07duB](https://user-images.githubusercontent.com/13506050/236306239-1291fab2-b09e-4659-b327-9dd525e094c8.png)