### PR TITLE
fix(customRPC): replace empty string with undefined

### DIFF
--- a/src/plugins/customRPC.tsx
+++ b/src/plugins/customRPC.tsx
@@ -187,7 +187,7 @@ async function createActivity(): Promise<Activity | undefined> {
     if (imageBig) {
         activity.assets = {
             large_image: await getApplicationAsset(imageBig),
-            large_text: imageBigTooltip
+            large_text: imageBigTooltip === "" ? undefined : imageBigTooltip
         };
     }
 


### PR DESCRIPTION
### Changes
- Fix the blank tooltip showing over the large image when hovered.
![image](https://github.com/Vendicated/Vencord/assets/40339350/f3cc6822-2edf-4854-ad27-b1fd63e19909) -> ![image](https://github.com/Vendicated/Vencord/assets/40339350/f165a0a3-8ca1-48fa-a5e8-78d4260e19ab)
*The cursor was hovering over the images when the screenshots were taken, it is just not in the images.*

- The small image's tooltip doesn't exhibit this behaviour, so no extra code was needed.

#### To reproduce the bug:
1. Set large image's tooltip to anything (other than undefined/null), and save.
2. Toggle plugin.
3. Set tooltip to nothing, and save.
4. Toggle plugin.