### PR TITLE
Fix command API

### DIFF
--- a/src/plugins/_api/commands.ts
+++ b/src/plugins/_api/commands.ts
@@ -26,7 +26,7 @@ export default definePlugin({
     patches: [
         // obtain BUILT_IN_COMMANDS instance
         {
-            find: '"giphy","tenor"',
+            find: '"gif","tenor"',
             replacement: [
                 {
                     // Matches BUILT_IN_COMMANDS. This is not exported so this is
@@ -34,7 +34,7 @@ export default definePlugin({
                     // patch simpler
 
                     // textCommands = builtInCommands.filter(...)
-                    match: /(?<=\w=)(\w)(\.filter\(.{0,30}giphy)/,
+                    match: /(?<=\w=)(\w)(\.filter\(.{0,30}gif)/,
                     replace: "Vencord.Api.Commands._init($1)$2",
                 }
             ],

--- a/src/plugins/_api/commands.ts
+++ b/src/plugins/_api/commands.ts
@@ -26,7 +26,7 @@ export default definePlugin({
     patches: [
         // obtain BUILT_IN_COMMANDS instance
         {
-            find: '"gif","tenor"',
+            find: ',"tenor"',
             replacement: [
                 {
                     // Matches BUILT_IN_COMMANDS. This is not exported so this is
@@ -34,7 +34,7 @@ export default definePlugin({
                     // patch simpler
 
                     // textCommands = builtInCommands.filter(...)
-                    match: /(?<=\w=)(\w)(\.filter\(.{0,30}gif)/,
+                    match: /(?<=\w=)(\w)(\.filter\(.{0,60}tenor)/,
                     replace: "Vencord.Api.Commands._init($1)$2",
                 }
             ],


### PR DESCRIPTION
Fix the command API, broken by discord removing the /giphy command, which was used to locate the injection point for the CommandAPI _init() function. This fix is only a sketchy temporary fix and i am uncertain whether it should be used over a better, more stable solution.. but it works for now for me ig? I am mostly worried that i have seen some users who still have /giphy.. so this would break  the CommandAPI for them..