### PR TITLE
feat(plugin): unlimitedAccounts

### DIFF
--- a/src/plugins/unlimitedAccounts.ts
+++ b/src/plugins/unlimitedAccounts.ts
@@ -22,7 +22,7 @@ import definePlugin, { OptionType } from "@utils/types";
 
 const settings = definePluginSettings({
     maxAccounts: {
-        description: "Number of accounts that can be added or 0 for infinite",
+        description: "Number of accounts that can be added, or 0 for no limit",
         default: Number.POSITIVE_INFINITY,
         type: OptionType.NUMBER,
         restartNeeded: true,

--- a/src/plugins/unlimitedAccounts.ts
+++ b/src/plugins/unlimitedAccounts.ts
@@ -26,7 +26,7 @@ const settings = definePluginSettings({
         default: 0,
         type: OptionType.NUMBER,
         restartNeeded: true,
-    }
+    },
 });
 
 export default definePlugin({
@@ -39,8 +39,9 @@ export default definePlugin({
             find: "switch-accounts-modal",
             replacement: {
                 match: /var (.{1,2})=\d+,(.{1,2})="switch-accounts-modal"/,
-                replace: 'var $1=Vencord.Settings.plugins.UnlimitedAccounts.maxAccounts===0?Infinity:Vencord.Settings.plugins.UnlimitedAccounts.maxAccounts,$2="switch-accounts-modal"',
+                replace: 'var $1=$self.getMaxAccounts(),$2="switch-accounts-modal"',
             },
         },
     ],
+    getMaxAccounts() { return settings.store.maxAccounts === 0 ? Infinity : settings.store.maxAccounts; },
 });

--- a/src/plugins/unlimitedAccounts.ts
+++ b/src/plugins/unlimitedAccounts.ts
@@ -1,0 +1,46 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    maxAccounts: {
+        description: "Number of accounts that can be added or 0 for infinite",
+        default: Number.POSITIVE_INFINITY,
+        type: OptionType.NUMBER,
+        restartNeeded: true,
+    }
+});
+
+export default definePlugin({
+    name: "UnlimitedAccounts",
+    description: "Increases the amount of accounts you can add.",
+    authors: [Devs.Balaclava],
+    settings,
+    patches: [
+        {
+            find: "switch-accounts-modal",
+            replacement: {
+                match: /var (.{1,2})=\d+,(.{1,2})="switch-accounts-modal"/,
+                replace: 'var $1=Vencord.Settings.plugins.UnlimitedAccounts.maxAccounts===0?Infinity:Vencord.Settings.plugins.UnlimitedAccounts.maxAccounts,$2="switch-accounts-modal"',
+            },
+        },
+    ],
+});

--- a/src/plugins/unlimitedAccounts.ts
+++ b/src/plugins/unlimitedAccounts.ts
@@ -23,7 +23,7 @@ import definePlugin, { OptionType } from "@utils/types";
 const settings = definePluginSettings({
     maxAccounts: {
         description: "Number of accounts that can be added, or 0 for no limit",
-        default: Number.POSITIVE_INFINITY,
+        default: 0,
         type: OptionType.NUMBER,
         restartNeeded: true,
     }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -334,6 +334,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     HypedDomi: {
         name: "HypedDomi",
         id: 354191516979429376n
+    },
+    Balaclava: {
+        name: "Balaclava",
+        id: 854886148455399436n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
This PR adds the unlimitedAccounts plugin.
It allows you to add more than 5 accounts to your client.

With the introduction of pomelos, this function has become very interesting for **collectors**, like me!
I really like Vencord and I don't want to use another mod because of this plugin, so I decided to do it.
(and I've also seen users asking for something to do this using Vencord)

I already ran the `pnpm test`

<div align="center">
  <table>
    <tr>
      <td>
        <div align="center">Accounts</div>
        <img src="https://i.imgur.com/X2rWmMn.png" alt="Accounts" width="500">
      </td>
      <td>
        <div align="center">Options</div>
        <img src="https://i.imgur.com/3CpXRkK.png" alt="Options" width="1350">
      </td>
    </tr>
  </table>
</div>

