### PR TITLE
Ipc Plugins

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -47,6 +47,8 @@ if (IS_VESKTOP || !IS_VANILLA) {
                 case "vencordDesktopPreload.js.map":
                 case "patcher.js.map":
                 case "vencordDesktopMain.js.map":
+                case "ipcPlugins.js.map":
+                case "vencordDesktopIpcPlugins.js.map":
                     cb(join(__dirname, url));
                     break;
                 default:

--- a/src/main/ipcPlugins/renderer.ts
+++ b/src/main/ipcPlugins/renderer.ts
@@ -1,0 +1,28 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import type { IpcPlugin, SettingsDefinition, SettingsStore } from "@utils/types";
+
+import ipcPlugins from "~ipcPlugins";
+
+declare global {
+    interface Window {
+        ipcPlugins: Record<string, IpcPlugin>;
+        PluginSettings: Record<string, SettingsStore<SettingsDefinition>>;
+    }
+}
+
+if (!window.ipcPlugins) window.ipcPlugins = {};
+
+for (const _plugin of Object.values(ipcPlugins)) {
+    const plugin = _plugin as IpcPlugin;
+    window.ipcPlugins[plugin.name] = plugin;
+}
+
+
+for (const plugin of Object.values(window.ipcPlugins)) {
+    if (window.location.href.match(plugin.matcher)) plugin.entrypoint(window.PluginSettings[plugin.name]);
+}

--- a/src/main/updater/common.ts
+++ b/src/main/updater/common.ts
@@ -20,6 +20,7 @@ export const VENCORD_FILES = [
     IS_DISCORD_DESKTOP ? "patcher.js" : "vencordDesktopMain.js",
     IS_DISCORD_DESKTOP ? "preload.js" : "vencordDesktopPreload.js",
     IS_DISCORD_DESKTOP ? "renderer.js" : "vencordDesktopRenderer.js",
+    IS_DISCORD_DESKTOP ? "ipcPlugins.js" : "vencordDesktopIpcPlugins.js",
     IS_DISCORD_DESKTOP ? "renderer.css" : "vencordDesktopRenderer.css",
 ];
 

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -24,6 +24,12 @@ declare module "~plugins" {
     export default plugins;
 }
 
+declare module "~ipcPlugins" {
+    const ipcPlugins: Record<string, import("@utils/types").IpcPlugin>;
+    export default ipcPlugins;
+}
+
+
 declare module "~git-hash" {
     const hash: string;
     export default hash;

--- a/src/plugins/fixSpotifyEmbeds.desktop/index.ts
+++ b/src/plugins/fixSpotifyEmbeds.desktop/index.ts
@@ -22,5 +22,5 @@ export default definePlugin({
             stickToMarkers: false,
             default: 10
         }
-    })
+    }),
 });

--- a/src/plugins/fixSpotifyEmbeds.desktop/ipcPlugin.ts
+++ b/src/plugins/fixSpotifyEmbeds.desktop/ipcPlugin.ts
@@ -1,0 +1,20 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { defineIpcPlugin } from "@utils/types";
+
+export default defineIpcPlugin({
+    name: "FixSpotifyEmbeds",
+    matcher: /^https:\/\/open\.spotify\.com\/embed\//,
+
+    entrypoint(settings) {
+        const original = Audio.prototype.play;
+        Audio.prototype.play = function () {
+            this.volume = (settings.volume / 100) || 0.1;
+            return original.apply(this, arguments);
+        };
+    }
+});

--- a/src/plugins/watchTogetherAdblock.desktop/index.ts
+++ b/src/plugins/watchTogetherAdblock.desktop/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+// The entire code of this plugin can be found in ipcPlugins
+export default definePlugin({
+    name: "WatchTogetherAdblock",
+    description: "Injects AdGuard to Watch Together",
+    authors: [Devs.matiq, Devs.ImLvna],
+
+
+});

--- a/src/plugins/watchTogetherAdblock.desktop/ipcPlugin.ts
+++ b/src/plugins/watchTogetherAdblock.desktop/ipcPlugin.ts
@@ -1,0 +1,260 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { defineIpcPlugin } from "@utils/types";
+
+export default defineIpcPlugin({
+    name: "WatchTogetherAdblock",
+    matcher: /^https:\/\/www\.youtube\.com/,
+
+    async entrypoint() {
+        const LOGO_ID = "block-youtube-ads-logo";
+        const hiddenCSS = [
+            "#__ffYoutube1",
+            "#__ffYoutube2",
+            "#__ffYoutube3",
+            "#__ffYoutube4",
+            "#feed-pyv-container",
+            "#feedmodule-PRO",
+            "#homepage-chrome-side-promo",
+            "#merch-shelf",
+            "#offer-module",
+            '#pla-shelf > ytd-pla-shelf-renderer[class="style-scope ytd-watch"]',
+            "#pla-shelf",
+            "#premium-yva",
+            "#promo-info",
+            "#promo-list",
+            "#promotion-shelf",
+            "#related > ytd-watch-next-secondary-results-renderer > #items > ytd-compact-promoted-video-renderer.ytd-watch-next-secondary-results-renderer",
+            "#search-pva",
+            "#shelf-pyv-container",
+            "#video-masthead",
+            "#watch-branded-actions",
+            "#watch-buy-urls",
+            "#watch-channel-brand-div",
+            "#watch7-branded-banner",
+            "#YtKevlarVisibilityIdentifier",
+            "#YtSparklesVisibilityIdentifier",
+            ".carousel-offer-url-container",
+            ".companion-ad-container",
+            ".GoogleActiveViewElement",
+            '.list-view[style="margin: 7px 0pt;"]',
+            ".promoted-sparkles-text-search-root-container",
+            ".promoted-videos",
+            ".searchView.list-view",
+            ".sparkles-light-cta",
+            ".watch-extra-info-column",
+            ".watch-extra-info-right",
+            ".ytd-carousel-ad-renderer",
+            ".ytd-compact-promoted-video-renderer",
+            ".ytd-companion-slot-renderer",
+            ".ytd-merch-shelf-renderer",
+            ".ytd-player-legacy-desktop-watch-ads-renderer",
+            ".ytd-promoted-sparkles-text-search-renderer",
+            ".ytd-promoted-video-renderer",
+            ".ytd-search-pyv-renderer",
+            ".ytd-video-masthead-ad-v3-renderer",
+            ".ytp-ad-action-interstitial-background-container",
+            ".ytp-ad-action-interstitial-slot",
+            ".ytp-ad-image-overlay",
+            ".ytp-ad-overlay-container",
+            ".ytp-ad-progress",
+            ".ytp-ad-progress-list",
+            '[class*="ytd-display-ad-"]',
+            '[layout*="display-ad-"]',
+            'a[href^="http://www.youtube.com/cthru?"]',
+            'a[href^="https://www.youtube.com/cthru?"]',
+            "ytd-action-companion-ad-renderer",
+            "ytd-banner-promo-renderer",
+            "ytd-compact-promoted-video-renderer",
+            "ytd-companion-slot-renderer",
+            "ytd-display-ad-renderer",
+            "ytd-promoted-sparkles-text-search-renderer",
+            "ytd-promoted-sparkles-web-renderer",
+            "ytd-search-pyv-renderer",
+            "ytd-single-option-survey-renderer",
+            "ytd-video-masthead-ad-advertiser-info-renderer",
+            "ytd-video-masthead-ad-v3-renderer",
+            "YTM-PROMOTED-VIDEO-RENDERER",
+        ];
+        /**
+     * Adds CSS to the page
+     */
+        const hideElements = () => {
+            const selectors = hiddenCSS;
+            if (!selectors) {
+                return;
+            }
+            const rule = selectors.join(", ") + " { display: none!important; }";
+            const style = document.createElement("style");
+            style.innerHTML = rule;
+            document.head.appendChild(style);
+        };
+        /**
+     * Calls the "callback" function on every DOM change, but not for the tracked events
+     * @param {Function} callback callback function
+     */
+        const observeDomChanges = callback => {
+            const domMutationObserver = new MutationObserver(mutations => {
+                callback(mutations);
+            });
+            domMutationObserver.observe(document.documentElement, {
+                childList: true,
+                subtree: true,
+            });
+        };
+        /**
+     * This function is supposed to be called on every DOM change
+     */
+        const hideDynamicAds = () => {
+            const elements = document.querySelectorAll("#contents > ytd-rich-item-renderer ytd-display-ad-renderer");
+            if (elements.length === 0) {
+                return;
+            }
+            elements.forEach(el => {
+                if (el.parentNode && el.parentNode.parentNode) {
+                    const parent = el.parentNode.parentNode as HTMLElement;
+                    if (parent.localName === "ytd-rich-item-renderer") {
+                        parent.style.display = "none";
+                    }
+                }
+            });
+        };
+        /**
+     * This function checks if the video ads are currently running
+     * and auto-clicks the skip button.
+     */
+        const autoSkipAds = () => {
+            // If there's a video that plays the ad at this moment, scroll this ad
+            if (document.querySelector(".ad-showing")) {
+                const video = document.querySelector("video");
+                if (video && video.duration) {
+                    video.currentTime = video.duration;
+                    // Skip button should appear after that,
+                    // now simply click it automatically
+                    setTimeout(() => {
+                        const skipBtn = document.querySelector("button.ytp-ad-skip-button") as HTMLElement;
+                        if (skipBtn) {
+                            skipBtn.click();
+                        }
+                    }, 100);
+                }
+            }
+        };
+        /**
+     * This function overrides a property on the specified object.
+     *
+     * @param {object} obj object to look for properties in
+     * @param {string} propertyName property to override
+     * @param {*} overrideValue value to set
+     */
+        const overrideObject = (obj, propertyName, overrideValue) => {
+            if (!obj) {
+                return false;
+            }
+            let overriden = false;
+            for (const key in obj) {
+                // eslint-disable-next-line no-prototype-builtins
+                if (obj.hasOwnProperty(key) && key === propertyName) {
+                    obj[key] = overrideValue;
+                    overriden = true;
+                    // eslint-disable-next-line no-prototype-builtins
+                } else if (obj.hasOwnProperty(key) && typeof obj[key] === "object") {
+                    if (overrideObject(obj[key], propertyName, overrideValue)) {
+                        overriden = true;
+                    }
+                }
+            }
+            if (overriden) {
+                console.log("found: " + propertyName);
+            }
+            return overriden;
+        };
+        /**
+     * Overrides JSON.parse and Response.json functions.
+     * Examines these functions arguments, looks for properties with the specified name there
+     * and if it exists, changes it's value to what was specified.
+     *
+     * @param {string} propertyName name of the property
+     * @param {*} overrideValue new value for the property
+     */
+        const jsonOverride = (propertyName, overrideValue) => {
+            const nativeJSONParse = JSON.parse;
+            JSON.parse = (...args) => {
+                const obj = nativeJSONParse.apply(this, args);
+                // Override it's props and return back to the caller
+                overrideObject(obj, propertyName, overrideValue);
+                return obj;
+            };
+            // Override Response.prototype.json
+            const nativeResponseJson = Response.prototype.json;
+            Response.prototype.json = new Proxy(nativeResponseJson, {
+                apply(...args) {
+                    // Call the target function, get the original Promise
+                    // @ts-ignore
+                    const promise = Reflect.apply(args) as Promise;
+                    // Create a new one and override the JSON inside
+                    return new Promise((resolve, reject) => {
+                        promise.then(data => {
+                            overrideObject(data, propertyName, overrideValue);
+                            resolve(data);
+                        }).catch(error => reject(error));
+                    });
+                },
+            });
+        };
+        const addAdGuardLogoStyle = () => { };
+        const addAdGuardLogo = () => {
+            if (document.getElementById(LOGO_ID)) {
+                return;
+            }
+            const logo = document.createElement("span");
+            logo.innerHTML = "__logo_text__";
+            logo.setAttribute("id", LOGO_ID);
+            if (window.location.hostname === "m.youtube.com") {
+                const btn = document.querySelector("header.mobile-topbar-header > button") as HTMLElement;
+                if (btn) {
+                    btn.parentNode?.insertBefore(logo, btn.nextSibling);
+                    addAdGuardLogoStyle();
+                }
+            } else if (window.location.hostname === "www.youtube.com") {
+                const code = document.getElementById("country-code");
+                if (code) {
+                    code.innerHTML = "";
+                    code.appendChild(logo);
+                    addAdGuardLogoStyle();
+                }
+            } else if (window.location.hostname === "music.youtube.com") {
+                const el = document.querySelector(".ytmusic-nav-bar#left-content");
+                if (el) {
+                    el.appendChild(logo);
+                    addAdGuardLogoStyle();
+                }
+            } else if (window.location.hostname === "www.youtube-nocookie.com") {
+                const code = document.querySelector("#yt-masthead #logo-container .content-region");
+                if (code) {
+                    code.innerHTML = "";
+                    code.appendChild(logo);
+                    addAdGuardLogoStyle();
+                }
+            }
+        };
+        // Removes ads metadata from YouTube XHR requests
+        jsonOverride("adPlacements", []);
+        jsonOverride("playerAds", []);
+        // Applies CSS that hides YouTube ad elements
+        hideElements();
+        // Some changes should be re-evaluated on every page change
+        addAdGuardLogo();
+        hideDynamicAds();
+        autoSkipAds();
+        observeDomChanges(() => {
+            addAdGuardLogo();
+            hideDynamicAds();
+            autoSkipAds();
+        });
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -379,6 +379,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "ProffDea",
         id: 609329952180928513n
     },
+    matiq: {
+        name: "matiq",
+        id: 257118451892617217n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,20 +1,8 @@
 /*
- * Vencord, a modification for Discord's desktop app
- * Copyright (c) 2022 Vendicated and contributors
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
-*/
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 import { Command } from "@api/Commands";
 import { FluxEvents } from "@webpack/types";
@@ -24,6 +12,10 @@ import { Promisable } from "type-fest";
 export default function definePlugin<P extends PluginDef>(p: P & Record<string, any>) {
     return p;
 }
+export function defineIpcPlugin<P extends IpcPlugin>(p: P) {
+    return p;
+}
+
 
 export type ReplaceFn = (match: string, ...groups: string[]) => string;
 
@@ -115,6 +107,13 @@ export interface PluginDef {
     toolboxActions?: Record<string, () => void>;
 
     tags?: string[];
+}
+
+export interface IpcPlugin {
+    name: string;
+    matcher: RegExp;
+
+    entrypoint: (settings: SettingsStore<SettingsDefinition>) => void | Promise<void>;
 }
 
 export const enum OptionType {
@@ -255,7 +254,7 @@ type PluginSettingDefaultType<O extends PluginSettingDef> = O extends PluginSett
     O["options"] extends { default?: boolean; }[] ? O["options"][number]["value"] : undefined
 ) : O extends { default: infer T; } ? T : undefined;
 
-type SettingsStore<D extends SettingsDefinition> = {
+export type SettingsStore<D extends SettingsDefinition> = {
     [K in keyof D]: PluginSettingType<D[K]> | PluginSettingDefaultType<D[K]>;
 };
 


### PR DESCRIPTION
Allows plugins to inject into discord frames. This is done by creating ipcPlugin.ts inside the plugin folder. This must have the same name as the plugin it belongs to. The plugin will be injected into frames specified by the `matcher` param. I have migrated fixSpotifyEmbeds, and included #1742 as a proof of concept