### PR TITLE
feat(plugin): ShowTimeouts

### DIFF
--- a/src/plugins/showTimeouts.ts
+++ b/src/plugins/showTimeouts.ts
@@ -21,7 +21,7 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "ShowTimeouts",
-    description: "Shows member timeout chat badges without permission.",
+    description: "Display member timeout icons in chat regardless of permissions.",
     authors: [Devs.Dolfies],
     patches: [
         {

--- a/src/plugins/showTimeouts.ts
+++ b/src/plugins/showTimeouts.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "ShowTimeouts",
+    description: "Shows timed out members without perms.",
+    authors: [Devs.Dolfies],
+    patches: [
+        {
+            find: "showCommunicationDisabledStyles",
+            replacement: {
+                match: /&&\i\.\i\.canManageUser\(\i\.\i\.MODERATE_MEMBERS,\i\.author,\i\)/,
+                replace: "",
+            },
+        },
+    ],
+});

--- a/src/plugins/showTimeouts.ts
+++ b/src/plugins/showTimeouts.ts
@@ -21,7 +21,7 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "ShowTimeouts",
-    description: "Shows timed out members without permission.",
+    description: "Shows member timeout chat badges without permission.",
     authors: [Devs.Dolfies],
     patches: [
         {

--- a/src/plugins/showTimeouts.ts
+++ b/src/plugins/showTimeouts.ts
@@ -21,7 +21,7 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "ShowTimeouts",
-    description: "Shows timed out members without perms.",
+    description: "Shows timed out members without permission.",
     authors: [Devs.Dolfies],
     patches: [
         {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -355,6 +355,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "bb010g",
         id: 72791153467990016n,
     },
+    Dolfies: {
+        name: "Dolfies",
+        id: 852892297661906993n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
### Summary
Shows the timeout chat badge without moderate member perms.

![screenshot](https://i.dolfi.es/5CPjDkWgrt.png?key=1uNxch8Z3Y6LIU)