### PR TITLE
feat(PronounDB): update to v2 API

### DIFF
--- a/src/plugins/pronoundb/pronoundbUtils.ts
+++ b/src/plugins/pronoundb/pronoundbUtils.ts
@@ -128,7 +128,7 @@ async function bulkFetchPronouns(ids: string[]): Promise<PronounsResponse> {
     params.append("ids", ids.join(","));
 
     try {
-        const req = await fetch("https://pronoundb.org/api/v1/lookup-bulk?" + params.toString(), {
+        const req = await fetch("https://pronoundb.org/api/v2/lookup?" + params.toString(), {
             method: "GET",
             headers: {
                 "Accept": "application/json",
@@ -137,8 +137,9 @@ async function bulkFetchPronouns(ids: string[]): Promise<PronounsResponse> {
         });
         return await req.json()
             .then((res: PronounsResponse) => {
-                Object.assign(cache, res);
-                return res;
+                const translatedRes = Object.fromEntries(Object.entries(res).map(([k, v]) => [k, v.sets?.en?.join("/") ?? "unspecified"]));
+                Object.assign(cache, translatedRes);
+                return translatedRes;
             });
     } catch (e) {
         // If the request errors, treat it as if no pronouns were found for all ids, and log it
@@ -150,14 +151,21 @@ async function bulkFetchPronouns(ids: string[]): Promise<PronounsResponse> {
 }
 
 export function formatPronouns(pronouns: string): string {
+    let formattedPronouns;
+    if (pronouns.includes("/")) {
+        formattedPronouns = pronouns.split("/").map(x => PronounMapping[x].split(/[\/ ]/)[0]).join("/");
+    } else {
+        formattedPronouns = PronounMapping[pronouns];
+    }
+
     const { pronounsFormat } = Settings.plugins.PronounDB as { pronounsFormat: PronounsFormat, enabled: boolean; };
     // For capitalized pronouns, just return the mapping (it is by default capitalized)
-    if (pronounsFormat === PronounsFormat.Capitalized) return PronounMapping[pronouns];
+    if (pronounsFormat === PronounsFormat.Capitalized) return formattedPronouns;
     // If it is set to lowercase and a special code (any, ask, avoid), then just return the capitalized text
     else if (
         pronounsFormat === PronounsFormat.Lowercase
         && ["any", "ask", "avoid", "other"].includes(pronouns)
-    ) return PronounMapping[pronouns];
+    ) return formattedPronouns;
     // Otherwise (lowercase and not a special code), then convert the mapping to lowercase
-    else return PronounMapping[pronouns].toLowerCase();
+    else return formattedPronouns.toLowerCase();
 }

--- a/src/plugins/pronoundb/pronoundbUtils.ts
+++ b/src/plugins/pronoundb/pronoundbUtils.ts
@@ -151,7 +151,7 @@ async function bulkFetchPronouns(ids: string[]): Promise<PronounsResponse> {
 }
 
 export function formatPronouns(pronouns: string): string {
-    let formattedPronouns;
+    let formattedPronouns: string;
     if (pronouns.includes("/")) {
         formattedPronouns = pronouns.split("/").map(x => PronounMapping[x].split(/[\/ ]/)[0]).join("/");
     } else {

--- a/src/plugins/pronoundb/pronoundbUtils.ts
+++ b/src/plugins/pronoundb/pronoundbUtils.ts
@@ -153,7 +153,7 @@ async function bulkFetchPronouns(ids: string[]): Promise<PronounsResponse> {
 export function formatPronouns(pronouns: string): string {
     let formattedPronouns: string;
     if (pronouns.includes("/")) {
-        formattedPronouns = pronouns.split("/").map(x => PronounMapping[x].split(/[\/ ]/)[0]).join("/");
+        formattedPronouns = pronouns.split("/").map(x => PronounMapping[x].split(/[/ ]/)[0]).join("/");
     } else {
         formattedPronouns = PronounMapping[pronouns];
     }

--- a/src/plugins/pronoundb/types.ts
+++ b/src/plugins/pronoundb/types.ts
@@ -26,31 +26,22 @@ export interface UserProfilePronounsProps {
 }
 
 export interface PronounsResponse {
-    [id: string]: PronounCode;
+    [userId: string]: {
+        sets: {
+            [locale: string]: string[]
+        }
+    }
 }
 
 export type PronounCode = keyof typeof PronounMapping;
 
 export const PronounMapping = {
-    hh: "He/Him",
-    hi: "He/It",
-    hs: "He/She",
-    ht: "He/They",
-    ih: "It/Him",
-    ii: "It/Its",
-    is: "It/She",
-    it: "It/They",
-    shh: "She/He",
-    sh: "She/Her",
-    si: "She/It",
-    st: "She/They",
-    th: "They/He",
-    ti: "They/It",
-    ts: "They/She",
-    tt: "They/Them",
+    he: "He/Him",
+    it: "It/Its",
+    she: "She/Her",
+    they: "They/Them",
     any: "Any pronouns",
     other: "Other pronouns",
     ask: "Ask me my pronouns",
     avoid: "Avoid pronouns, use my name",
-    unspecified: "Unspecified"
 } as const;


### PR DESCRIPTION
The new version of PronounDB supports pronoun sets like "he/any" and "he/she/they".

For multiple pronouns, it will show up like "he/any" or "He/Any", but for single pronouns it will still show up like "he/him" or "He/Him" or "Any pronouns".

Multi-language pronouns are also supported now, but I've chosen to hardcode English for now. This can be reevaluated later.