### PR TITLE
USRBG: Hide Nitro badge if banner's source is USRBG

### DIFF
--- a/src/plugins/usrbg/index.tsx
+++ b/src/plugins/usrbg/index.tsx
@@ -47,8 +47,8 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "USRBG",
-    description: "USRBG is a community maintained database of Discord banners, allowing anyone to get a banner without requiring Nitro",
-    authors: [Devs.AutumnVN, Devs.pylix],
+    description: "Displays user banners from USRBG, allowing anyone to get a banner without Nitro",
+    authors: [Devs.AutumnVN, Devs.pylix, Devs.TheKodeToad],
     settings,
     patches: [
         {
@@ -61,6 +61,10 @@ export default definePlugin({
                 {
                     match: /(\i)\.bannerSrc,/,
                     replace: "$self.useBannerHook($1),"
+                },
+                {
+                    match: /\?\(0,\i\.jsx\)\(\i,{type:\i,shown/,
+                    replace: "&&$self.showBadge(arguments[0])$&"
                 }
             ]
         },
@@ -78,7 +82,7 @@ export default definePlugin({
 
     settingsAboutComponent: () => {
         return (
-            <Link href="https://github.com/AutumnVN/usrbg#how-to-request-your-own-usrbg-banner">CLICK HERE TO GET YOUR OWN BANNER</Link>
+            <Link href="https://github.com/AutumnVN/usrbg#how-to-request-your-own-usrbg-banner">How to request a banner</Link>
         );
     },
 
@@ -102,6 +106,10 @@ export default definePlugin({
 
     premiumHook({ userId }: any) {
         if (data[userId]) return 2;
+    },
+
+    showBadge({ displayProfile, user }: any) {
+        return displayProfile?.banner && (!data[user.id] || settings.store.nitroFirst);
     },
 
     async start() {

--- a/src/plugins/usrbg/index.tsx
+++ b/src/plugins/usrbg/index.tsx
@@ -64,7 +64,7 @@ export default definePlugin({
                 },
                 {
                     match: /\?\(0,\i\.jsx\)\(\i,{type:\i,shown/,
-                    replace: "&&$self.showBadge(arguments[0])$&"
+                    replace: "&&$self.shouldShowBadge(arguments[0])$&"
                 }
             ]
         },
@@ -108,7 +108,7 @@ export default definePlugin({
         if (data[userId]) return 2;
     },
 
-    showBadge({ displayProfile, user }: any) {
+    shouldShowBadge({ displayProfile, user }: any) {
         return displayProfile?.banner && (!data[user.id] || settings.store.nitroFirst);
     },
 

--- a/src/plugins/usrbg/index.tsx
+++ b/src/plugins/usrbg/index.tsx
@@ -82,7 +82,7 @@ export default definePlugin({
 
     settingsAboutComponent: () => {
         return (
-            <Link href="https://github.com/AutumnVN/usrbg#how-to-request-your-own-usrbg-banner">How to request a banner</Link>
+            <Link href="https://github.com/AutumnVN/usrbg#how-to-request-your-own-usrbg-banner">CLICK HERE TO GET YOUR OWN BANNER</Link>
         );
     },
 


### PR DESCRIPTION
The reason for doing this is that having Nitro's badge doesn't make much sense. There could be another badge but i'm pretty sure it's only intended for a plug in the first place!