### PR TITLE
bugfix: fix csp on non-chromium browsers

### DIFF
--- a/browser/background.js
+++ b/browser/background.js
@@ -30,3 +30,28 @@ chrome.webRequest.onHeadersReceived.addListener(
     { urls: ["https://raw.githubusercontent.com/*", "*://*.discord.com/*"], types: ["main_frame", "stylesheet"] },
     ["blocking", "responseHeaders"]
 );
+
+browser.webRequest.onHeadersReceived.addListener(
+    ({ responseHeaders, type, url }) => {
+        if (!responseHeaders) return;
+
+        if (type === "main_frame") {
+            // In main frame requests, the CSP needs to be removed to enable fetching of custom css
+            // as desired by the user
+            removeFirst(responseHeaders, h => h.name.toLowerCase() === "content-security-policy");
+        } else if (type === "stylesheet" && url.startsWith("https://raw.githubusercontent.com/")) {
+            // Most users will load css from GitHub, but GitHub doesn't set the correct content type,
+            // so we fix it here
+            removeFirst(responseHeaders, h => h.name.toLowerCase() === "content-type");
+            responseHeaders.push({
+                name: "Content-Type",
+                value: "text/css"
+            });
+        }
+        return { responseHeaders };
+    },
+    { urls: ["https://raw.githubusercontent.com/*", "*://*.discord.com/*"], types: ["main_frame", "stylesheet"] },
+    ["blocking", "responseHeaders"]
+);
+
+

--- a/browser/background.js
+++ b/browser/background.js
@@ -53,5 +53,3 @@ browser.webRequest.onHeadersReceived.addListener(
     { urls: ["https://raw.githubusercontent.com/*", "*://*.discord.com/*"], types: ["main_frame", "stylesheet"] },
     ["blocking", "responseHeaders"]
 );
-
-


### PR DESCRIPTION
Although I am aware of official support dropping on Firefox(-based) browsers, this feels necessary for many plugins that relies on external requests to work reliably.