### PR TITLE
ClearURLs: Add si parameter on youtu.be

### DIFF
--- a/src/plugins/clearURLs/defaultRules.ts
+++ b/src/plugins/clearURLs/defaultRules.ts
@@ -127,6 +127,7 @@ export const defaultRules = [
     "redircnt@yandex.*",
     "feature@youtube.com",
     "kw@youtube.com",
+    "si@youtu.be",
     "wt_zmc",
     "utm_source",
     "utm_content",


### PR DESCRIPTION
Add the new `si` parameter to ClearURLs that has recently been added to sharing modals across YouTube.

![example](https://github.com/Vendicated/Vencord/assets/22241432/dcfee33f-cb3b-4605-b2ae-f9d17fe11f02)

Thanks,
pointy