### PR TITLE
ImageZoom: add nearest neighbour

### DIFF
--- a/src/plugins/imageZoom/components/Magnifier.tsx
+++ b/src/plugins/imageZoom/components/Magnifier.tsx
@@ -156,7 +156,7 @@ export const Magnifier: React.FC<MagnifierProps> = ({ instance, size: initialSiz
 
     return (
         <div
-            className="vc-imgzoom-lens"
+            className={`vc-imgzoom-lens ${settings.store.nearestNeighbour ? "nearest-neighbor" : ""}`}
             style={{
                 opacity,
                 width: size.current + "px",

--- a/src/plugins/imageZoom/index.tsx
+++ b/src/plugins/imageZoom/index.tsx
@@ -50,6 +50,12 @@ export const settings = definePluginSettings({
         default: true,
     },
 
+    nearestNeighbour: {
+        type: OptionType.BOOLEAN,
+        description: "Use Nearest Neighbour Interpolation when scaling images",
+        default: false,
+    },
+
     zoom: {
         description: "Zoom of the lens",
         type: OptionType.SLIDER,

--- a/src/plugins/imageZoom/styles.css
+++ b/src/plugins/imageZoom/styles.css
@@ -11,6 +11,10 @@
     pointer-events: none;
 }
 
+.vc-imgzoom-lens.nearest-neighbor > img {
+    image-rendering: pixelated; /* https://googlechrome.github.io/samples/image-rendering-pixelated/index.html */
+}
+
 /* make the carousel take up less space so we can click the backdrop and exit out of it */
 [class|="carouselModal"] {
     height: fit-content;


### PR DESCRIPTION
add nearest neighbour interpolation option.

`image-rendering: pixelated;` demo:
https://googlechrome.github.io/samples/image-rendering-pixelated/index.html


## normal:
![image](https://github.com/Vendicated/Vencord/assets/47534062/bdfd8ba3-7676-4da9-a6e7-5071b4b97fe4)

## nearest neighbour interpolation:
![image](https://github.com/Vendicated/Vencord/assets/47534062/6b52ab28-d451-42a4-8a69-8d66918636be)
