### PR TITLE
ClearURLs: Add si parameter on youtube.com

### DIFF
--- a/src/plugins/clearURLs/defaultRules.ts
+++ b/src/plugins/clearURLs/defaultRules.ts
@@ -127,6 +127,7 @@ export const defaultRules = [
     "redircnt@yandex.*",
     "feature@youtube.com",
     "kw@youtube.com",
+    "si@youtube.com",
     "si@youtu.be",
     "wt_zmc",
     "utm_source",

--- a/src/plugins/clearURLs/defaultRules.ts
+++ b/src/plugins/clearURLs/defaultRules.ts
@@ -128,6 +128,7 @@ export const defaultRules = [
     "feature@youtube.com",
     "kw@youtube.com",
     "si@youtube.com",
+    "pp@youtube.com",
     "si@youtu.be",
     "wt_zmc",
     "utm_source",


### PR DESCRIPTION
It removes ?si= from youtube.com/shorts/ links, TESTED, it works.