### PR TITLE
FakeNitro: Fix using stickers everywhere

### DIFF
--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -206,10 +206,10 @@ export default definePlugin({
         },
         // Allow stickers to be sent everywhere
         {
-            find: "canUseStickersEverywhere:function",
+            find: "canUseCustomStickersEverywhere:function",
             predicate: () => settings.store.enableStickerBypass,
             replacement: {
-                match: /canUseStickersEverywhere:function\(\i\){/,
+                match: /canUseCustomStickersEverywhere:function\(\i\){/,
                 replace: "$&return true;"
             },
         },


### PR DESCRIPTION
They renamed `canUseStickersEverywhere` to `canUseCustomStickersEverywhere` apparently