### PR TITLE
fix(TypingTweaks): use global displayName over username

### DIFF
--- a/src/plugins/typingTweaks.tsx
+++ b/src/plugins/typingTweaks.tsx
@@ -89,7 +89,7 @@ const TypingUser = ErrorBoundary.wrap(function ({ user, guildId }: Props) {
                         src={user.getAvatarURL(guildId, 128)} />
                 </div>
             )}
-            {GuildMemberStore.getNick(guildId!, user.id) || !guildId && RelationshipStore.getNickname(user.id) || user.username}
+            {GuildMemberStore.getNick(guildId!, user.id) || !guildId && RelationshipStore.getNickname(user.id) || user.globalName || user.username}
         </strong>
     );
 }, { noop: true });


### PR DESCRIPTION
This adds support for Discord's new global display name feature rolled out ahead of the new username system, and makes it prefer the global display name over the username like the stock client does.