### PR TITLE
fix: ImageZoom + PiP

### DIFF
--- a/src/plugins/imageZoom/styles.css
+++ b/src/plugins/imageZoom/styles.css
@@ -25,12 +25,6 @@
     box-shadow: none;
 }
 
-[class*="modalCarouselWrapper"] {
-    height: fit-content;
-    top: 50%;
-    transform: translateY(-50%);
-}
-
 [class|="wrapper"]:has(> #vc-imgzoom-magnify-modal) {
     position: absolute;
     left: 50%;

--- a/src/plugins/pictureInPicture/index.tsx
+++ b/src/plugins/pictureInPicture/index.tsx
@@ -28,7 +28,7 @@ export default definePlugin({
         {
             find: ".nonMediaAttachment]",
             replacement: {
-                match: /\.nonMediaAttachment\].{0,10}children:\[\S{3}/,
+                match: /\.nonMediaAttachment\].{0,10}children:\[\S/,
                 replace: "$&&&$self.renderPiPButton(),"
             },
         },


### PR DESCRIPTION
- ImageZoom: removed CSS that caused media mosaic to warp all the way to the top
- PiP: fixed a bug that replaced the remove attachment button with the PiP button (even on non-video attachments)