### PR TITLE
plugin(DisableGamePresence)

### DIFF
--- a/src/plugins/disableGamePresence.ts
+++ b/src/plugins/disableGamePresence.ts
@@ -1,0 +1,55 @@
+import { definePluginSettings } from "@api/Settings"
+import definePlugin, { OptionType } from "@utils/types";
+import { Devs } from "@utils/constants";
+
+const settings = definePluginSettings({
+    executableNames: {
+        description: "List of games to exclude by executable path (separate by comma)",
+        type: OptionType.STRING,
+        default: "",
+        restartNeeded: true,
+    },
+
+    gameTitles: {
+        description: "List of games to exclude by game title (separate by comma).",
+        type: OptionType.STRING,
+        default: "",
+        restartNeeded: true,
+    }
+})
+
+
+export default definePlugin({
+    name: "DisableGamePresence",
+    description: "Allows you to exclude games from prescence by name or executable path.\nA full list of detectable games can be found here: https://discord.com/api/v9/applications/detectable",
+    authors: [Devs.wally],
+    patches: [
+        {
+            find: "If-None-Match",
+            replacement: {
+                match: /type:"GAMES_DATABASE_UPDATE",games:(\w),/,
+                replace: "type:\"GAMES_DATABASE_UPDATE\",games:$self.filterGames($1),"
+            }
+        }
+    ],
+    settings,
+
+    filterGames(games) {
+        var gameTitles = settings.store.gameTitles.split(",");
+        var gameExecutables = settings.store.gameTitles.split(",");
+
+        games = games.filter(function(game) {
+            if (gameTitles.includes(game.name)) {
+                return false
+            }
+
+            if (game.executables.find((executable) => gameExecutables.includes(executable.name))) {
+                return false
+            }
+
+            return true
+        })
+
+        return games
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -334,6 +334,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     HypedDomi: {
         name: "HypedDomi",
         id: 354191516979429376n
+    },
+    wally: {
+        name: "wally",
+        id: 727303510185607279n,
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
This plugin allows you to disable specific games from being detected based on title or executable path.

An example usecase is Discord recently added a game called "Everything" to their detectable games (https://discord.com/api/v9/applications/detectable) which also picks up Everything Search which may be annoying to some users.

Thanks 😄 