### PR TITLE
lastfm: Add setting for artist name and song title only

### DIFF
--- a/src/plugins/lastfm.tsx
+++ b/src/plugins/lastfm.tsx
@@ -76,6 +76,8 @@ const enum NameFormat {
     StatusName = "status-name",
     ArtistFirst = "artist-first",
     SongFirst = "song-first",
+    ArtistOnly = "artist-name-only",
+    SongOnly = "song-title-only"
 }
 
 const applicationId = "1108588077900898414";
@@ -143,6 +145,14 @@ const settings = definePluginSettings({
             {
                 label: "Use format 'song - artist'",
                 value: NameFormat.SongFirst
+            },
+            {
+                label: "Use artist name only",
+                value: NameFormat.ArtistOnly
+            },
+            {
+                label: "Use song name only",
+                value: NameFormat.SongOnly
             }
         ],
     },
@@ -171,7 +181,7 @@ const settings = definePluginSettings({
 export default definePlugin({
     name: "LastFMRichPresence",
     description: "Little plugin for Last.fm rich presence",
-    authors: [Devs.dzshn, Devs.RuiNtD, Devs.blahajZip],
+    authors: [Devs.dzshn, Devs.RuiNtD, Devs.blahajZip, Devs.archeruwu],
 
     settingsAboutComponent: () => (
         <>
@@ -298,6 +308,10 @@ export default definePlugin({
                     return trackData.artist + " - " + trackData.name;
                 case NameFormat.SongFirst:
                     return trackData.name + " - " + trackData.artist;
+                case NameFormat.ArtistOnly:
+                    return trackData.artist;
+                case NameFormat.SongOnly:
+                    return trackData.name;
                 default:
                     return settings.store.statusName;
             }

--- a/src/plugins/lastfm.tsx
+++ b/src/plugins/lastfm.tsx
@@ -76,8 +76,8 @@ const enum NameFormat {
     StatusName = "status-name",
     ArtistFirst = "artist-first",
     SongFirst = "song-first",
-    ArtistOnly = "artist-name-only",
-    SongOnly = "song-title-only"
+    ArtistOnly = "artist",
+    SongOnly = "song"
 }
 
 const applicationId = "1108588077900898414";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -370,6 +370,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     blahajZip: {
         name: "blahaj.zip",
         id: 683954422241427471n,
+    },
+    archeruwu: {
+        name: "archer_uwu",
+        id: 160068695383736320n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
Adds 2 more options to the lastfm plugin

Artist Only:
![image](https://github.com/Vendicated/Vencord/assets/18449883/f9f45bd5-8abf-4d62-a213-eec59c5c5848)


Title Only:
![image](https://github.com/Vendicated/Vencord/assets/18449883/faad12f4-74ac-4bdf-8074-3f3cbfa66c99)

