### PR TITLE
Make new plugins show at the top of the Plugins settings

### DIFF
--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -257,8 +257,7 @@ export default function PluginSettings() {
     if (newPlugins != null) {
         const combinedArray = [...new Set([...newPlugins, ...sortedPlugins.map(obj => obj.name)])];
         sortedPlugins = combinedArray
-            .map(name => sortedPlugins.find(obj => obj.name === name)!)
-            .filter(obj => obj !== undefined);
+            .map(name => sortedPlugins.find(obj => obj.name === name)!);
     }
 
 

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -215,9 +215,6 @@ export default function PluginSettings() {
         return o;
     }, []);
 
-    const sortedPlugins = React.useMemo(() => Object.values(Plugins)
-        .sort((a, b) => a.name.localeCompare(b.name)), []);
-
     const [searchValue, setSearchValue] = React.useState({ value: "", status: SearchStatus.ALL });
 
     const onSearch = (query: string) => setSearchValue(prev => ({ ...prev, value: query }));
@@ -238,6 +235,9 @@ export default function PluginSettings() {
         );
     };
 
+    let sortedPlugins = React.useMemo(() => Object.values(Plugins)
+        .sort((a, b) => a.name.localeCompare(b.name)), []);
+
     const [newPlugins] = useAwaiter(() => DataStore.get("Vencord_existingPlugins").then((cachedPlugins: Record<string, number> | undefined) => {
         const now = Date.now() / 1000;
         const existingTimestamps: Record<string, number> = {};
@@ -254,6 +254,13 @@ export default function PluginSettings() {
 
         return window._.isEqual(newPlugins, sortedPluginNames) ? [] : newPlugins;
     }));
+    if (newPlugins != null) {
+        const combinedArray = [...new Set([...newPlugins, ...sortedPlugins.map(obj => obj.name)])];
+        sortedPlugins = combinedArray
+            .map(name => sortedPlugins.find(obj => obj.name === name)!)
+            .filter(obj => obj !== undefined);
+    }
+
 
     type P = JSX.Element | JSX.Element[];
     let plugins: P, requiredPlugins: P;


### PR DESCRIPTION
![](https://cdn.discordapp.com/attachments/1020339327831658629/1149731604579758120/image.png)
Unfortunately, the `zTestPlugin` visible in the screenshot is not included with this PR.