### PR TITLE
Plugin: NoPendingCount

### DIFF
--- a/src/plugins/noPendingCount.ts
+++ b/src/plugins/noPendingCount.ts
@@ -1,6 +1,6 @@
 /*
  * Vencord, a modification for Discord's desktop app
- * Copyright (c) 2022 Vendicated and contributors
+ * Copyright (c) 2023 Vendicated and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/plugins/noPendingCount.ts
+++ b/src/plugins/noPendingCount.ts
@@ -17,10 +17,10 @@
 */
 
 
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
-import { definePluginSettings } from "@api/Settings";
 
 const MessageRequestStore = findByPropsLazy("getMessageRequestsCount");
 

--- a/src/plugins/noPendingCount.ts
+++ b/src/plugins/noPendingCount.ts
@@ -59,8 +59,8 @@ export default definePlugin({
             find: ".getPendingCount=",
             predicate: () => settings.store.hideFriendRequestsCount,
             replacement: {
-                match: /(\i)\.getPendingCount=function\(\){return\s\i};/,
-                replace: "$1.getPendingCount=function(){return 0};"
+                match: /(?<=\.getPendingCount=function\(\)\{)/,
+                replace: "return 0;"
             }
         },
         {
@@ -77,8 +77,8 @@ export default definePlugin({
             find: ".getSpamChannelsCount(),",
             predicate: () => settings.store.hideMessageRequestsCount,
             replacement: {
-                match: /(,\i=\i\.getSpamChannelsCount\(\)),(\i)=\i\.getMessageRequestsCount\(\),(\i=\i>0\|\|\i>0;return\s*?\i}})/,
-                replace: "$1,$2=$self.getRealMessageRequestCount(),$3"
+                match: /(?<=getSpamChannelsCount\(\),\i=)\i\.getMessageRequestsCount\(\)/,
+                replace: "$self.getRealMessageRequestCount()"
             }
         },
         {

--- a/src/plugins/noPendingCount.ts
+++ b/src/plugins/noPendingCount.ts
@@ -1,0 +1,97 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+import { definePluginSettings } from "@api/Settings";
+
+const MessageRequestStore = findByPropsLazy("getMessageRequestsCount");
+
+const settings = definePluginSettings({
+    hideFriendRequestsCount: {
+        type: OptionType.BOOLEAN,
+        description: "Hide incoming friend requests count",
+        default: true,
+        restartNeeded: true
+    },
+    hideMessageRequestsCount: {
+        type: OptionType.BOOLEAN,
+        description: "Hide message requests count",
+        default: true,
+        restartNeeded: true
+    },
+    hidePremiumOffersCount: {
+        type: OptionType.BOOLEAN,
+        description: "Hide nitro offers count",
+        default: true,
+        restartNeeded: true
+    }
+});
+
+export default definePlugin({
+    name: "NoPendingCount",
+    description: "Removes the ping count of incoming friend requests, message requests, and nitro offers.",
+    authors: [Devs.amia],
+
+    settings: settings,
+
+    // Functions used to determine the top left count indicator can be found in the single module that calls getUnacknowledgedOffers(...)
+    // or by searching for "showProgressBadge:"
+    patches: [
+        {
+            find: ".getPendingCount=",
+            predicate: () => settings.store.hideFriendRequestsCount,
+            replacement: {
+                match: /(\i)\.getPendingCount=function\(\){return\s\i};/,
+                replace: "$1.getPendingCount=function(){return 0};"
+            }
+        },
+        {
+            find: ".getMessageRequestsCount=",
+            predicate: () => settings.store.hideMessageRequestsCount,
+            replacement: {
+                match: /(\i)\.getMessageRequestsCount=function\(\){return \i\.size};/,
+                replace: "$1.getMessageRequestsCount=function(){return 0};"
+            }
+        },
+        // This prevents the Message Requests tab from always hiding due to the previous patch (and is compatible with spam requests)
+        // In short, only the red badge is hidden. Button visibility behavior isn't changed.
+        {
+            find: ".getSpamChannelsCount(),",
+            predicate: () => settings.store.hideMessageRequestsCount,
+            replacement: {
+                match: /(,\i=\i\.getSpamChannelsCount\(\)),(\i)=\i\.getMessageRequestsCount\(\),(\i=\i>0\|\|\i>0;return\s*?\i}})/,
+                replace: "$1,$2=$self.getRealMessageRequestCount(),$3"
+            }
+        },
+        {
+            find: "showProgressBadge:",
+            predicate: () => settings.store.hidePremiumOffersCount,
+            replacement: {
+                match: /\(function\(\){return \i\.\i\.getUnacknowledgedOffers\(\i\)\.length}\)/,
+                replace: "(function(){return 0})"
+            }
+        }
+    ],
+
+    getRealMessageRequestCount() {
+        return MessageRequestStore.getMessageRequestChannelIds().size;
+    }
+});

--- a/src/plugins/noPendingCount.ts
+++ b/src/plugins/noPendingCount.ts
@@ -67,8 +67,8 @@ export default definePlugin({
             find: ".getMessageRequestsCount=",
             predicate: () => settings.store.hideMessageRequestsCount,
             replacement: {
-                match: /(\i)\.getMessageRequestsCount=function\(\){return \i\.size};/,
-                replace: "$1.getMessageRequestsCount=function(){return 0};"
+                match: /(?<=\.getMessageRequestsCount=function\(\)\{)/,
+                replace: "return 0;"
             }
         },
         // This prevents the Message Requests tab from always hiding due to the previous patch (and is compatible with spam requests)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -315,6 +315,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "UwU",
         id: 691413039156690994n,
     },
+    amia: {
+        name: "amia",
+        id: 142007603549962240n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This plugin removes the ping count of incoming friend requests, message requests, and nitro offers.
Ping indicators are removed in the following places:

- Home button (count reduced)
- Friends tab button
- Pending tab button
- Message Requests button
- Taskbar icon (count reduced)

The visibility logic of the Message Requests tab button is preserved (i.e. still appears when there are message requests, and disappears otherwise).