### PR TITLE
feat(plugin): NoSentryConsole

### DIFF
--- a/src/plugins/_core/noTrack.ts
+++ b/src/plugins/_core/noTrack.ts
@@ -55,7 +55,7 @@ export default definePlugin({
         {
             find: ".installedLogHooks)",
             replacement: {
-                match: /if\(\w\.getDebugLogging\(\)&&!\w.installedLogHooks\)/,
+                match: /if\(\i\.getDebugLogging\(\)&&!\i.installedLogHooks\)/,
                 replace: "if(false)"
             }
         },

--- a/src/plugins/_core/noTrack.ts
+++ b/src/plugins/_core/noTrack.ts
@@ -22,7 +22,7 @@ import definePlugin from "@utils/types";
 export default definePlugin({
     name: "NoTrack",
     description: "Disable Discord's tracking ('science'), metrics and Sentry crash reporting",
-    authors: [Devs.Cyn, Devs.Ven, Devs.Nuckyz],
+    authors: [Devs.Cyn, Devs.Ven, Devs.Nuckyz, Devs.Arrow],
     required: true,
     patches: [
         {
@@ -51,6 +51,13 @@ export default definePlugin({
                     replace: "return;"
                 }
             ]
-        }
+        },
+        {
+            find: ".installedLogHooks)",
+            replacement: {
+                match: /if\(\w\.getDebugLogging\(\)&&!\w.installedLogHooks\)/,
+                replace: "if(false)"
+            }
+        },
     ]
 });

--- a/src/plugins/_core/noTrack.ts
+++ b/src/plugins/_core/noTrack.ts
@@ -55,7 +55,7 @@ export default definePlugin({
         {
             find: ".installedLogHooks)",
             replacement: {
-                match: /if\(\i\.getDebugLogging\(\)&&!\i.installedLogHooks\)/,
+                match: /if\(\i\.getDebugLogging\(\)&&!\i\.installedLogHooks\)/,
                 replace: "if(false)"
             }
         },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -339,6 +339,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Rini",
         id: 1079479184478441643n
     },
+    Arrow: {
+        name: "arrow",
+        id: 958158495302176778n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
**NoSentryConsole**: Disables the sentry console log hook to return breadcrumbs to console. Very useful for development and reporting issues alike.

### The problem
Discord uses Sentry and it will install a hook into the console object.
Doesn't seem that bad, right?
Well, it makes the breadcrumbs/origin in the console from the file that installs that hook,
which ends up making it very hard to tell where non-error logs are coming from!

### The solution
So this plugin just deletes that hook.
The hook doesn't even do anything anyway, thanks to NoTrack.
This just removes that unnecessary code and allows for a much better experience when debugging,
developing plugins, or reporting issues!
![What it does](https://github.com/Vendicated/Vencord/assets/81983357/f0eba75b-f85c-4de8-adbf-a405b594445c)
