### PR TITLE
fix: MutualGroupDMs

### DIFF
--- a/src/plugins/mutualGroupDMs/index.tsx
+++ b/src/plugins/mutualGroupDMs/index.tsx
@@ -47,16 +47,17 @@ export default definePlugin({
     patches: [
         {
             find: ".Messages.USER_PROFILE_MODAL", // Note: the module is lazy-loaded
-            replacement: [
-                {
-                    match: /(?<=\.MUTUAL_GUILDS\}\),)(?=(\i\.bot).{0,20}(\(0,\i\.jsx\)\(.{0,100}id:))/,
-                    replace: '$1?null:$2"MUTUAL_GDMS",children:"Mutual Groups"}),'
-                },
-                {
-                    match: /(?<={user:(\i),onClose:(\i)}\);)(?=case \i\.\i\.MUTUAL_FRIENDS)/,
-                    replace: "case \"MUTUAL_GDMS\":return $self.renderMutualGDMs($1,$2);"
-                }
-            ]
+            replacement: {
+                match: /(?<=\.MUTUAL_GUILDS\}\),)(?=(\i\.bot).{0,20}(\(0,\i\.jsx\)\(.{0,100}id:))/,
+                replace: '$1?null:$2"MUTUAL_GDMS",children:"Mutual Groups"}),'
+            }
+        },
+        {
+            find: ".UserProfileSections.USER_INFO_CONNECTIONS:",
+            replacement: {
+                match: /(?<={user:(\i),onClose:(\i)}\);)(?=case \i\.\i\.MUTUAL_FRIENDS)/,
+                replace: "case \"MUTUAL_GDMS\":return $self.renderMutualGDMs($1,$2);"
+            }
         }
     ],
 

--- a/src/plugins/mutualGroupDMs/index.tsx
+++ b/src/plugins/mutualGroupDMs/index.tsx
@@ -49,7 +49,7 @@ export default definePlugin({
             find: ".Messages.USER_PROFILE_MODAL", // Note: the module is lazy-loaded
             replacement: {
                 match: /(?<=\.MUTUAL_GUILDS\}\),)(?=(\i\.bot).{0,20}(\(0,\i\.jsx\)\(.{0,100}id:))/,
-                replace: '$1?null:$2"MUTUAL_GDMS",children:"Mutual Groups"}),'
+                replace: '($1||arguments[0].isCurrentUser)?null:$2"MUTUAL_GDMS",children:"Mutual Groups"}),'
             }
         },
         {


### PR DESCRIPTION
This fixes a broken patch caused by rspack, as well as an existing bug where the tab would display on your own profile if you had an activity.