### PR TITLE
VoiceMessages: Improve permission check

### DIFF
--- a/src/plugins/voiceMessages/index.tsx
+++ b/src/plugins/voiceMessages/index.tsx
@@ -215,7 +215,7 @@ function Modal({ modalProps }: { modalProps: ModalProps; }) {
 }
 
 const ctxMenuPatch: NavContextMenuPatchCallback = (children, props) => () => {
-    if (props.channel.guild_id && !PermissionStore.can(PermissionsBits.SEND_VOICE_MESSAGES, props.channel)) return;
+    if (props.channel.guild_id && !PermissionStore.can(PermissionsBits.SEND_VOICE_MESSAGES, props.channel) || props.channel.guild.id && !PermissionStore.can(PermissionsBits.SEND_MESSAGES, props.channel)) return;
 
     children.push(
         <Menu.MenuItem

--- a/src/plugins/voiceMessages/index.tsx
+++ b/src/plugins/voiceMessages/index.tsx
@@ -215,7 +215,8 @@ function Modal({ modalProps }: { modalProps: ModalProps; }) {
 }
 
 const ctxMenuPatch: NavContextMenuPatchCallback = (children, props) => () => {
-    if (props.channel.guild_id && !PermissionStore.can(PermissionsBits.SEND_VOICE_MESSAGES, props.channel) || props.channel.guild.id && !PermissionStore.can(PermissionsBits.SEND_MESSAGES, props.channel)) return;
+    console.log(!(PermissionStore.can(PermissionsBits.SEND_MESSAGES, props.channel)));
+    if (props.channel.guild_id && !(PermissionStore.can(PermissionsBits.SEND_VOICE_MESSAGES, props.channel) && PermissionStore.can(PermissionsBits.SEND_MESSAGES, props.channel))) return;
 
     children.push(
         <Menu.MenuItem

--- a/src/plugins/voiceMessages/index.tsx
+++ b/src/plugins/voiceMessages/index.tsx
@@ -215,7 +215,6 @@ function Modal({ modalProps }: { modalProps: ModalProps; }) {
 }
 
 const ctxMenuPatch: NavContextMenuPatchCallback = (children, props) => () => {
-    console.log(!(PermissionStore.can(PermissionsBits.SEND_MESSAGES, props.channel)));
     if (props.channel.guild_id && !(PermissionStore.can(PermissionsBits.SEND_VOICE_MESSAGES, props.channel) && PermissionStore.can(PermissionsBits.SEND_MESSAGES, props.channel))) return;
 
     children.push(

--- a/src/utils/quickCss.ts
+++ b/src/utils/quickCss.ts
@@ -52,9 +52,9 @@ async function initThemes() {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-    initThemes();
-    addSettingsListener("themeLinks", initThemes);
-
     toggle(Settings.useQuickCss);
     addSettingsListener("useQuickCss", toggle);
+
+    initThemes();
+    addSettingsListener("themeLinks", initThemes);
 });

--- a/src/utils/quickCss.ts
+++ b/src/utils/quickCss.ts
@@ -52,9 +52,9 @@ async function initThemes() {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-    toggle(Settings.useQuickCss);
-    addSettingsListener("useQuickCss", toggle);
-
     initThemes();
     addSettingsListener("themeLinks", initThemes);
+
+    toggle(Settings.useQuickCss);
+    addSettingsListener("useQuickCss", toggle);
 });


### PR DESCRIPTION
The upload button is not supposed to appear in channels in which you can't send messages. However, misconfigured channel permissions (or intentional idk) can make it appear thanks to one perm: create threads. In this case, the "Send voice message" button would still appear, but voice messages can't be sent in that channel. This fixes it.

Note: The third commit undoes the first commit since I suck at git so you can ignore those two