### PR TITLE
web: fix themes tab

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -255,18 +255,3 @@ export function DeleteIcon(props: IconProps) {
         </Icon>
     );
 }
-
-export function ReportIcon(props: IconProps) {
-    return (
-        <Icon
-            {...props}
-            className={classes(props.className, "vc-report-icon")}
-            viewBox="0 0 24 24"
-        >
-            <path
-                fill="currentColor"
-                d="M20,6.002H14V3.002C14,2.45 13.553,2.002 13,2.002H4C3.447,2.002 3,2.45 3,3.002V22.002H5V14.002H10.586L8.293,16.295C8.007,16.581 7.922,17.011 8.076,17.385C8.23,17.759 8.596,18.002 9,18.002H20C20.553,18.002 21,17.554 21,17.002V7.002C21,6.45 20.553,6.002 20,6.002Z"
-            />
-        </Icon>
-    );
-}

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -236,3 +236,37 @@ export function ReplyIcon(props: IconProps) {
         </Icon>
     );
 }
+
+export function DeleteIcon(props: IconProps) {
+    return (
+        <Icon
+            {...props}
+            className={classes(props.className, "vc-delete-icon")}
+            viewBox="0 0 24 24"
+        >
+            <path
+                fill="currentColor"
+                d="M15 3.999V2H9V3.999H3V5.999H21V3.999H15Z"
+            />
+            <path
+                fill="currentColor"
+                d="M5 6.99902V18.999C5 20.101 5.897 20.999 7 20.999H17C18.103 20.999 19 20.101 19 18.999V6.99902H5ZM11 17H9V11H11V17ZM15 17H13V11H15V17Z"
+            />
+        </Icon>
+    );
+}
+
+export function ReportIcon(props: IconProps) {
+    return (
+        <Icon
+            {...props}
+            className={classes(props.className, "vc-report-icon")}
+            viewBox="0 0 24 24"
+        >
+            <path
+                fill="currentColor"
+                d="M20,6.002H14V3.002C14,2.45 13.553,2.002 13,2.002H4C3.447,2.002 3,2.45 3,3.002V22.002H5V14.002H10.586L8.293,16.295C8.007,16.581 7.922,17.011 8.076,17.385C8.23,17.759 8.596,18.002 9,18.002H20C20.553,18.002 21,17.554 21,17.002V7.002C21,6.45 20.553,6.002 20,6.002Z"
+            />
+        </Icon>
+    );
+}

--- a/src/components/VencordSettings/ThemesTab.tsx
+++ b/src/components/VencordSettings/ThemesTab.tsx
@@ -20,6 +20,7 @@ import { useSettings } from "@api/Settings";
 import { classNameFactory } from "@api/Styles";
 import { ErrorCard } from "@components/ErrorCard";
 import { Flex } from "@components/Flex";
+import { DeleteIcon } from "@components/Icons";
 import { Link } from "@components/Link";
 import { IsFirefox } from "@utils/constants";
 import { Margins } from "@utils/margins";
@@ -42,7 +43,6 @@ type FileInput = ComponentType<{
 }>;
 
 const InviteActions = findByPropsLazy("resolveInvite");
-const TrashIcon = findByCodeLazy("M5 6.99902V18.999C5 20.101 5.897 20.999");
 const FileInput: FileInput = findByCodeLazy("activateUploadDialogue=");
 const TextAreaProps = findLazy(m => typeof m.textarea === "string");
 
@@ -114,7 +114,7 @@ function ThemeCard({ theme, enabled, onChange, onDelete }: ThemeCardProps) {
             infoButton={
                 IS_WEB && (
                     <div style={{ cursor: "pointer", color: "var(--status-danger" }} onClick={onDelete}>
-                        <TrashIcon />
+                        <DeleteIcon />
                     </div>
                 )
             }

--- a/src/plugins/reviewDB/components/MessageButton.tsx
+++ b/src/plugins/reviewDB/components/MessageButton.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { DeleteIcon, ReportIcon } from "@components/Icons";
 import { classes } from "@utils/misc";
 import { findByPropsLazy } from "@webpack";
 import { Tooltip } from "@webpack/common";
@@ -31,10 +32,7 @@ export function DeleteButton({ onClick }: { onClick(): void; }) {
                     className={classes(iconClasses.button, iconClasses.dangerous)}
                     onClick={onClick}
                 >
-                    <svg width="16" height="16" viewBox="0 0 20 20">
-                        <path fill="currentColor" d="M15 3.999V2H9V3.999H3V5.999H21V3.999H15Z" />
-                        <path fill="currentColor" d="M5 6.99902V18.999C5 20.101 5.897 20.999 7 20.999H17C18.103 20.999 19 20.101 19 18.999V6.99902H5ZM11 17H9V11H11V17ZM15 17H13V11H15V17Z" />
-                    </svg>
+                    <DeleteIcon width={20} height={20} />
                 </div>
             )}
         </Tooltip>
@@ -50,9 +48,7 @@ export function ReportButton({ onClick }: { onClick(): void; }) {
                     className={iconClasses.button}
                     onClick={onClick}
                 >
-                    <svg width="16" height="16" viewBox="0 0 20 20">
-                        <path fill="currentColor" d="M20,6.002H14V3.002C14,2.45 13.553,2.002 13,2.002H4C3.447,2.002 3,2.45 3,3.002V22.002H5V14.002H10.586L8.293,16.295C8.007,16.581 7.922,17.011 8.076,17.385C8.23,17.759 8.596,18.002 9,18.002H20C20.553,18.002 21,17.554 21,17.002V7.002C21,6.45 20.553,6.002 20,6.002Z" />
-                    </svg>
+                    <ReportIcon width={20} height={20} />
                 </div>
             )}
         </Tooltip>

--- a/src/plugins/reviewDB/components/MessageButton.tsx
+++ b/src/plugins/reviewDB/components/MessageButton.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { DeleteIcon, ReportIcon } from "@components/Icons";
+import { DeleteIcon } from "@components/Icons";
 import { classes } from "@utils/misc";
 import { findByPropsLazy } from "@webpack";
 import { Tooltip } from "@webpack/common";
@@ -48,7 +48,12 @@ export function ReportButton({ onClick }: { onClick(): void; }) {
                     className={iconClasses.button}
                     onClick={onClick}
                 >
-                    <ReportIcon width={20} height={20} />
+                    <svg width={20} height={20} viewBox="0 0 24 24">
+                        <path
+                            fill="currentColor"
+                            d="M20,6.002H14V3.002C14,2.45 13.553,2.002 13,2.002H4C3.447,2.002 3,2.45 3,3.002V22.002H5V14.002H10.586L8.293,16.295C8.007,16.581 7.922,17.011 8.076,17.385C8.23,17.759 8.596,18.002 9,18.002H20C20.553,18.002 21,17.554 21,17.002V7.002C21,6.45 20.553,6.002 20,6.002Z"
+                        />
+                    </svg>
                 </div>
             )}
         </Tooltip>

--- a/src/plugins/reviewDB/components/MessageButton.tsx
+++ b/src/plugins/reviewDB/components/MessageButton.tsx
@@ -32,7 +32,7 @@ export function DeleteButton({ onClick }: { onClick(): void; }) {
                     className={classes(iconClasses.button, iconClasses.dangerous)}
                     onClick={onClick}
                 >
-                    <DeleteIcon width={20} height={20} />
+                    <DeleteIcon width="20" height="20" />
                 </div>
             )}
         </Tooltip>
@@ -48,7 +48,7 @@ export function ReportButton({ onClick }: { onClick(): void; }) {
                     className={iconClasses.button}
                     onClick={onClick}
                 >
-                    <svg width={20} height={20} viewBox="0 0 24 24">
+                    <svg width="20" height="20" viewBox="0 0 24 24">
                         <path
                             fill="currentColor"
                             d="M20,6.002H14V3.002C14,2.45 13.553,2.002 13,2.002H4C3.447,2.002 3,2.45 3,3.002V22.002H5V14.002H10.586L8.293,16.295C8.007,16.581 7.922,17.011 8.076,17.385C8.23,17.759 8.596,18.002 9,18.002H20C20.553,18.002 21,17.554 21,17.002V7.002C21,6.45 20.553,6.002 20,6.002Z"

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -20,6 +20,7 @@ import { DataStore } from "@api/index";
 import { addPreSendListener, removePreSendListener } from "@api/MessageEvents";
 import { definePluginSettings } from "@api/Settings";
 import { Flex } from "@components/Flex";
+import { DeleteIcon } from "@components/Icons";
 import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
 import { useForceUpdater } from "@utils/react";
@@ -173,6 +174,7 @@ function TextReplace({ title, rulesArray, rulesKey, update }: TextReplaceProps) 
                                     onClick={() => onClickRemove(index)}
                                     style={{
                                         background: "none",
+                                        color: "var(--status-danger)",
                                         ...(index === rulesArray.length - 1
                                             ? {
                                                 visibility: "hidden",
@@ -182,11 +184,7 @@ function TextReplace({ title, rulesArray, rulesKey, update }: TextReplaceProps) 
                                         )
                                     }}
                                 >
-                                    <svg width="24" height="24" viewBox="0 0 24 24">
-                                        <title>Delete Rule</title>
-                                        <path fill="var(--status-danger)" d="M15 3.999V2H9V3.999H3V5.999H21V3.999H15Z" />
-                                        <path fill="var(--status-danger)" d="M5 6.99902V18.999C5 20.101 5.897 20.999 7 20.999H17C18.103 20.999 19 20.101 19 18.999V6.99902H5ZM11 17H9V11H11V17ZM15 17H13V11H15V17Z" />
-                                    </svg>
+                                    <DeleteIcon />
                                 </Button>
                             </Flex>
                             {isRegexRules && renderFindError(rule.find)}


### PR DESCRIPTION
This fixes the themes tab on web. The reviewdb icons should look almost the same, in fact maybe slightly better since the viewBox seemed to be different to Discord's (and incorrect?).