### PR TITLE
meta: Add .gitkeep file to mark userplugins folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ lerna-debug.log*
 .pnpm-debug.log*
 *.tsbuildinfo
 
-src/userplugins
+src/userplugins/*
+!src/userplugins/.gitkeep
 
 ExtensionCache/
 settings/


### PR DESCRIPTION
This makes it easier for users to find where to put userplugins, as that folder already exists