### PR TITLE
Plugin: Fix Twitter Embeds

### DIFF
--- a/src/plugins/fixTwitterEmbeds/index.ts
+++ b/src/plugins/fixTwitterEmbeds/index.ts
@@ -1,0 +1,71 @@
+import {
+    addPreEditListener,
+    addPreSendListener,
+    MessageObject,
+    removePreEditListener,
+    removePreSendListener
+} from "@api/MessageEvents";
+
+import { definePluginSettings } from "@api/Settings";
+import definePlugin, { OptionType } from "@utils/types";
+
+export default definePlugin({
+    name: "Fix Twitter Embeds",
+    description: "Fixes embeds using fxtwitter or vxtwitter",
+    authors: [
+        {
+            id: 0n,
+            name: "Cyrene",
+        },
+    ],
+
+    settings: definePluginSettings({
+        service: {
+            description: "Which service would you like to use?",
+            type: OptionType.SELECT,
+            options: [
+                {
+                    label: "fxtwitter",
+                    value: "fxtwitter.com",
+                    default: true
+                },
+                {
+                    label: "vxtwitter",
+                    value: "vxtwitter.com",
+                }
+            ]
+        }
+    }),
+
+    onSend(msg: MessageObject) {
+        if (msg.content.match(/http(s)?:\/\/(twitter|x)\.com/)) {
+            msg.content = msg.content.replace(
+                /(https?:\/\/[^\s<]+[^<.,:;"'>)|\]\s])/g,
+                match => this.replace(match)
+            );
+        }
+    },
+
+    replace(match: string) {
+        try {
+            var url = new URL(match);
+        } catch (error) {
+            return match;
+        }
+
+        url.hostname = this.settings.store.service;
+        return url.toString();
+    },
+
+    start() {
+        this.preSend = addPreSendListener((_, msg) => this.onSend(msg));
+        this.preEdit = addPreEditListener((_cid, _mid, msg) =>
+            this.onSend(msg)
+        );
+    },
+
+    stop() {
+        removePreSendListener(this.preSend);
+        removePreEditListener(this.preEdit);
+    },
+});

--- a/src/plugins/fixTwitterEmbeds/index.ts
+++ b/src/plugins/fixTwitterEmbeds/index.ts
@@ -1,3 +1,9 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import {
     addPreEditListener,
     addPreSendListener,
@@ -5,19 +11,14 @@ import {
     removePreEditListener,
     removePreSendListener
 } from "@api/MessageEvents";
-
 import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
 export default definePlugin({
     name: "Fix Twitter Embeds",
     description: "Fixes embeds using fxtwitter or vxtwitter",
-    authors: [
-        {
-            id: 0n,
-            name: "Cyrene",
-        },
-    ],
+    authors: [Devs.Cyrene],
 
     settings: definePluginSettings({
         service: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -379,6 +379,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "ProffDea",
         id: 609329952180928513n
     },
+    Cyrene: {
+        name: "Cyrene",
+        id: 129343413614149634n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Simple plugin that automatically replaces twitter.com and x.com URLs with ones that have been "fixed" so embeds continue to work.