### PR TITLE
fix(PronounDB): don't use guild pronouns in global profile modal

### DIFF
--- a/src/plugins/pronoundb/index.ts
+++ b/src/plugins/pronoundb/index.ts
@@ -69,7 +69,7 @@ export default definePlugin({
             replacement: [
                 {
                     match: /getGlobalName\(\i\);(?<=displayProfile.{0,200})/,
-                    replace: "$&const [vcPronounce,vcPronounSource]=$self.useProfilePronouns(arguments[0].user.id);if(arguments[0].displayProfile&&vcPronounce)arguments[0].displayProfile.pronouns=vcPronounce;"
+                    replace: "$&const [vcPronounce,vcPronounSource]=$self.useProfilePronouns(arguments[0].user.id,true);if(arguments[0].displayProfile&&vcPronounce)arguments[0].displayProfile.pronouns=vcPronounce;"
                 },
                 PRONOUN_TOOLTIP_PATCH
             ]

--- a/src/plugins/pronoundb/pronoundbUtils.ts
+++ b/src/plugins/pronoundb/pronoundbUtils.ts
@@ -58,16 +58,20 @@ const bulkFetch = debounce(async () => {
     }
 });
 
-function getDiscordPronouns(id: string) {
+function getDiscordPronouns(id: string, useGlobalProfile: boolean = false) {
+    const globalPronouns = UserProfileStore.getUserProfile(id)?.pronouns;
+
+    if (useGlobalProfile) return globalPronouns;
+
     return (
         UserProfileStore.getGuildMemberProfile(id, getCurrentChannel()?.guild_id)?.pronouns
-        || UserProfileStore.getUserProfile(id)?.pronouns
+        || globalPronouns
     );
 }
 
-export function useFormattedPronouns(id: string): PronounsWithSource {
+export function useFormattedPronouns(id: string, useGlobalProfile: boolean = false): PronounsWithSource {
     // Discord is so stupid you can put tons of newlines in pronouns
-    const discordPronouns = getDiscordPronouns(id)?.trim().replace(NewLineRe, " ");
+    const discordPronouns = getDiscordPronouns(id, useGlobalProfile)?.trim().replace(NewLineRe, " ");
 
     const [result] = useAwaiter(() => fetchPronouns(id), {
         fallbackValue: getCachedPronouns(id),
@@ -83,8 +87,8 @@ export function useFormattedPronouns(id: string): PronounsWithSource {
     return [discordPronouns, "Discord"];
 }
 
-export function useProfilePronouns(id: string): PronounsWithSource {
-    const pronouns = useFormattedPronouns(id);
+export function useProfilePronouns(id: string, useGlobalProfile: boolean = false): PronounsWithSource {
+    const pronouns = useFormattedPronouns(id, useGlobalProfile);
 
     if (!settings.store.showInProfile) return EmptyPronouns;
     if (!settings.store.showSelf && id === UserStore.getCurrentUser().id) return EmptyPronouns;


### PR DESCRIPTION
It was getting pronouns from the currently focused channel's server if you opened someone's global profile from within a server.