### PR TITLE
messageLogger: apply deleted style to ephemeral messages

### DIFF
--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -2,7 +2,10 @@
 .messagelogger-deleted [class*="contents-"] > :is(div, h1, h2, h3, p) {
     color: #f04747 !important;
 }
-
+/* Bot "thinking" text highlighting */
+.messagelogger-deleted [class*="colorStandard-"] :is(div) {
+    color: #f04747 !important;
+}
 /* Embed highlighting */
 .messagelogger-deleted article :is(div, span, h1, h2, h3, p) {
     color: #f04747 !important;

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -4,7 +4,7 @@
 }
 
 /* Bot "thinking" text highlighting */
-.messagelogger-deleted [class*="colorStandard-"] :is(div) {
+div.messagelogger-deleted [class*="colorStandard-"] {
     color: #f04747 !important;
 }
 

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -4,7 +4,7 @@
 }
 
 /* Bot "thinking" text highlighting */
-div.messagelogger-deleted [class*="colorStandard-"] {
+.messagelogger-deleted [class*="colorStandard-"] {
     color: #f04747 !important;
 }
 

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -2,10 +2,12 @@
 .messagelogger-deleted [class*="contents-"] > :is(div, h1, h2, h3, p) {
     color: #f04747 !important;
 }
+
 /* Bot "thinking" text highlighting */
 .messagelogger-deleted [class*="colorStandard-"] :is(div) {
     color: #f04747 !important;
 }
+
 /* Embed highlighting */
 .messagelogger-deleted article :is(div, span, h1, h2, h3, p) {
     color: #f04747 !important;


### PR DESCRIPTION
The bot "thinking" text was previously not shown red when deleted.
I noticed this bug when using YAGPDB's poll feature. When the poll is created, a "YAGPDB.xyz is thinking..." during the creation of the poll, and deleted after. However, it is not shown in red once deleted. Image below.
![image](https://github.com/Vendicated/Vencord/assets/81651922/a0202346-fdb4-43d2-ba17-46493dfcbadb)
This PR should fix this bug.