### PR TITLE
feat(PermissionsViewer): separated list scrolling, hide irrelevant perms

### DIFF
--- a/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
@@ -21,7 +21,7 @@ import { Flex } from "@components/Flex";
 import { InfoIcon, OwnerCrownIcon } from "@components/Icons";
 import { getUniqueUsername } from "@utils/discord";
 import { ModalCloseButton, ModalContent, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
-import { ContextMenuApi, FluxDispatcher, GuildMemberStore, GuildStore, Menu, PermissionsBits, Text, Tooltip, useEffect, UserStore, useState, useStateFromStores } from "@webpack/common";
+import { ContextMenuApi, FluxDispatcher, GuildMemberStore, GuildStore, Menu, PermissionsBits, ScrollerThin, Text, Tooltip, useEffect, UserStore, useState, useStateFromStores } from "@webpack/common";
 import type { Guild } from "discord-types/general";
 
 import { settings } from "..";
@@ -99,7 +99,7 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
 
                 {selectedItem && (
                     <div className={cl("perms-container")}>
-                        <div className={cl("perms-list")}>
+                        <ScrollerThin className={cl("perms-list")}>
                             {permissions.map((permission, index) => {
                                 const user = UserStore.getUser(permission.id ?? "");
                                 const role = roles[permission.id ?? ""];
@@ -156,8 +156,8 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
                                     </button>
                                 );
                             })}
-                        </div>
-                        <div className={cl("perms-perms")}>
+                        </ScrollerThin>
+                        <ScrollerThin className={cl("perms-perms")}>
                             {Object.entries(PermissionsBits).map(([permissionName, bit]) => (
                                 <div className={cl("perms-perms-item")}>
                                     <div className={cl("perms-perms-item-icon")}>
@@ -184,7 +184,7 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
                                     </Tooltip>
                                 </div>
                             ))}
-                        </div>
+                        </ScrollerThin>
                     </div>
                 )}
             </ModalContent>

--- a/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
@@ -165,25 +165,23 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
                         </ScrollerThin>
                         <ScrollerThin className={cl("perms-perms")}>
                             {Object.entries(PermissionsBits).map(([permissionName, bit]) => {
+                                const { permissions, overwriteAllow, overwriteDeny } = selectedItem;
+                                const permissionValue = permissions !== undefined
+                                    ? permissions === 0n ? PermissionValue.Passthrough
+                                        : (permissions & bit) === bit ? PermissionValue.Allow : PermissionValue.Deny
+                                    : undefined;
+                                const overwriteValue = overwriteAllow !== undefined || overwriteDeny !== undefined
+                                    ? overwriteAllow !== undefined && (overwriteAllow & bit) === bit ? PermissionValue.Allow
+                                        : overwriteDeny !== undefined && (overwriteDeny & bit) === bit ? PermissionValue.Deny
+                                            : PermissionValue.Passthrough
+                                    : undefined;
+                                const computedPermissionValue = overwriteValue !== undefined && overwriteValue !== PermissionValue.Passthrough
+                                    ? overwriteValue
+                                    : permissionValue;
+
                                 return <div className={cl("perms-perms-item")}>
                                     <div className={cl("perms-perms-item-icon")}>
-                                        <PermissionIcon permissionValue={(() => {
-                                            const { permissions, overwriteAllow, overwriteDeny } = selectedItem;
-                                            const permissionValue = permissions !== undefined
-                                                ? permissions === 0n ? PermissionValue.Passthrough
-                                                    : (permissions & bit) === bit ? PermissionValue.Allow : PermissionValue.Deny
-                                                : undefined;
-                                            const overwriteValue = overwriteAllow !== undefined || overwriteDeny !== undefined
-                                                ? overwriteAllow !== undefined && (overwriteAllow & bit) === bit ? PermissionValue.Allow
-                                                    : overwriteDeny !== undefined && (overwriteDeny & bit) === bit ? PermissionValue.Deny
-                                                        : PermissionValue.Passthrough
-                                                : undefined;
-                                            const computedPermissionValue = overwriteValue !== undefined && overwriteValue !== PermissionValue.Passthrough
-                                                ? overwriteValue
-                                                : permissionValue;
-
-                                            return computedPermissionValue ?? PermissionValue.Passthrough;
-                                        })()} />
+                                        <PermissionIcon permissionValue={computedPermissionValue ?? PermissionValue.Passthrough} />
                                     </div>
                                     <Text variant="text-md/normal">{getPermissionString(permissionName)}</Text>
 

--- a/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
@@ -25,7 +25,7 @@ import { ContextMenuApi, FluxDispatcher, GuildMemberStore, GuildStore, Menu, Per
 import type { Guild } from "discord-types/general";
 
 import { settings } from "..";
-import { cl, getPermissionDescription, getPermissionString } from "../utils";
+import { cl, getComputedPermissionValue, getOverwriteValue, getPermissionDescription, getPermissionString, getPermissionValue } from "../utils";
 import { PermissionIcon } from "./icons";
 
 export const enum PermissionType {
@@ -166,18 +166,9 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
                         <ScrollerThin className={cl("perms-perms")}>
                             {Object.entries(PermissionsBits).map(([permissionName, bit]) => {
                                 const { permissions, overwriteAllow, overwriteDeny } = selectedItem;
-                                const permissionValue = permissions !== undefined
-                                    ? permissions === 0n ? PermissionValue.Passthrough
-                                        : (permissions & bit) === bit ? PermissionValue.Allow : PermissionValue.Deny
-                                    : undefined;
-                                const overwriteValue = overwriteAllow !== undefined || overwriteDeny !== undefined
-                                    ? overwriteAllow !== undefined && (overwriteAllow & bit) === bit ? PermissionValue.Allow
-                                        : overwriteDeny !== undefined && (overwriteDeny & bit) === bit ? PermissionValue.Deny
-                                            : PermissionValue.Passthrough
-                                    : undefined;
-                                const computedPermissionValue = overwriteValue !== undefined && overwriteValue !== PermissionValue.Passthrough
-                                    ? overwriteValue
-                                    : permissionValue;
+                                const permissionValue = getPermissionValue(bit, permissions);
+                                const overwriteValue = getOverwriteValue(bit, overwriteAllow, overwriteDeny);
+                                const computedPermissionValue = getComputedPermissionValue(overwriteValue, permissionValue);
 
                                 return <div className={cl("perms-perms-item")}>
                                     <div className={cl("perms-perms-item-icon")}>

--- a/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
@@ -170,7 +170,10 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
                                 const overwriteValue = getOverwriteValue(bit, overwriteAllow, overwriteDeny);
                                 const computedPermissionValue = getComputedPermissionValue(overwriteValue, permissionValue);
 
-                                return <div className={cl("perms-perms-item")}>
+                                return <div className={cl("perms-perms-item")}
+                                    data-vc-permviewer-permission-value={permissionValue}
+                                    data-vc-permviewer-overwrite-value={overwriteValue}
+                                >
                                     <div className={cl("perms-perms-item-icon")}>
                                         <PermissionIcon permissionValue={computedPermissionValue ?? PermissionValue.Passthrough} />
                                     </div>

--- a/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
@@ -213,13 +213,15 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
                                     const permissionValue = getPermissionValue(permissionBit, permissions);
                                     const overwriteValue = getOverwriteValue(permissionBit, overwriteAllow, overwriteDeny);
 
-                                    return <Fragment key={permissionName}>
-                                        <PermissionItem className={cl("perms-perms-items-item")}
-                                            permissionName={permissionName}
-                                            permissionValue={permissionValue}
-                                            overwriteValue={overwriteValue}
-                                        />
-                                    </Fragment>;
+                                    return irrelevantPermissionsHidden && !isPermissionValueRelevant(permissionValue) && !isOverwriteValueRelevant(overwriteValue)
+                                        ? <Fragment key={permissionName} />
+                                        : <Fragment key={permissionName}>
+                                            <PermissionItem className={cl("perms-perms-items-item")}
+                                                permissionName={permissionName}
+                                                permissionValue={permissionValue}
+                                                overwriteValue={overwriteValue}
+                                            />
+                                        </Fragment>;
                                 })}
                             </div>
                         </ScrollerThin>

--- a/src/plugins/permissionsViewer/components/UserPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/UserPermissions.tsx
@@ -104,8 +104,8 @@ function UserPermissionsComponent({ guild, guildMember, showBorder }: { guild: G
                     guildMember.nick || UserStore.getUser(guildMember.userId).username
                 )
             }
-            onDropDownClick={state => settings.store.defaultPermissionsDropdownState = !state}
-            defaultState={settings.store.defaultPermissionsDropdownState}
+            onDropDownClick={state => settings.store.permissionsDropdownOpenByDefault = !state}
+            defaultState={settings.store.permissionsDropdownOpenByDefault}
             buttons={[
                 (<Tooltip text={`Sorting by ${stns.permissionsSortOrder === PermissionsSortOrder.HighestRole ? "Highest Role" : "Lowest Role"}`}>
                     {tooltipProps => (

--- a/src/plugins/permissionsViewer/components/icons.tsx
+++ b/src/plugins/permissionsViewer/components/icons.tsx
@@ -18,9 +18,9 @@
 
 import { PermissionValue } from "./RolesAndUsersPermissions";
 
-export function PermissionDeniedIcon() {
+export function PermissionDeniedIcon({ ...props }: {} & React.SVGProps<SVGSVGElement>) {
     return (
-        <svg
+        <svg {...props}
             height="24"
             width="24"
             viewBox="0 0 24 24"
@@ -31,9 +31,9 @@ export function PermissionDeniedIcon() {
     );
 }
 
-export function PermissionPassthroughIcon() {
+export function PermissionPassthroughIcon({ ...props }: {} & React.SVGProps<SVGSVGElement>) {
     return (
-        <svg
+        <svg {...props}
             height="24"
             width="24"
             viewBox="0 0 16 16"
@@ -46,9 +46,9 @@ export function PermissionPassthroughIcon() {
     );
 }
 
-export function PermissionAllowedIcon() {
+export function PermissionAllowedIcon({ ...props }: {} & React.SVGProps<SVGSVGElement>) {
     return (
-        <svg
+        <svg {...props}
             height="24"
             width="24"
             viewBox="0 0 24 24"
@@ -59,10 +59,10 @@ export function PermissionAllowedIcon() {
     );
 }
 
-export function PermissionIcon({ permissionValue }: { permissionValue: PermissionValue; }) {
+export function PermissionIcon({ permissionValue, ...props }: { permissionValue: PermissionValue; } & React.SVGProps<SVGSVGElement>) {
     switch (permissionValue) {
-        case PermissionValue.Deny: return PermissionDeniedIcon();
-        case PermissionValue.Allow: return PermissionAllowedIcon();
-        case PermissionValue.Passthrough: return PermissionPassthroughIcon();
+        case PermissionValue.Deny: return PermissionDeniedIcon(props);
+        case PermissionValue.Allow: return PermissionAllowedIcon(props);
+        case PermissionValue.Passthrough: return PermissionPassthroughIcon(props);
     }
 }

--- a/src/plugins/permissionsViewer/components/icons.tsx
+++ b/src/plugins/permissionsViewer/components/icons.tsx
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { PermissionValue } from "./RolesAndUsersPermissions";
+
 export function PermissionDeniedIcon() {
     return (
         <svg
@@ -25,6 +27,21 @@ export function PermissionDeniedIcon() {
         >
             <title>Denied</title>
             <path fill="var(--status-danger)" d="M18.4 4L12 10.4L5.6 4L4 5.6L10.4 12L4 18.4L5.6 20L12 13.6L18.4 20L20 18.4L13.6 12L20 5.6L18.4 4Z" />
+        </svg>
+    );
+}
+
+export function PermissionPassthroughIcon() {
+    return (
+        <svg
+            height="24"
+            width="24"
+            viewBox="0 0 16 16"
+        >
+            <g>
+                <title>Not overwritten</title>
+                <polygon fill="var(--text-normal)" points="12 2.32 10.513 2 4 13.68 5.487 14" />
+            </g>
         </svg>
     );
 }
@@ -42,17 +59,10 @@ export function PermissionAllowedIcon() {
     );
 }
 
-export function PermissionDefaultIcon() {
-    return (
-        <svg
-            height="24"
-            width="24"
-            viewBox="0 0 16 16"
-        >
-            <g>
-                <title>Not overwritten</title>
-                <polygon fill="var(--text-normal)" points="12 2.32 10.513 2 4 13.68 5.487 14" />
-            </g>
-        </svg>
-    );
+export function PermissionIcon({ permissionValue }: { permissionValue: PermissionValue; }) {
+    switch (permissionValue) {
+        case PermissionValue.Deny: return PermissionDeniedIcon();
+        case PermissionValue.Allow: return PermissionAllowedIcon();
+        case PermissionValue.Passthrough: return PermissionPassthroughIcon();
+    }
 }

--- a/src/plugins/permissionsViewer/index.tsx
+++ b/src/plugins/permissionsViewer/index.tsx
@@ -49,11 +49,16 @@ export const settings = definePluginSettings({
             { label: "Lowest Role", value: PermissionsSortOrder.LowestRole }
         ],
     },
-    defaultPermissionsDropdownState: {
+    irrelevantPermissionsHiddenByDefault: {
+        description: "Whether irrelevant permissions should be hidden by default in the viewer",
+        type: OptionType.BOOLEAN,
+        default: false,
+    },
+    permissionsDropdownOpenByDefault: {
         description: "Whether the permissions dropdown on user popouts should be open by default",
         type: OptionType.BOOLEAN,
         default: false,
-    }
+    },
 });
 
 function MenuItem(guildId: string, id?: string, type?: MenuItemParentType) {

--- a/src/plugins/permissionsViewer/index.tsx
+++ b/src/plugins/permissionsViewer/index.tsx
@@ -158,7 +158,7 @@ function makeContextMenuPatch(childId: string | string[], type?: MenuItemParentT
 export default definePlugin({
     name: "PermissionsViewer",
     description: "View the permissions a user or channel has, and the roles of a server",
-    authors: [Devs.Nuckyz, Devs.Ven],
+    authors: [Devs.Nuckyz, Devs.Ven, Devs.bb010g],
     settings,
 
     patches: [

--- a/src/plugins/permissionsViewer/styles.css
+++ b/src/plugins/permissionsViewer/styles.css
@@ -53,6 +53,8 @@
 }
 
 .vc-permviewer-perms-container {
+    box-sizing: border-box;
+    height: 100%;
     display: grid;
     grid-template-columns: 1fr 2fr;
     grid-template-areas: "list permissions";

--- a/src/plugins/permissionsViewer/styles.css
+++ b/src/plugins/permissionsViewer/styles.css
@@ -140,6 +140,10 @@
     column-gap: var(--vc-permviewer-perm-item-column-gap);
 }
 
+.vc-permviewer-perms-perms-hide-irrelevant-permissions .vc-permviewer-perm-is-irrelevant {
+    display: none;
+}
+
 .vc-permviewer-perm-item-icon {
     grid-column: vc-permviewer-perm-item-icon;
     grid-row: vc-permviewer-perm-item-icon;

--- a/src/plugins/permissionsViewer/styles.css
+++ b/src/plugins/permissionsViewer/styles.css
@@ -114,40 +114,57 @@
 }
 
 .vc-permviewer-perms-perms {
+    --vc-permviewer-perms-perms-row-gap: 10px;
+    --vc-permviewer-perms-perms-column-gap: 10px;
+    --vc-permviewer-perms-perms-row-border-width: 2px;
+    --vc-permviewer-perm-item-row-gap: var(--vc-permviewer-perms-perms-row-gap);
+    --vc-permviewer-perm-item-column-gap: var(--vc-permviewer-perms-perms-column-gap);
+    --vc-permviewer-perm-item-border-width: var(--vc-permviewer-perms-perms-row-border-width);
+
     grid-area: permissions;
     display: flex;
     flex-direction: column;
     margin-left: 5px;
 }
 
-.vc-permviewer-perms-perms-item {
-    position: relative;
-    display: flex;
+.vc-permviewer-perms-perms-items {
+    display: grid;
+}
+
+.vc-permviewer-perm-item {
+    display: grid;
     align-items: center;
-    padding: 10px;
-    border-bottom: 2px solid var(--background-modifier-active);
+    padding: var(--vc-permviewer-perm-item-row-gap) var(--vc-permviewer-perm-item-column-gap);
+    border-bottom: var(--vc-permviewer-perm-item-border-width) solid var(--background-modifier-active);
+    grid-template: "vc-permviewer-perm-item-icon vc-permviewer-perm-item-title vc-permviewer-perm-item-info" 1fr / auto 1fr auto;
+    column-gap: var(--vc-permviewer-perm-item-column-gap);
 }
 
-.vc-permviewer-perms-perms-item:last-child {
-    border: 0;
-}
-
-.vc-permviewer-perms-perms-item-icon {
+.vc-permviewer-perm-item-icon {
+    grid-column: vc-permviewer-perm-item-icon;
+    grid-row: vc-permviewer-perm-item-icon;
     border: 1px solid var(--background-modifier-selected);
     width: 24px;
     height: 24px;
-    margin-right: 5px;
 }
 
-.vc-permviewer-perms-perms-item .vc-info-icon {
+.vc-permviewer-perm-item-title {
+    grid-column: vc-permviewer-perm-item-title;
+    grid-row: vc-permviewer-perm-item-title;
+}
+
+.vc-permviewer-perm-item-info {
+    grid-column: vc-permviewer-perm-item-info;
+    grid-row: vc-permviewer-perm-item-title;
+}
+
+.vc-permviewer-perm-item > .vc-info-icon {
     color: var(--interactive-muted);
     cursor: pointer;
-    position: absolute;
-    right: 0;
     scale: 0.9;
     transition: color ease-in 0.1s;
 }
 
-.vc-permviewer-perms-perms-item .vc-info-icon:hover {
+.vc-permviewer-perm-item > .vc-info-icon:hover {
     color: var(--interactive-active);
 }

--- a/src/plugins/permissionsViewer/utils.ts
+++ b/src/plugins/permissionsViewer/utils.ts
@@ -23,7 +23,7 @@ import { Guild, GuildMember, Role } from "discord-types/general";
 import type { ReactNode } from "react";
 
 import { PermissionsSortOrder, settings } from ".";
-import { PermissionType } from "./components/RolesAndUsersPermissions";
+import { PermissionType, PermissionValue } from "./components/RolesAndUsersPermissions";
 
 export const cl = classNameFactory("vc-permviewer-");
 
@@ -65,6 +65,48 @@ export function getPermissionDescription(permission: string): ReactNode {
     if (typeof msg === "string") return msg;
 
     return "";
+}
+
+export function getPermissionValue(permissionBit: bigint, permissions: bigint): PermissionValue;
+export function getPermissionValue(permissionBit: bigint, permissions: undefined): undefined;
+export function getPermissionValue(permissionBit: bigint, permissions?: bigint): PermissionValue | undefined;
+export function getPermissionValue(permissionBit: bigint, permissions?: bigint): PermissionValue | undefined {
+    return permissions !== undefined
+        ? permissions === 0n ? PermissionValue.Passthrough
+            : (permissions & permissionBit) === permissionBit ? PermissionValue.Allow : PermissionValue.Deny
+        : undefined;
+}
+
+export function getOverwriteValue(permissionBit: bigint, overwriteAllow: bigint, overwriteDeny: bigint): PermissionValue;
+export function getOverwriteValue(permissionBit: bigint, overwriteAllow: undefined, overwriteDeny: bigint): PermissionValue;
+export function getOverwriteValue(permissionBit: bigint, overwriteAllow: bigint, overwriteDeny: undefined): PermissionValue;
+export function getOverwriteValue(permissionBit: bigint, overwriteAllow: undefined, overwriteDeny: undefined): undefined;
+export function getOverwriteValue(permissionBit: bigint, overwriteAllow?: bigint, overwriteDeny?: bigint): PermissionValue | undefined;
+export function getOverwriteValue(permissionBit: bigint, overwriteAllow?: bigint, overwriteDeny?: bigint): PermissionValue | undefined {
+    return overwriteAllow !== undefined || overwriteDeny !== undefined
+        ? overwriteAllow !== undefined && (overwriteAllow & permissionBit) === permissionBit ? PermissionValue.Allow
+            : overwriteDeny !== undefined && (overwriteDeny & permissionBit) === permissionBit ? PermissionValue.Deny
+                : PermissionValue.Passthrough
+        : undefined;
+}
+
+export function isPermissionValueRelevant<T extends PermissionValue>(permissionValue?: T): permissionValue is Exclude<T, PermissionValue.Passthrough | PermissionValue.Deny> {
+    return permissionValue !== undefined && permissionValue !== PermissionValue.Passthrough &&
+        permissionValue !== PermissionValue.Deny;
+}
+
+export function isOverwriteValueRelevant<T extends PermissionValue>(overwriteValue?: T): overwriteValue is Exclude<T, PermissionValue.Passthrough> {
+    return overwriteValue !== undefined && overwriteValue !== PermissionValue.Passthrough;
+}
+
+export function getComputedPermissionValue<T extends PermissionValue, U extends PermissionValue>(overwriteValue: T, permissionValue: U): Exclude<T, PermissionValue.Passthrough> | U;
+export function getComputedPermissionValue<T extends PermissionValue, U extends PermissionValue>(overwriteValue: undefined, permissionValue: U): U;
+export function getComputedPermissionValue<T extends PermissionValue, U extends PermissionValue>(overwriteValue: undefined, permissionValue: undefined): undefined;
+export function getComputedPermissionValue<T extends PermissionValue, U extends PermissionValue>(overwriteValue: T | undefined, permissionValue: undefined): Exclude<T, PermissionValue.Passthrough> | undefined;
+export function getComputedPermissionValue<T extends PermissionValue, U extends PermissionValue>(overwriteValue: undefined, permissionValue: U | undefined): U | undefined;
+export function getComputedPermissionValue<T extends PermissionValue, U extends PermissionValue>(overwriteValue: T | undefined, permissionValue: U | undefined): Exclude<T, PermissionValue.Passthrough> | U | undefined;
+export function getComputedPermissionValue<T extends PermissionValue, U extends PermissionValue>(overwriteValue?: T, permissionValue?: U): Exclude<T, PermissionValue.Passthrough> | U | undefined {
+    return isOverwriteValueRelevant(overwriteValue) ? overwriteValue : permissionValue;
 }
 
 export function getSortedRoles({ id }: Guild, member: GuildMember) {

--- a/src/webpack/common/react.ts
+++ b/src/webpack/common/react.ts
@@ -19,6 +19,7 @@
 // eslint-disable-next-line path-alias/no-relative
 import { findByPropsLazy, waitFor } from "../webpack";
 
+export let Fragment: typeof React.Fragment;
 export let React: typeof import("react");
 export let useState: typeof React.useState;
 export let useEffect: typeof React.useEffect;
@@ -31,5 +32,5 @@ export const ReactDOM: typeof import("react-dom") & typeof import("react-dom/cli
 
 waitFor("useState", m => {
     React = m;
-    ({ useEffect, useState, useMemo, useRef, useReducer, useCallback } = React);
+    ({ Fragment, useEffect, useState, useMemo, useRef, useReducer, useCallback } = React);
 });


### PR DESCRIPTION
The role listing in the permissions viewer can now be scrolled separately from the permissions listing. Additionally, the permission list scroll position is preserved when changing which role is displayed.

The permissions viewer permissions listing now has a toggle to hide permissions which are irrelevant to the computed permission set. By default, all permissions are shown, but this default can be changed. You can also hide or show irrelevant permissions for just the current permissions viewer instance. This hiding is performed via CSS, for efficiency.

## Screenshots

![DiscordCanary_14wtHuIeR7](https://github.com/Vendicated/Vencord/assets/340132/4f574971-f333-42f0-b47d-1d70da57b210)

![DiscordCanary_abGgfrd2z1](https://github.com/Vendicated/Vencord/assets/340132/b6e262a3-1bcd-4473-826e-fa703758b690)