### PR TITLE
More consistent username formatting

### DIFF
--- a/src/plugins/mutualGroupDMs.tsx
+++ b/src/plugins/mutualGroupDMs.tsx
@@ -19,6 +19,7 @@
 
 import { Devs } from "@utils/constants";
 import { isNonNullish } from "@utils/guards";
+import { getDisplayName } from "@utils/discord";
 import definePlugin from "@utils/types";
 import { findByPropsLazy } from "@webpack";
 import { Avatar, ChannelStore, Clickable, RelationshipStore, ScrollerThin, UserStore } from "@webpack/common";
@@ -26,7 +27,6 @@ import { Channel, User } from "discord-types/general";
 
 const SelectedChannelActionCreators = findByPropsLazy("selectPrivateChannel");
 const AvatarUtils = findByPropsLazy("getChannelIconURL");
-const UserUtils = findByPropsLazy("getGlobalName");
 
 const ProfileListClasses = findByPropsLazy("emptyIconFriends", "emptyIconGuilds");
 const GuildLabelClasses = findByPropsLazy("guildNick", "guildAvatarWithoutIcon");
@@ -36,7 +36,7 @@ function getGroupDMName(channel: Channel) {
         channel.recipients
             .map(UserStore.getUser)
             .filter(isNonNullish)
-            .map(c => RelationshipStore.getNickname(c.id) || UserUtils.getName(c))
+            .map(u => getDisplayName(null, u.id))
             .join(", ");
 }
 

--- a/src/plugins/mutualGroupDMs.tsx
+++ b/src/plugins/mutualGroupDMs.tsx
@@ -18,11 +18,11 @@
 
 
 import { Devs } from "@utils/constants";
-import { isNonNullish } from "@utils/guards";
 import { getDisplayName } from "@utils/discord";
+import { isNonNullish } from "@utils/guards";
 import definePlugin from "@utils/types";
 import { findByPropsLazy } from "@webpack";
-import { Avatar, ChannelStore, Clickable, RelationshipStore, ScrollerThin, UserStore } from "@webpack/common";
+import { Avatar, ChannelStore, Clickable, ScrollerThin, UserStore } from "@webpack/common";
 import { Channel, User } from "discord-types/general";
 
 const SelectedChannelActionCreators = findByPropsLazy("selectPrivateChannel");

--- a/src/plugins/permissionsViewer/components/UserPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/UserPermissions.tsx
@@ -18,6 +18,7 @@
 
 import ErrorBoundary from "@components/ErrorBoundary";
 import ExpandableHeader from "@components/ExpandableHeader";
+import { getUniqueUsername } from "@utils/discord";
 import { proxyLazy } from "@utils/lazy";
 import { classes } from "@utils/misc";
 import { filters, findBulk } from "@webpack";
@@ -104,7 +105,7 @@ function UserPermissionsComponent({ guild, guildMember }: { guild: Guild; guildM
                 openRolesAndUsersPermissionsModal(
                     rolePermissions,
                     guild,
-                    guildMember.nick || UserStore.getUser(guildMember.userId).username
+                    getUniqueUsername(UserStore.getUser(guildMember.userId))
                 )
             }
             defaultState={settings.store.defaultPermissionsDropdownState}

--- a/src/plugins/permissionsViewer/index.tsx
+++ b/src/plugins/permissionsViewer/index.tsx
@@ -21,6 +21,7 @@ import "./styles.css";
 import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
+import { getUniqueUsername } from "@utils/discord";
 import definePlugin, { OptionType } from "@utils/types";
 import { ChannelStore, GuildMemberStore, GuildStore, Menu, PermissionsBits, UserStore } from "@webpack/common";
 import type { Guild, GuildMember } from "discord-types/general";
@@ -86,7 +87,7 @@ function MenuItem(guildId: string, id?: string, type?: MenuItemParentType) {
                             });
                         }
 
-                        header = member.nick ?? UserStore.getUser(member.userId).username;
+                        header = getUniqueUsername(UserStore.getUser(member.userId));
 
                         break;
                     }

--- a/src/plugins/typingIndicator.tsx
+++ b/src/plugins/typingIndicator.tsx
@@ -19,10 +19,11 @@
 import { definePluginSettings, Settings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
+import { getDisplayName } from "@utils/discord";
 import { LazyComponent } from "@utils/react";
 import definePlugin, { OptionType } from "@utils/types";
 import { find, findLazy, findStoreLazy } from "@webpack";
-import { ChannelStore, GuildMemberStore, RelationshipStore, Tooltip, UserStore, useStateFromStores } from "@webpack/common";
+import { ChannelStore, RelationshipStore, Tooltip, UserStore, useStateFromStores } from "@webpack/common";
 
 import { buildSeveralUsers } from "./typingTweaks";
 
@@ -33,9 +34,6 @@ const UserGuildSettingsStore = findStoreLazy("UserGuildSettingsStore");
 
 const Formatters = findLazy(m => m.Messages?.SEVERAL_USERS_TYPING);
 
-function getDisplayName(guildId: string, userId: string) {
-    return GuildMemberStore.getNick(guildId, userId) ?? UserStore.getUser(userId).username;
-}
 
 function TypingIndicator({ channelId }: { channelId: string; }) {
     const typingUsers: Record<string, number> = useStateFromStores(

--- a/src/plugins/typingTweaks.tsx
+++ b/src/plugins/typingTweaks.tsx
@@ -19,7 +19,7 @@
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
-import { openUserProfile, getDisplayName } from "@utils/discord";
+import { getDisplayName, openUserProfile } from "@utils/discord";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByCodeLazy } from "@webpack";
 import { GuildMemberStore, React } from "@webpack/common";

--- a/src/plugins/typingTweaks.tsx
+++ b/src/plugins/typingTweaks.tsx
@@ -19,10 +19,10 @@
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
-import { openUserProfile } from "@utils/discord";
+import { openUserProfile, getDisplayName } from "@utils/discord";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByCodeLazy } from "@webpack";
-import { GuildMemberStore, React, RelationshipStore } from "@webpack/common";
+import { GuildMemberStore, React } from "@webpack/common";
 import { User } from "discord-types/general";
 
 const Avatar = findByCodeLazy(".typingIndicatorRef", "svg");
@@ -81,11 +81,7 @@ const TypingUser = ErrorBoundary.wrap(function ({ user, guildId }: Props) {
                         src={user.getAvatarURL(guildId, 128)} />
                 </div>
             )}
-            {GuildMemberStore.getNick(guildId!, user.id)
-                || (!guildId && RelationshipStore.getNickname(user.id))
-                || (user as any).globalName
-                || user.username
-            }
+            {getDisplayName(guildId, user.id)}
         </strong>
     );
 }, { noop: true });

--- a/src/utils/discord.tsx
+++ b/src/utils/discord.tsx
@@ -18,13 +18,14 @@
 
 import { MessageObject } from "@api/MessageEvents";
 import { findByCodeLazy, findByPropsLazy, findLazy } from "@webpack";
-import { ChannelStore, ComponentDispatch, GuildStore, MaskedLink, ModalImageClasses, PrivateChannelsStore, SelectedChannelStore, SelectedGuildStore, UserUtils } from "@webpack/common";
+import { ChannelStore, ComponentDispatch, GuildMemberStore, GuildStore, MaskedLink, ModalImageClasses, PrivateChannelsStore, RelationshipStore, SelectedChannelStore, SelectedGuildStore, UserStore, UserUtils } from "@webpack/common";
 import { Guild, Message, User } from "discord-types/general";
 
 import { ImageModal, ModalRoot, ModalSize, openModal } from "./modal";
 
 const PreloadedUserSettings = findLazy(m => m.ProtoClass?.typeName.endsWith("PreloadedUserSettings"));
 const MessageActions = findByPropsLazy("editMessage", "sendMessage");
+const DiscordUserUtils = findByPropsLazy("getGlobalName");
 
 export function getCurrentChannel() {
     return ChannelStore.getChannel(SelectedChannelStore.getChannelId());
@@ -123,4 +124,19 @@ export async function openUserProfile(id: string) {
  */
 export function getUniqueUsername(user: User) {
     return user.discriminator === "0" ? user.username : user.tag;
+}
+
+/**
+ * Returns user's display name applicable for all contexts:
+ * - guild nickname (if guildId is provided)
+ * - friend nickname (only if guildId is not provided)
+ * - globalName
+ * - username (pomelo)
+ * - username#1234
+ */
+export function getDisplayName(guildId: string | null, userId: string): string {
+    return (guildId && GuildMemberStore.getNick(guildId, userId))
+        || (!guildId && RelationshipStore.getNickname(userId))
+        || DiscordUserUtils.getName(UserStore.getUser(userId));
+
 }

--- a/src/utils/discord.tsx
+++ b/src/utils/discord.tsx
@@ -123,7 +123,7 @@ export async function openUserProfile(id: string) {
  * Get the unique username for a user. Returns user.username for pomelo people, user.tag otherwise
  */
 export function getUniqueUsername(user: User) {
-    return user.discriminator === "0" ? user.username : user.tag;
+    return DiscordUserUtils.getUserTag(user);
 }
 
 /**


### PR DESCRIPTION
- In PermissionsViewer, don't use guild nickname because Discord itself doesn't in channel settings
- Fixed TypingIndicator not using global names