### PR TITLE
fix(cloud): cross-client enabling without proper validation

### DIFF
--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -27,6 +27,7 @@ export { PlainSettings, Settings };
 import "./utils/quickCss";
 import "./webpack/patchWebpack";
 
+import { get as dsGet } from "./api/DataStore";
 import { showNotification } from "./api/Notifications";
 import { PlainSettings, Settings } from "./api/Settings";
 import { patches, PMLogger, startAllPlugins } from "./plugins";
@@ -38,6 +39,22 @@ import { onceReady } from "./webpack";
 import { SettingsRouter } from "./webpack/common";
 
 async function syncSettings() {
+    // pre-check for local shared settings
+    if (
+        Settings.cloud.authenticated &&
+        await dsGet("Vencord_cloudSecret") === null // this has been enabled due to local settings share or some other bug
+    ) {
+        // show a notification letting them know and tell them how to fix it
+        showNotification({
+            title: "Cloud Integrations",
+            body: "We've noticed you have cloud integrations enabled in another client! Due to limitations, you will " +
+                "need to re-authenticate to continue using them. Click here to go to the settings page to do so!",
+            color: "var(--yellow-360)",
+            onClick: () => SettingsRouter.open("VencordCloud")
+        });
+        return;
+    }
+
     if (
         Settings.cloud.settingsSync && // if it's enabled
         Settings.cloud.authenticated // if cloud integrations are enabled


### PR DESCRIPTION
This isn't really a fix per se, more of a heads up to the end user. As more people have started to use Vesktop, people are confused on why Cloud Integrations doesn't work correctly (because the secret doesn't carry over, only their settings, which contains the Cloud Integrations enable state).

The alternative is to move it to IndexedDB, but it would require rewriting a bit of the code whilst I think the temporary bandaid is a good solution until we can get around to redoing it correctly.