### PR TITLE
InvisibleChat: fixup decryption modal

### DIFF
--- a/src/plugins/invisibleChat/components/DecryptionModal.tsx
+++ b/src/plugins/invisibleChat/components/DecryptionModal.tsx
@@ -28,7 +28,7 @@ import { Button, Forms, React, TextInput } from "@webpack/common";
 import { decrypt } from "../index";
 
 export function DecModal(props: any) {
-    const secret: string = props?.message?.content;
+    const encryptedMessage: string = props?.message?.content;
     const [password, setPassword] = React.useState("password");
 
     return (
@@ -38,9 +38,9 @@ export function DecModal(props: any) {
             </ModalHeader>
 
             <ModalContent>
-                <Forms.FormTitle tag="h5" style={{ marginTop: "10px" }}>Secret</Forms.FormTitle>
-                <TextInput defaultValue={secret} disabled={true}></TextInput>
-                <Forms.FormTitle tag="h5">Password</Forms.FormTitle>
+                <Forms.FormTitle tag="h5" style={{ marginTop: "10px" }}>Message with Encryption</Forms.FormTitle>
+                <TextInput defaultValue={encryptedMessage} disabled={true}></TextInput>
+                <Forms.FormTitle tag="h5" style={{ marginTop: "10px" }}>Password</Forms.FormTitle>
                 <TextInput
                     style={{ marginBottom: "20px" }}
                     onChange={setPassword}
@@ -51,7 +51,7 @@ export function DecModal(props: any) {
                 <Button
                     color={Button.Colors.GREEN}
                     onClick={() => {
-                        const toSend = decrypt(secret, password, true);
+                        const toSend = decrypt(encryptedMessage, password, true);
                         if (!toSend || !props?.message) return;
                         // @ts-expect-error
                         Vencord.Plugins.plugins.InvisibleChat.buildEmbed(props?.message, toSend);

--- a/src/plugins/invisibleChat/index.tsx
+++ b/src/plugins/invisibleChat/index.tsx
@@ -225,8 +225,8 @@ export function encrypt(secret: string, password: string, cover: string): string
     return steggo.hide(secret + "\u200b", password, cover);
 }
 
-export function decrypt(secret: string, password: string, removeIndicator: boolean): string {
-    const decrypted = steggo.reveal(secret, password);
+export function decrypt(encrypted: string, password: string, removeIndicator: boolean): string {
+    const decrypted = steggo.reveal(encrypted, password);
     return removeIndicator ? decrypted.replace("\u200b", "") : decrypted;
 }
 


### PR DESCRIPTION
`secret` is used for both the message with encryption and the message obtained after decrypting -- clarified difference between them in code and modal itself.
also added spacing between the two fields as they were colliding before and didn't look great
(attached: before and after changes)
![image](https://github.com/Vendicated/Vencord/assets/144252537/52a7b0d1-4ad6-4398-813f-79a65ac89fb8)
![image](https://github.com/Vendicated/Vencord/assets/144252537/de25d66a-3a9f-4431-ba9d-13262e5bc1b5)
