### PR TITLE
add oneko setting for custom spritesheet URL

### DIFF
--- a/src/plugins/oneko.ts
+++ b/src/plugins/oneko.ts
@@ -16,19 +16,29 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
-import definePlugin from "@utils/types";
+import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    onekoSpritesheetURL: {
+        type: OptionType.STRING,
+        description: "oneko spritesheet URL",
+        default: "https://raw.githubusercontent.com/adryd325/oneko.js/14bab15a755d0e35cd4ae19c931d96d306f99f42/oneko.gif"
+    }
+});
 
 export default definePlugin({
     name: "oneko",
     description: "cat follow mouse (real)",
     // Listing adryd here because this literally just evals her script
     authors: [Devs.Ven, Devs.adryd],
+    settings: settings,
 
     start() {
         fetch("https://raw.githubusercontent.com/adryd325/oneko.js/5977144dce83e4d71af1de005d16e38eebeb7b72/oneko.js")
             .then(x => x.text())
-            .then(s => s.replace("./oneko.gif", "https://raw.githubusercontent.com/adryd325/oneko.js/14bab15a755d0e35cd4ae19c931d96d306f99f42/oneko.gif"))
+            .then(s => s.replace("./oneko.gif", settings.store.onekoSpritesheetURL))
             .then(eval);
     },
 


### PR DESCRIPTION
This commit adds a setting to the oneko plugin for custom oneko.gif URL support.