### PR TITLE
reviewDB: fix usericons appearing over modals

### DIFF
--- a/src/plugins/reviewDB/style.css
+++ b/src/plugins/reviewDB/style.css
@@ -63,6 +63,10 @@
     margin-bottom: 8px;
 }
 
+.vc-rdb-review .avatar-2e8lTP {
+    z-index: 0;
+}
+
 .vc-rdb-review-comment img {
     vertical-align: text-top;
 }


### PR DESCRIPTION
Minor fix, overrides Discord's `z-index: 1` on usericons that was causing it to appear over the top of modals

| before | after |
|-|-|
|![image](https://github.com/Vendicated/Vencord/assets/29710355/6ded4916-f25d-4239-a0ab-991c717ca864)|![image](https://github.com/Vendicated/Vencord/assets/29710355/181c1546-194d-4e9f-a5d2-dd17b7d362c6)|
