### PR TITLE
adds Discord tracking parameters

### DIFF
--- a/src/plugins/clearURLs/defaultRules.ts
+++ b/src/plugins/clearURLs/defaultRules.ts
@@ -139,4 +139,10 @@ export const defaultRules = [
     "si@open.spotify.com",
     "igshid",
     "share_id@reddit.com",
+    "ex@cdn.discordapp.com",
+    "is@cdn.discordapp.com",
+    "hm@cdn.discordapp.com",
+    "ex@media.discordapp.com",
+    "is@media.discordapp.com",
+    "hm@media.discordapp.com",
 ];


### PR DESCRIPTION
Discord recently added tracking parameters to their CDN and cache urls (cdn. and media. in order).

This happens when the user uses the right click > copy link feature in the app (or using the share button on mobile)

This adds the parameters to the clearURLs plugin