### PR TITLE
NoReplyMention: add option to only exclude specific users from pings

### DIFF
--- a/src/plugins/noReplyMention.tsx
+++ b/src/plugins/noReplyMention.tsx
@@ -22,11 +22,26 @@ import definePlugin, { OptionType } from "@utils/types";
 import type { Message } from "discord-types/general";
 
 const settings = definePluginSettings({
-    exemptList: {
+    userList: {
         description:
-            "List of users to exempt from this plugin (separated by commas or spaces)",
+            "List of users to allow or exempt pings for (separated by commas or spaces)",
         type: OptionType.STRING,
         default: "1234567890123445,1234567890123445",
+    },
+    shouldPingListed: {
+        description: "Behaviour",
+        type: OptionType.SELECT,
+        options: [
+            {
+                label: "Do not ping the listed users",
+                value: false,
+            },
+            {
+                label: "Only ping the listed users",
+                value: true,
+                default: true,
+            },
+        ],
     },
     inverseShiftReply: {
         description: "Invert Discord's shift replying behaviour (enable to make shift reply mention user)",
@@ -38,11 +53,12 @@ const settings = definePluginSettings({
 export default definePlugin({
     name: "NoReplyMention",
     description: "Disables reply pings by default",
-    authors: [Devs.DustyAngel47, Devs.axyie, Devs.pylix],
+    authors: [Devs.DustyAngel47, Devs.axyie, Devs.pylix, Devs.outfoxxed],
     settings,
 
     shouldMention(message: Message, isHoldingShift: boolean) {
-        const isExempt = settings.store.exemptList.includes(message.author.id);
+        const isListed = settings.store.userList.includes(message.author.id);
+        const isExempt = settings.store.shouldPingListed ? isListed : !isListed;
         return settings.store.inverseShiftReply ? isHoldingShift !== isExempt : !isHoldingShift && isExempt;
     },
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -290,5 +290,9 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     CatNoir: {
         name: "CatNoir",
         id: 260371016348336128n
-    }
+    },
+    outfoxxed: {
+        name: "outfoxxed",
+        id: 837425748435796060n
+    },
 });


### PR DESCRIPTION
Adds a new behavior option to NoReplyMention that lets you avoid pinging only specific users instead of only not pinging specific users.

Note: Not sure if I was supposed to add myself to the author list or not, looking through commit history it seems like I am.