### PR TITLE
PronounDB: fix caching not respecting user preference

### DIFF
--- a/src/plugins/pronoundb/index.ts
+++ b/src/plugins/pronoundb/index.ts
@@ -52,7 +52,7 @@ export default definePlugin({
             find: ".userTagNoNickname",
             replacement: {
                 match: /=(\i)\.pronouns/,
-                replace: "=$self.useProfilePronouns($1.user.id,$1.pronouns)"
+                replace: "=$self.useProfilePronouns($1.user.id)"
             }
         },
         // Patch the profile modal username header to use our pronoun hook instead of Discord's pronouns
@@ -60,7 +60,7 @@ export default definePlugin({
             find: ".USER_PROFILE_ACTIVITY",
             replacement: {
                 match: /\).showPronouns/,
-                replace: ").showPronouns||true;const vcPronounce=$self.useProfilePronouns(arguments[0].user.id,arguments[0].displayProfile?.pronouns);if(arguments[0].displayProfile&&vcPronounce)arguments[0].displayProfile.pronouns=vcPronounce"
+                replace: ").showPronouns||true;const vcPronounce=$self.useProfilePronouns(arguments[0].user.id);if(arguments[0].displayProfile&&vcPronounce)arguments[0].displayProfile.pronouns=vcPronounce"
             }
         }
     ],


### PR DESCRIPTION
We don't need to cache Discord pronouns in the `cache` object, because they're already cached in the user object.