### PR TITLE
Fix titlebar duplication with native Windows titlebar

### DIFF
--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -136,7 +136,7 @@ if (IS_DISCORD_DESKTOP && Settings.winNativeTitleBar && navigator.platform.toLow
     document.addEventListener("DOMContentLoaded", () => {
         document.head.append(Object.assign(document.createElement("style"), {
             id: "vencord-native-titlebar-style",
-            textContent: "[class*=titleBar-]{display: none!important}"
+            textContent: "[class*=titleBar]{display: none!important}"
         }));
     }, { once: true });
 }


### PR DESCRIPTION
Unrelated sidenote: Fixing shit would be easier if OPENING THE INSPECTOR AT ALL DIDN'T CRASH THE ENTIRETY OF DISCORD. NICE ONE, DISCORD. (yes I literally tried it on vanilla Canary and it still somehow fucking crashes)