### PR TITLE
feat(plugin): showMoreLines

### DIFF
--- a/src/plugins/showMoreLines.ts
+++ b/src/plugins/showMoreLines.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "ShowMoreLines",
+    description: "Removes the 100 lines limit of the file preview",
+    authors: [Devs.Lumap],
+    patches: [
+        {
+            find: "?100:6,",
+            replacement: {
+                match: "?100:6,",
+                replace: "?Infinity:6,",
+            },
+        },
+    ],
+});

--- a/src/plugins/showMoreLines.ts
+++ b/src/plugins/showMoreLines.ts
@@ -21,7 +21,7 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "ShowMoreLines",
-    description: "Removes the 100 lines limit of the file preview",
+    description: "Removes the 100 lines limit of the file preview. May cause lag with very big files, be careful!",
     authors: [Devs.Lumap],
     patches: [
         {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -334,6 +334,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     HypedDomi: {
         name: "HypedDomi",
         id: 354191516979429376n
+    },
+    Lumap: {
+        name: "lumap",
+        id: 635383782576357407n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
This plugin removes the 100 lines limit of Discord's file preview

Before:
![](https://cdn.discordapp.com/attachments/1020339327831658629/1133811698193682452/image.png)

After:
![](https://cdn.discordapp.com/attachments/1020339327831658629/1133810672086560869/image.png)