### PR TITLE
feat(startup timings): add Time-To-Interactive info

### DIFF
--- a/src/plugins/startupTimings/StartupTimingPage.css
+++ b/src/plugins/startupTimings/StartupTimingPage.css
@@ -1,0 +1,23 @@
+.vc-startuptimings-server-trace {
+    color: var(--header-primary);
+    user-select: text;
+}
+
+.vc-startuptimings-grid {
+    color: var(--header-primary);
+    display: grid;
+    gap: 2px 10px;
+    user-select: text;
+}
+
+.vc-startuptimings-4-cols {
+    grid-template-columns: repeat(3, auto) 1fr;
+}
+
+.vc-startuptimings-3-cols {
+    grid-template-columns: repeat(2, auto) 1fr;
+}
+
+.vc-startuptimings-2-cols {
+    grid-template-columns: auto 1fr;
+}

--- a/src/plugins/startupTimings/StartupTimingPage.tsx
+++ b/src/plugins/startupTimings/StartupTimingPage.tsx
@@ -149,7 +149,7 @@ function ServerTrace({ trace }: ServerTraceProps) {
 
 function TTIAnalytics() {
     const analytics = TTITracker.serializeTTITracker();
-    const filteredAnalytics = Object.entries(analytics).filter(([key, value]) => !/_start|_end$/.test(key) && value !== null && value !== undefined);
+    const filteredAnalytics = Object.entries(analytics).filter(([key, value]) => !/_start$|_end$/.test(key) && value !== null && value !== undefined);
 
     return (
         <ErrorBoundary>


### PR DESCRIPTION
Adds TTI information & some payload stats to the startup timings tab
![image](https://github.com/Vendicated/Vencord/assets/27697325/2d459d19-f709-4bfc-9b6e-885c1fe7e72a)
![image](https://github.com/Vendicated/Vencord/assets/27697325/f5a9f30f-27b6-4ed6-9770-4c91d086ac8b)
