### PR TITLE
feat(permissionfreewill): onboarding deletion

### DIFF
--- a/src/plugins/permissionFreeWill/README.md
+++ b/src/plugins/permissionFreeWill/README.md
@@ -7,3 +7,8 @@ you don't want to do this") and onboarding requirements ("Making this change wil
 
 This plugin will let you create permissions in servers that **WILL** lock you out of channels until an administrator
 can resolve it for you. Please be careful with the overwrites you are making and check carefully.
+
+## Community Server Channels
+
+Community Server channels (i.e., `#rules` and `#moderator-only`) are actually mandatory and their existence is enforced
+by the API, therefore this plugin cannot remove the restrictions behind them.

--- a/src/plugins/permissionFreeWill/index.ts
+++ b/src/plugins/permissionFreeWill/index.ts
@@ -50,6 +50,17 @@ export default definePlugin({
                 }
             ],
             predicate: () => settings.store.onboarding
+        },
+        // Onboarding deletion
+        {
+            find: "Messages.DELETE_DEFAULT_CHANNEL_BODY",
+            replacement: [
+                {
+                    match: /if\((?=null!=\i.{5,20}Messages.DELETE_DEFAULT_CHANNEL_BODY)/,
+                    replace: "$&false&&"
+                }
+            ],
+            predicate: () => settings.store.onboarding
         }
     ],
     settings


### PR DESCRIPTION
onboarding has client-side restrictions to prevent deleting channels used in it, although in reality this is actually useless since you can still use onboarding without them

