### PR TITLE
feat(MessageLogger): add option to ignore channels and guilds

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -158,13 +158,18 @@ export default definePlugin({
             description: "Comma-separated list of channel IDs to ignore",
             default: ""
         },
+        ignoreGuilds: {
+            type: OptionType.STRING,
+            description: "Comma-separated list of guild IDs to ignore",
+            default: ""
+        },
     },
 
     handleDelete(cache: any, data: { ids: string[], id: string; mlDeleted?: boolean; }, isBulk: boolean) {
         try {
             if (cache == null || (!isBulk && !cache.has(data.id))) return cache;
 
-            const { ignoreBots, ignoreSelf, ignoreUsers, ignoreChannels } = Settings.plugins.MessageLogger;
+            const { ignoreBots, ignoreSelf, ignoreUsers, ignoreChannels, ignoreGuilds } = Settings.plugins.MessageLogger;
             const myId = UserStore.getCurrentUser().id;
 
             function mutate(id: string) {
@@ -177,7 +182,8 @@ export default definePlugin({
                     ignoreBots && msg.author?.bot ||
                     ignoreSelf && msg.author?.id === myId ||
                     ignoreUsers.includes(msg.author?.id) ||
-                    ignoreChannels.includes(msg.channel_id);
+                    ignoreChannels.includes(msg.channel_id) ||
+                    ignoreGuilds.includes(msg.guild_id);
 
                 if (shouldIgnore) {
                     cache = cache.remove(id);

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -152,14 +152,19 @@ export default definePlugin({
             type: OptionType.STRING,
             description: "Comma-separated list of user IDs to ignore",
             default: ""
-        }
+        },
+        ignoreChannels: {
+            type: OptionType.STRING,
+            description: "Comma-separated list of channel IDs to ignore",
+            default: ""
+        },
     },
 
     handleDelete(cache: any, data: { ids: string[], id: string; mlDeleted?: boolean; }, isBulk: boolean) {
         try {
             if (cache == null || (!isBulk && !cache.has(data.id))) return cache;
 
-            const { ignoreBots, ignoreSelf, ignoreUsers } = Settings.plugins.MessageLogger;
+            const { ignoreBots, ignoreSelf, ignoreUsers, ignoreChannels } = Settings.plugins.MessageLogger;
             const myId = UserStore.getCurrentUser().id;
 
             function mutate(id: string) {
@@ -171,7 +176,8 @@ export default definePlugin({
                     (msg.flags & EPHEMERAL) === EPHEMERAL ||
                     ignoreBots && msg.author?.bot ||
                     ignoreSelf && msg.author?.id === myId ||
-                    ignoreUsers.includes(msg.author?.id);
+                    ignoreUsers.includes(msg.author?.id) ||
+                    ignoreChannels.includes(msg.channel_id);
 
                 if (shouldIgnore) {
                     cache = cache.remove(id);


### PR DESCRIPTION
Add two new options to outright ignore channels, and guilds from creating
logs with the MessageLogger plugin.

In some high-traffic channels and guilds that receive a lot of edits and/or
deletions (by virtue of so-called "sticky messages"), the MessageLogger
plugin tends to get in the way of reading the chat history.

This patch adds an option to provide a comma-separated list of channel
IDs to ignore from logging. Additionally, after some direct conversation
on the support server, it was concluded to also add an option to ignore
guilds, such that this plugins settings can be considered complete.

(See https://canary.discord.com/channels/1015060230222131221/1015063227299811479/1129443488346419220)

Local tests confirm it is working as intended. To the best of my
knowledge, I followed the style guide of this project.
However, as this is my first time working with TypeScript and the
Vencord codebase, please feel free to give feedback and pointers on how
to proceed, so we can get this merged.

Unfortunately, I was not able to find any relevant discussions or issues
with regards to such a feature request. If there are any, please do link
them.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
