### PR TITLE
plugins(NormalizeResourceLinks): create plugin

### DIFF
--- a/src/plugins/normalizeMessageLinks/index.ts
+++ b/src/plugins/normalizeMessageLinks/index.ts
@@ -8,19 +8,19 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 
 export default definePlugin({
-    name: "NormalizeResourceLinks",
-    description: "Normalize resource links to match stable Discord",
+    name: "NormalizeMessageLinks",
+    description: "Strip canary/ptb from message links",
     authors: [Devs.bb010g],
     patches: [
         {
             find: ".Messages.COPY_MESSAGE_LINK,",
             replacement: {
                 match: /\.concat\(location\.host\)/,
-                replace: ".concat(self.normalizeResourceHost(location.host))",
+                replace: ".concat($self.normalizeHost(location.host))",
             },
         },
     ],
-    normalizeResourceHost(host: string) {
+    normalizeHost(host: string) {
         return host.replace(/(^|\b)(canary\.|ptb\.)(discord.com)$/, "$1$3");
     },
 });

--- a/src/plugins/normalizeResourceLinks/index.ts
+++ b/src/plugins/normalizeResourceLinks/index.ts
@@ -15,8 +15,8 @@ export default definePlugin({
         {
             find: ".Messages.COPY_MESSAGE_LINK,",
             replacement: {
-                match: /(\.concat\()(location\.host)(\))/,
-                replace: "$1$self.normalizeResourceHost($2)$3",
+                match: /\.concat\(location\.host\)/,
+                replace: ".concat(self.normalizeResourceHost(location.host))",
             },
         },
     ],

--- a/src/plugins/normalizeResourceLinks/index.ts
+++ b/src/plugins/normalizeResourceLinks/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NormalizeResourceLinks",
+    description: "Normalize resource links to match stable Discord",
+    authors: [Devs.bb010g],
+    patches: [
+        {
+            find: ".Messages.COPY_MESSAGE_LINK,",
+            replacement: {
+                match: /(\.concat\()(location\.host)(\))/,
+                replace:
+                    "$1Vencord.Plugins.plugins.NormalizeResourceLinks.normalizeResourceHost($2)$3",
+            },
+        },
+    ],
+    normalizeResourceHost(host: string) {
+        return host.replace(/(^|[^a-z-])(canary\.|ptb\.)(discord.com)$/, "$1$3");
+    },
+});

--- a/src/plugins/normalizeResourceLinks/index.ts
+++ b/src/plugins/normalizeResourceLinks/index.ts
@@ -17,7 +17,7 @@ export default definePlugin({
             replacement: {
                 match: /(\.concat\()(location\.host)(\))/,
                 replace:
-                    "$1Vencord.Plugins.plugins.NormalizeResourceLinks.normalizeResourceHost($2)$3",
+                    "$1$self.normalizeResourceHost($2)$3",
             },
         },
     ],

--- a/src/plugins/normalizeResourceLinks/index.ts
+++ b/src/plugins/normalizeResourceLinks/index.ts
@@ -16,12 +16,11 @@ export default definePlugin({
             find: ".Messages.COPY_MESSAGE_LINK,",
             replacement: {
                 match: /(\.concat\()(location\.host)(\))/,
-                replace:
-                    "$1$self.normalizeResourceHost($2)$3",
+                replace: "$1$self.normalizeResourceHost($2)$3",
             },
         },
     ],
     normalizeResourceHost(host: string) {
-        return host.replace(/(^|[^a-z-])(canary\.|ptb\.)(discord.com)$/, "$1$3");
+        return host.replace(/(^|\b)(canary\.|ptb\.)(discord.com)$/, "$1$3");
     },
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -347,6 +347,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "arrow",
         id: 958158495302176778n
     },
+    bb010g: {
+        name: "bb010g",
+        id: 72791153467990016n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Finally, I can stop manually removing the `canary.` from my copied links

This patches the copy link button action (which directly reads ambient `location.host`), because any deeper patches would risk breaking functionality.