### PR TITLE
VcNarrator: Add 'Use Display Name' option + update discord-types from 1.3.26 -> 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
         "diff": "^5.1.0",
-        "discord-types": "^1.3.26",
+        "discord-types": "^1.3.3",
         "esbuild": "^0.15.18",
         "eslint": "^8.46.0",
         "eslint-import-resolver-alias": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ devDependencies:
     specifier: ^5.1.0
     version: 5.1.0
   discord-types:
-    specifier: ^1.3.26
-    version: 1.3.26
+    specifier: ^1.3.3
+    version: 1.3.3
   esbuild:
     specifier: ^0.15.18
     version: 0.15.18
@@ -1214,8 +1214,8 @@ packages:
       path-type: 4.0.0
     dev: true
 
-  /discord-types@1.3.26:
-    resolution: {integrity: sha512-ToG51AOCH+JTQf7b+8vuYQe5Iqwz7nZ7StpECAZ/VZcI1ZhQk13pvt9KkRTfRv1xNvwJ2qib4e3+RifQlo8VPQ==}
+  /discord-types@1.3.3:
+    resolution: {integrity: sha512-6LGLIw8RBWKdio7FoIfwExSZQuej2XXDKgT7mfR3qMOpEspknVDFQJcfhPuiD1iy2NdcAygvvVfJMliYwiUwqw==}
     dependencies:
       '@types/react': 17.0.2
       moment: 2.29.4

--- a/src/plugins/vcNarrator/index.tsx
+++ b/src/plugins/vcNarrator/index.tsx
@@ -144,13 +144,15 @@ function updateStatuses(type: string, { deaf, mute, selfDeaf, selfMute, userId, 
 function playSample(tempSettings: any, type: string) {
     const settings = Object.assign({}, Settings.plugins.VcNarrator, tempSettings);
 
-    speak(formatText(settings[type + "Message"], UserStore.getCurrentUser().username, "general"), settings);
+    const user = UserStore.getCurrentUser();
+    const name = Settings.plugins.VcNarrator.useDisplayName ? (user as any).globalName : user.username;
+    speak(formatText(settings[type + "Message"], name, "general"), settings);
 }
 
 export default definePlugin({
     name: "VcNarrator",
     description: "Announces when users join, leave, or move voice channels via narrator",
-    authors: [Devs.Ven],
+    authors: [Devs.Ven, Devs.Lifix],
 
     flux: {
         VOICE_STATE_UPDATES({ voiceStates }: { voiceStates: VoiceState[]; }) {
@@ -171,7 +173,9 @@ export default definePlugin({
                 if (!type) continue;
 
                 const template = Settings.plugins.VcNarrator[type + "Message"];
-                const user = isMe && !Settings.plugins.VcNarrator.sayOwnName ? "" : UserStore.getUser(userId).username;
+                const userObject = UserStore.getUser(userId);
+                const user = isMe && !Settings.plugins.VcNarrator.sayOwnName ? "" :
+                    Settings.plugins.VcNarrator.useDisplayName ? (userObject as any).globalName : userObject.username;
                 const channel = ChannelStore.getChannel(id).name;
 
                 speak(formatText(template, user, channel));
@@ -238,6 +242,11 @@ export default definePlugin({
             },
             sayOwnName: {
                 description: "Say own name",
+                type: OptionType.BOOLEAN,
+                default: false
+            },
+            useDisplayName: {
+                description: "Use display names instead of usernames",
                 type: OptionType.BOOLEAN,
                 default: false
             },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -379,6 +379,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "ProffDea",
         id: 609329952180928513n
     },
+    Lifix: {
+        name: "Lifix",
+        id: 180430713873498113n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Allows users to hear the display name of a user instead of the username, which is useful as some usernames dont sound right when narrated as they don't have any spaces and many people are now using periods, making `username.` sound like "username..... has joined your channel"