### PR TITLE
DevPlugin: AssetExplorer

### DIFF
--- a/src/plugins/assetExplorer.dev.tsx
+++ b/src/plugins/assetExplorer.dev.tsx
@@ -24,7 +24,7 @@ import { Text, Toasts } from "@webpack/common";
 
 const pluginName = "AssetExplorer" as const;
 export default definePlugin({
-    name: pluginName,
+    name: "AssetExplorer",
     description: "Dev util for exploring icons bundled with discord.",
     authors: [Devs.Arjix],
 

--- a/src/plugins/assetExplorer.dev.tsx
+++ b/src/plugins/assetExplorer.dev.tsx
@@ -1,0 +1,90 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import { closeModal, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
+import definePlugin from "@utils/types";
+import { Text, Toasts } from "@webpack/common";
+
+
+const pluginName = "AssetExplorer" as const;
+export default definePlugin({
+    name: pluginName,
+    description: "Dev util for exploring icons bundled with discord.",
+    authors: [Devs.Arjix],
+
+    assets: [],
+    patches: [{
+        find: "?\"currentColor\":",
+        replacement: {
+            match: /function (\w)\(\w\){.{1,100}void 0===\w\?"currentColor":.{1,200}"svg"/gs,
+            replace: "$self.assets.push($1);$&"
+        },
+        all: true
+    }],
+
+    toolboxActions: {
+        "Open Explorer"() {
+            const key = openModal(modalProps => (
+                <AssetExplorerModal
+                    modalProps={modalProps}
+                    close={() => closeModal(key)}
+                    assets={(Vencord.Plugins.plugins[pluginName] as any).assets}
+                />
+            ));
+        }
+    }
+});
+
+
+interface AssetProps {
+    width: number;
+    height: number;
+    color: string;
+}
+
+function AssetExplorerModal({ modalProps, assets, close }: { modalProps: ModalProps; close(): void; assets: React.FC<AssetProps>[]; }) {
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE}>
+            <ModalHeader>
+                <Text variant="heading-lg/semibold" style={{ flexGrow: 1 }}>Asset Explorer</Text>
+                <ModalCloseButton onClick={close} />
+            </ModalHeader>
+
+            <ModalContent>
+                <div style={{ marginBottom: "10px" }}></div>
+                {assets.map(Asset => {
+                    if (`${Asset}`.includes("\"svg\""))
+                        return <span style={{ marginRight: "5px", cursor: "pointer" }} onClick={() => {
+                            console.log("Right click to find the definition!\n\n", Asset, "\n\nSome icons are not exported, so you'll have to either manually export them or copy them in ur plugin.");
+                            Toasts.show({
+                                message: "Logged to the console!",
+                                id: Toasts.genId(),
+                                type: Toasts.Type.MESSAGE
+                            });
+                        }}>
+                            <Asset width={24} height={24} color="var(--interactive-normal)" />
+                        </span>;
+                })}
+            </ModalContent>
+
+            <ModalFooter>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/plugins/assetExplorer.dev.tsx
+++ b/src/plugins/assetExplorer.dev.tsx
@@ -27,6 +27,7 @@ export default definePlugin({
     name: "AssetExplorer",
     description: "Dev util for exploring icons bundled with discord.",
     authors: [Devs.Arjix],
+    dependencies: ["VencordToolbox"],
 
     assets: [],
     patches: [{

--- a/src/plugins/assetExplorer.dev.tsx
+++ b/src/plugins/assetExplorer.dev.tsx
@@ -69,7 +69,7 @@ function AssetExplorerModal({ modalProps, assets, close }: { modalProps: ModalPr
             <ModalContent>
                 <div style={{ marginBottom: "10px" }}></div>
                 {assets.map(Asset => {
-                    if (`${Asset}`.includes("\"svg\""))
+                    if (`${Asset}`.includes('"svg"'))
                         return <span style={{ marginRight: "5px", cursor: "pointer" }} onClick={() => {
                             console.log("Right click to find the definition!\n\n", Asset, "\n\nSome icons are not exported, so you'll have to either manually export them or copy them in ur plugin.");
                             Toasts.show({

--- a/src/plugins/assetExplorer.dev.tsx
+++ b/src/plugins/assetExplorer.dev.tsx
@@ -17,7 +17,7 @@
 */
 
 import { Devs } from "@utils/constants";
-import { closeModal, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
 import definePlugin from "@utils/types";
 import { Text, Toasts } from "@webpack/common";
 
@@ -43,7 +43,6 @@ export default definePlugin({
             const key = openModal(modalProps => (
                 <AssetExplorerModal
                     modalProps={modalProps}
-                    close={() => closeModal(key)}
                     assets={(Vencord.Plugins.plugins[pluginName] as any).assets}
                 />
             ));
@@ -58,12 +57,12 @@ interface AssetProps {
     color: string;
 }
 
-function AssetExplorerModal({ modalProps, assets, close }: { modalProps: ModalProps; close(): void; assets: React.FC<AssetProps>[]; }) {
+function AssetExplorerModal({ modalProps, assets }: { modalProps: ModalProps; assets: React.FC<AssetProps>[]; }) {
     return (
         <ModalRoot {...modalProps} size={ModalSize.LARGE}>
             <ModalHeader>
                 <Text variant="heading-lg/semibold" style={{ flexGrow: 1 }}>Asset Explorer</Text>
-                <ModalCloseButton onClick={close} />
+                <ModalCloseButton onClick={modalProps.onClose} />
             </ModalHeader>
 
             <ModalContent>


### PR DESCRIPTION
## Warning
This plugin is for plugin devs, to use it you must build vencord in dev mode. (eg `pnpm watch`)

## About
This is a plugin to make finding icons an easier task for plugin devs.
Many icons are not exported, so you might have to either patch the icon to export it or copy the component and paste it in ur plugin.

## TODO
- [ ] Maybe load all the webpack chunks so all the icons are loaded?

![image](https://github.com/Vendicated/Vencord/assets/53124886/7f07b9cf-8e76-428d-8dab-085a1f56e449)
![image](https://github.com/Vendicated/Vencord/assets/53124886/8dc43d47-303b-4e57-ad04-1fadbda0d75b)
