### PR TITLE
TextReplace: Use settings.json for storing rules instead of DataStore API

### DIFF
--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -136,6 +136,7 @@ function TextReplace({ title, rulesArray, rulesKey, update }: TextReplaceProps) 
         rulesArray.splice(index, 1);
 
         await DataStore.set(rulesKey, rulesArray);
+        exportRulesToJson();
         update();
     }
 
@@ -272,7 +273,7 @@ const TEXT_REPLACE_RULES_CHANNEL_ID = "1102784112584040479";
 
 export default definePlugin({
     name: "TextReplace",
-    description: "Replace text in your messages. You can find pre-made rules in the #textreplace-rules channel in Vencord's Server",
+    description: "Replace text in your messages. You can find pre-made rules in the #textreplace-rules channel in Vencord's Server. If you want your rule changes to get imported from the settings.json, you need to reload Discord (CTRL + R).",
     authors: [Devs.AutumnVN, Devs.TheKodeToad],
     dependencies: ["MessageEventsAPI"],
 
@@ -282,6 +283,10 @@ export default definePlugin({
         importRulesFromJson();
         stringRules = await DataStore.get(STRING_RULES_KEY) ?? makeEmptyRuleArray();
         regexRules = await DataStore.get(REGEX_RULES_KEY) ?? makeEmptyRuleArray();
+        if (!("rules" in Vencord.Settings.plugins[PLUGIN_NAME])) {
+            // If the "rules" key doesn't exist in the settings.json yet, create it at startup so users can directly start defining their rules in the settings.json using a blank template.
+            exportRulesToJson();
+        }
 
         this.preSend = addPreSendListener((channelId, msg) => {
             // Channel used for sharing rules, applying rules here would be messy

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -266,7 +266,7 @@ const TEXT_REPLACE_RULES_CHANNEL_ID = "1102784112584040479";
 export default definePlugin({
     name: "TextReplace",
     description: "Replace text in your messages. You can find pre-made rules in the #textreplace-rules channel in Vencord's Server. If you want your rule changes to get imported from the settings.json, you need to reload Discord (CTRL + R).",
-    authors: [Devs.AutumnVN, Devs.TheKodeToad],
+    authors: [Devs.AutumnVN, Devs.TheKodeToad, Devs.hendrik3812],
     dependencies: ["MessageEventsAPI"],
 
     settings,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -374,6 +374,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     archeruwu: {
         name: "archer_uwu",
         id: 160068695383736320n
+    },
+    hendrik3812: {
+        name: "hendrik3812",
+        id: 286208399786377216n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
The changes of this PR change the way the existing TextReplace plugin stores the rules (find, replace). It uses the settings.store (aka. the settings.json file in the AppData directory) instead of Vencord's DataStore API (aka. the IndexedDB of Chromium).

Using the settings.json would have a few benefits imo:
- rules could be synced with Vencord Cloud Sync
- users can edit their rules in the settings.json directly using any text editor (which is a blessing if you want to edit a lot of rules or copy/paste them)
- sharing an entire set of rules with other users would be easier, too

I'm not aware of potential drawbacks. Let me know what you think about it.


![image](https://github.com/Vendicated/Vencord/assets/26305045/548915d1-4472-4373-a68a-230d2bf01fc3)