### PR TITLE
fix: TypingIndicator

### DIFF
--- a/src/plugins/typingIndicator/index.tsx
+++ b/src/plugins/typingIndicator/index.tsx
@@ -26,7 +26,12 @@ import { ChannelStore, GuildMemberStore, RelationshipStore, Tooltip, UserStore, 
 
 import { buildSeveralUsers } from "../typingTweaks";
 
-const ThreeDots = LazyComponent(() => find(m => m.type?.render?.toString()?.includes("().dots")));
+const ThreeDots = LazyComponent(() => {
+    // This doesn't really need to explicitly find Dots' own module, but it's fine
+    const res = find(m => m.Dots && !m.Menu);
+
+    return res?.Dots;
+});
 
 const TypingStore = findStoreLazy("TypingStore");
 const UserGuildSettingsStore = findStoreLazy("UserGuildSettingsStore");
@@ -126,8 +131,8 @@ export default definePlugin({
         {
             find: ".UNREAD_HIGHLIGHT",
             replacement: {
-                match: /\(\).children.+?:null(?<=(\i)=\i\.channel,.+?)/,
-                replace: (m, channel) => `${m},$self.TypingIndicator(${channel}.id)`
+                match: /channel:(\i).{0,100}?channelEmoji,.{0,250}?\.children.{0,50}?:null/,
+                replace: "$&,$self.TypingIndicator($1.id)"
             }
         }
     ],


### PR DESCRIPTION
While this patch (and new ThreeDots find) should work, Vencord's patcher doesn't seem to patch the earliest chunks of Discord, where this patch tries to modify. That will need resolving (and this testing to work more than "Patch OK!") before this can be merged.