### PR TITLE
fix: windows host updates

### DIFF
--- a/scripts/build/build.mjs
+++ b/scripts/build/build.mjs
@@ -43,7 +43,7 @@ const nodeCommonOpts = {
     format: "cjs",
     platform: "node",
     target: ["esnext"],
-    external: ["electron", ...commonOpts.external],
+    external: ["electron", "original-fs", ...commonOpts.external],
     define: defines,
 };
 

--- a/src/main/patchWin32Updater.ts
+++ b/src/main/patchWin32Updater.ts
@@ -17,7 +17,7 @@
 */
 
 import { app } from "electron";
-import { existsSync, mkdirSync, readdirSync, renameSync, statSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync, writeFileSync } from "original-fs";
 import { basename, dirname, join } from "path";
 
 function isNewer($new: string, old: string) {


### PR DESCRIPTION
Hi there,
I stumbled upon this issue just today when trying to patch host updates for uwu/shelter.
Electron modifies "fs" at runtime to provide support for asar files [(see Electron docs)](https://github.com/electron/electron/blob/main/docs/tutorial/asar-archives.md#treating-an-asar-archive-as-a-normal-file).
https://github.com/Vendicated/Vencord/blob/5d7ede34d811d56e2b2c845dd940471e3674a616/src/main/patchWin32Updater.ts#L52
When using the modified version of "fs" the `statSync(app).isDirectory()` call returns true (probably) to make the app.asar file behave like a normal directory. This leads to host updates never getting patched.

Another issue is that "fs" seems to lock the app.asar file so that Vencord is not able to rename `app.asar` to `_app.asar`
`Error: EBUSY: resource busy or locked, rename '...\resources\app.asar' -> '...\resources\_app.asar'`

Using the original-fs that's provided by Electron at runtime should fix both issues.
I hope this helps!