### PR TITLE
fix(dearrow): don't replace thumbnail if only original available

### DIFF
--- a/src/plugins/dearrow/index.tsx
+++ b/src/plugins/dearrow/index.tsx
@@ -63,7 +63,7 @@ async function embedDidMount(this: Component<Props>) {
             embed.rawTitle = titles[0].title;
         }
 
-        if (thumbnails[0]?.votes >= 0) {
+        if (thumbnails[0]?.votes >= 0 && thumbnails[0].timestamp) {
             embed.dearrow.oldThumb = embed.thumbnail.proxyURL;
             embed.thumbnail.proxyURL = `https://dearrow-thumb.ajay.app/api/v1/getThumbnail?videoID=${videoId}&time=${thumbnails[0].timestamp}`;
         }


### PR DESCRIPTION
Currently the plugin tries to replace thumbnails even when only the original thumbnail is available which fails because the `timestamp` for original thumbnails is `null`. This PR simply adds a check if the timestamp is a non-null value.

Example video where this issue currently occurs for me: https://www.youtube.com/watch?v=I6xwMIUPHss

![image](https://github.com/Vendicated/Vencord/assets/17235016/4743aed4-cf01-445a-84dd-26a7ae756824)
