### PR TITLE
ClearURLs: Add Discord Copy Link Tags

### DIFF
--- a/src/plugins/clearURLs/defaultRules.ts
+++ b/src/plugins/clearURLs/defaultRules.ts
@@ -139,4 +139,7 @@ export const defaultRules = [
     "si@open.spotify.com",
     "igshid",
     "share_id@reddit.com",
+    "ex@*.discordapp.*",
+    "is@*.discordapp.*",
+    "hm@*.discordapp.*",
 ];


### PR DESCRIPTION
Copying links in the Discord app now appends a ton of extra tags to the end. This seeks to fix that.
This was added for a day or two, removed for a day or two, and has since been added back again.
This implementation uses wildcards in case Discord changes this for old media.discordapp.net links.
That being said, I did a bit of research, and it doesn't seem copying media.discordapp.net links appends anything extra to the end, so this may be unnecessary. If this causes problems, let me know.