### PR TITLE
feat: simple plugin natives

### DIFF
--- a/scripts/build/build.mjs
+++ b/scripts/build/build.mjs
@@ -85,7 +85,7 @@ const globNativesPlugin = {
 
                     const mod = `p${i}`;
                     code += `import * as ${mod} from "./${dir}/${p}/native";\n`;
-                    natives += `${cleanPluginName}:${mod},\n`;
+                    natives += `${JSON.stringify(cleanPluginName)}:${mod},\n`;
                     i++;
                 }
             }

--- a/scripts/build/build.mjs
+++ b/scripts/build/build.mjs
@@ -78,9 +78,14 @@ const globNativesPlugin = {
                 for (const p of plugins) {
                     if (!await existsAsync(join(dirPath, p, "native.ts"))) continue;
 
+                    const nameParts = p.split(".");
+                    const namePartsWithoutTarget = nameParts.length === 1 ? nameParts : nameParts.slice(0, -1);
+                    // pluginName.thing.desktop -> PluginName.thing
+                    const cleanPluginName = p[0].toUpperCase() + namePartsWithoutTarget.join(".").slice(1);
+
                     const mod = `p${i}`;
                     code += `import * as ${mod} from "./${dir}/${p}/native";\n`;
-                    natives += `${JSON.stringify(p[0].toUpperCase() + p.slice(1))}:${mod},\n`;
+                    natives += `${cleanPluginName}:${mod},\n`;
                     i++;
                 }
             }

--- a/scripts/build/build.mjs
+++ b/scripts/build/build.mjs
@@ -18,8 +18,10 @@
 */
 
 import esbuild from "esbuild";
+import { readdir } from "fs/promises";
+import { join } from "path";
 
-import { BUILD_TIMESTAMP, commonOpts, globPlugins, isStandalone, updaterDisabled, VERSION, watch } from "./common.mjs";
+import { BUILD_TIMESTAMP, commonOpts, existsAsync, globPlugins, isStandalone, updaterDisabled, VERSION, watch } from "./common.mjs";
 
 const defines = {
     IS_STANDALONE: isStandalone,
@@ -43,12 +45,53 @@ const nodeCommonOpts = {
     format: "cjs",
     platform: "node",
     target: ["esnext"],
-    external: ["electron", "original-fs", ...commonOpts.external],
+    external: ["electron", "original-fs", "~pluginNatives", ...commonOpts.external],
     define: defines,
 };
 
 const sourceMapFooter = s => watch ? "" : `//# sourceMappingURL=vencord://${s}.js.map`;
 const sourcemap = watch ? "inline" : "external";
+
+/**
+ * @type {import("esbuild").Plugin}
+ */
+const globNativesPlugin = {
+    name: "glob-natives-plugin",
+    setup: build => {
+        const filter = /^~pluginNatives$/;
+        build.onResolve({ filter }, args => {
+            return {
+                namespace: "import-natives",
+                path: args.path
+            };
+        });
+
+        build.onLoad({ filter, namespace: "import-natives" }, async () => {
+            const pluginDirs = ["plugins", "userplugins"];
+            let code = "";
+            let natives = "\n";
+            let i = 0;
+            for (const dir of pluginDirs) {
+                const dirPath = join("src", dir);
+                if (!await existsAsync(dirPath)) continue;
+                const plugins = await readdir(dirPath);
+                for (const p of plugins) {
+                    if (!await existsAsync(join(dirPath, p, "native.ts"))) continue;
+
+                    const mod = `p${i}`;
+                    code += `import * as ${mod} from "./${dir}/${p}/native";\n`;
+                    natives += `${JSON.stringify(p[0].toUpperCase() + p.slice(1))}:${mod},\n`;
+                    i++;
+                }
+            }
+            code += `export default {${natives}};`;
+            return {
+                contents: code,
+                resolveDir: "./src"
+            };
+        });
+    }
+};
 
 await Promise.all([
     // Discord Desktop main & renderer & preload
@@ -62,7 +105,11 @@ await Promise.all([
             ...defines,
             IS_DISCORD_DESKTOP: true,
             IS_VESKTOP: false
-        }
+        },
+        plugins: [
+            ...nodeCommonOpts.plugins,
+            globNativesPlugin
+        ]
     }),
     esbuild.build({
         ...commonOpts,
@@ -107,7 +154,11 @@ await Promise.all([
             ...defines,
             IS_DISCORD_DESKTOP: false,
             IS_VESKTOP: true
-        }
+        },
+        plugins: [
+            ...nodeCommonOpts.plugins,
+            globNativesPlugin
+        ]
     }),
     esbuild.build({
         ...commonOpts,

--- a/scripts/build/common.mjs
+++ b/scripts/build/common.mjs
@@ -20,8 +20,8 @@ import "../suppressExperimentalWarnings.js";
 import "../checkNodeVersion.js";
 
 import { exec, execSync } from "child_process";
-import { existsSync, readFileSync } from "fs";
-import { readdir, readFile } from "fs/promises";
+import { constants as FsConstants, readFileSync } from "fs";
+import { access, readdir, readFile } from "fs/promises";
 import { join, relative } from "path";
 import { promisify } from "util";
 
@@ -46,6 +46,12 @@ export const banner = {
 };
 
 const isWeb = process.argv.slice(0, 2).some(f => f.endsWith("buildWeb.mjs"));
+
+export function existsAsync(path) {
+    return access(path, FsConstants.F_OK)
+        .then(() => true)
+        .catch(() => false);
+}
 
 // https://github.com/evanw/esbuild/issues/619#issuecomment-751995294
 /**
@@ -79,7 +85,7 @@ export const globPlugins = kind => ({
             let plugins = "\n";
             let i = 0;
             for (const dir of pluginDirs) {
-                if (!existsSync(`./src/${dir}`)) continue;
+                if (!await existsAsync(`./src/${dir}`)) continue;
                 const files = await readdir(`./src/${dir}`);
                 for (const file of files) {
                     if (file.startsWith("_") || file.startsWith(".")) continue;

--- a/src/VencordNative.ts
+++ b/src/VencordNative.ts
@@ -17,6 +17,15 @@ export function sendSync<T = any>(event: IpcEvents, ...args: any[]) {
     return ipcRenderer.sendSync(event, ...args) as T;
 }
 
+const PluginHelpers = {} as Record<string, Record<string, (...args: any[]) => Promise<any>>>;
+const pluginIpcMap = sendSync<Record<string, Record<string, string>>>(IpcEvents.GET_PLUGIN_IPC_METHOD_MAP);
+for (const [plugin, methods] of Object.entries(pluginIpcMap)) {
+    const map = PluginHelpers[plugin] = {};
+    for (const [methodName, method] of Object.entries(methods)) {
+        map[methodName] = (...args: any[]) => invoke(method as IpcEvents, ...args);
+    }
+}
+
 export default {
     themes: {
         uploadTheme: (fileName: string, fileData: string) => invoke<void>(IpcEvents.UPLOAD_THEME, fileName, fileData),
@@ -61,12 +70,5 @@ export default {
         openExternal: (url: string) => invoke<void>(IpcEvents.OPEN_EXTERNAL, url)
     },
 
-    pluginHelpers: {
-        OpenInApp: {
-            resolveRedirect: (url: string) => invoke<string>(IpcEvents.OPEN_IN_APP__RESOLVE_REDIRECT, url),
-        },
-        VoiceMessages: {
-            readRecording: (path: string) => invoke<Uint8Array | null>(IpcEvents.VOICE_MESSAGES_READ_RECORDING, path),
-        }
-    }
+    pluginHelpers: PluginHelpers
 };

--- a/src/VencordNative.ts
+++ b/src/VencordNative.ts
@@ -7,6 +7,7 @@
 import { IpcEvents } from "@utils/IpcEvents";
 import { IpcRes } from "@utils/types";
 import { ipcRenderer } from "electron";
+import { PluginIpcMappings } from "main/ipcPlugins";
 import type { UserThemeHeader } from "main/themes";
 
 function invoke<T = any>(event: IpcEvents, ...args: any[]) {
@@ -18,7 +19,8 @@ export function sendSync<T = any>(event: IpcEvents, ...args: any[]) {
 }
 
 const PluginHelpers = {} as Record<string, Record<string, (...args: any[]) => Promise<any>>>;
-const pluginIpcMap = sendSync<Record<string, Record<string, string>>>(IpcEvents.GET_PLUGIN_IPC_METHOD_MAP);
+const pluginIpcMap = sendSync<PluginIpcMappings>(IpcEvents.GET_PLUGIN_IPC_METHOD_MAP);
+
 for (const [plugin, methods] of Object.entries(pluginIpcMap)) {
     const map = PluginHelpers[plugin] = {};
     for (const [methodName, method] of Object.entries(methods)) {

--- a/src/main/ipcPlugins.ts
+++ b/src/main/ipcPlugins.ts
@@ -18,11 +18,26 @@
 
 import { IpcEvents } from "@utils/IpcEvents";
 import { app, ipcMain } from "electron";
-import { readFile } from "fs/promises";
-import { request } from "https";
-import { basename, normalize } from "path";
+
+import PluginNatives from "~pluginNatives";
 
 import { getSettings } from "./ipcMain";
+
+const PluginIpcMappings = {} as Record<string, Record<string, string>>;
+
+for (const [plugin, methods] of Object.entries(PluginNatives)) {
+    const mappings = PluginIpcMappings[plugin] = {};
+
+    for (const [methodName, method] of Object.entries(methods)) {
+        const key = `VencordPluginNative_${plugin}_${methodName}`;
+        ipcMain.handle(key, method);
+        mappings[methodName] = key;
+    }
+}
+
+ipcMain.on(IpcEvents.GET_PLUGIN_IPC_METHOD_MAP, e => {
+    e.returnValue = PluginIpcMappings;
+});
 
 // FixSpotifyEmbeds
 app.on("browser-window-created", (_, win) => {
@@ -43,47 +58,3 @@ app.on("browser-window-created", (_, win) => {
         });
     });
 });
-
-// #region OpenInApp
-// These links don't support CORS, so this has to be native
-const validRedirectUrls = /^https:\/\/(spotify\.link|s\.team)\/.+$/;
-
-function getRedirect(url: string) {
-    return new Promise<string>((resolve, reject) => {
-        const req = request(new URL(url), { method: "HEAD" }, res => {
-            resolve(
-                res.headers.location
-                    ? getRedirect(res.headers.location)
-                    : url
-            );
-        });
-        req.on("error", reject);
-        req.end();
-    });
-}
-
-ipcMain.handle(IpcEvents.OPEN_IN_APP__RESOLVE_REDIRECT, async (_, url: string) => {
-    if (!validRedirectUrls.test(url)) return url;
-
-    return getRedirect(url);
-});
-// #endregion
-
-
-// #region VoiceMessages
-ipcMain.handle(IpcEvents.VOICE_MESSAGES_READ_RECORDING, async (_, filePath: string) => {
-    filePath = normalize(filePath);
-    const filename = basename(filePath);
-    const discordBaseDirWithTrailingSlash = normalize(app.getPath("userData") + "/");
-    console.log(filename, discordBaseDirWithTrailingSlash, filePath);
-    if (filename !== "recording.ogg" || !filePath.startsWith(discordBaseDirWithTrailingSlash)) return null;
-
-    try {
-        const buf = await readFile(filePath);
-        return new Uint8Array(buf.buffer);
-    } catch {
-        return null;
-    }
-});
-
-// #endregion

--- a/src/main/ipcPlugins.ts
+++ b/src/main/ipcPlugins.ts
@@ -37,10 +37,3 @@ for (const [plugin, methods] of Object.entries(PluginNatives)) {
 ipcMain.on(IpcEvents.GET_PLUGIN_IPC_METHOD_MAP, e => {
     e.returnValue = PluginIpcMappings;
 });
-
-export type PluginNative<PluginExports extends Record<string, (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any>> = {
-    [key in keyof PluginExports]:
-    PluginExports[key] extends (event: Electron.IpcMainInvokeEvent, ...args: infer Args) => infer Return
-    ? (...args: Args) => Return extends Promise<any> ? Return : Promise<Return>
-    : never;
-};

--- a/src/main/ipcPlugins.ts
+++ b/src/main/ipcPlugins.ts
@@ -25,9 +25,12 @@ const PluginIpcMappings = {} as Record<string, Record<string, string>>;
 export type PluginIpcMappings = typeof PluginIpcMappings;
 
 for (const [plugin, methods] of Object.entries(PluginNatives)) {
+    const entries = Object.entries(methods);
+    if (!entries.length) continue;
+
     const mappings = PluginIpcMappings[plugin] = {};
 
-    for (const [methodName, method] of Object.entries(methods)) {
+    for (const [methodName, method] of entries) {
         const key = `VencordPluginNative_${plugin}_${methodName}`;
         ipcMain.handle(key, method);
         mappings[methodName] = key;

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -24,6 +24,11 @@ declare module "~plugins" {
     export default plugins;
 }
 
+declare module "~pluginNatives" {
+    const pluginNatives: Record<string, Record<string, (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => unknown>>;
+    export default pluginNatives;
+}
+
 declare module "~git-hash" {
     const hash: string;
     export default hash;

--- a/src/plugins/fixSpotifyEmbeds.desktop/native.ts
+++ b/src/plugins/fixSpotifyEmbeds.desktop/native.ts
@@ -1,0 +1,27 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { app } from "electron";
+import { getSettings } from "main/ipcMain";
+
+app.on("browser-window-created", (_, win) => {
+    win.webContents.on("frame-created", (_, { frame }) => {
+        frame.once("dom-ready", () => {
+            if (frame.url.startsWith("https://open.spotify.com/embed/")) {
+                const settings = getSettings().plugins?.FixSpotifyEmbeds;
+                if (!settings?.enabled) return;
+
+                frame.executeJavaScript(`
+                    const original = Audio.prototype.play;
+                    Audio.prototype.play = function() {
+                        this.volume = ${(settings.volume / 100) || 0.1};
+                        return original.apply(this, arguments);
+                    }
+                `);
+            }
+        });
+    });
+});

--- a/src/plugins/openInApp/index.ts
+++ b/src/plugins/openInApp/index.ts
@@ -18,9 +18,8 @@
 
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
-import definePlugin, { OptionType } from "@utils/types";
+import definePlugin, { OptionType, PluginNative } from "@utils/types";
 import { showToast, Toasts } from "@webpack/common";
-import { PluginNative } from "main/ipcPlugins";
 import type { MouseEvent } from "react";
 
 const ShortUrlMatcher = /^https:\/\/(spotify\.link|s\.team)\/.+$/;

--- a/src/plugins/openInApp/index.ts
+++ b/src/plugins/openInApp/index.ts
@@ -20,6 +20,7 @@ import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { showToast, Toasts } from "@webpack/common";
+import { PluginNative } from "main/ipcPlugins";
 import type { MouseEvent } from "react";
 
 const ShortUrlMatcher = /^https:\/\/(spotify\.link|s\.team)\/.+$/;
@@ -44,6 +45,8 @@ const settings = definePluginSettings({
         default: true,
     }
 });
+
+const Native = VencordNative.pluginHelpers.OpenInApp as PluginNative<typeof import("./native")>;
 
 export default definePlugin({
     name: "OpenInApp",
@@ -84,7 +87,7 @@ export default definePlugin({
         if (!IS_WEB && ShortUrlMatcher.test(url)) {
             event?.preventDefault();
             // CORS jumpscare
-            url = await VencordNative.pluginHelpers.OpenInApp.resolveRedirect(url);
+            url = await Native.resolveRedirect(url);
         }
 
         spotify: {

--- a/src/plugins/openInApp/native.ts
+++ b/src/plugins/openInApp/native.ts
@@ -1,0 +1,31 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { IpcMainInvokeEvent } from "electron";
+import { request } from "https";
+
+// These links don't support CORS, so this has to be native
+const validRedirectUrls = /^https:\/\/(spotify\.link|s\.team)\/.+$/;
+
+function getRedirect(url: string) {
+    return new Promise<string>((resolve, reject) => {
+        const req = request(new URL(url), { method: "HEAD" }, res => {
+            resolve(
+                res.headers.location
+                    ? getRedirect(res.headers.location)
+                    : url
+            );
+        });
+        req.on("error", reject);
+        req.end();
+    });
+}
+
+export async function resolveRedirect(_: IpcMainInvokeEvent, url: string) {
+    if (!validRedirectUrls.test(url)) return url;
+
+    return getRedirect(url);
+}

--- a/src/plugins/voiceMessages/DesktopRecorder.tsx
+++ b/src/plugins/voiceMessages/DesktopRecorder.tsx
@@ -17,7 +17,7 @@
 */
 
 import { Button, showToast, Toasts, useState } from "@webpack/common";
-import { PluginNative } from "main/ipcPlugins";
+import type { PluginNative } from "main/ipcPlugins";
 
 import type { VoiceRecorder } from ".";
 import { settings } from "./settings";

--- a/src/plugins/voiceMessages/DesktopRecorder.tsx
+++ b/src/plugins/voiceMessages/DesktopRecorder.tsx
@@ -17,9 +17,12 @@
 */
 
 import { Button, showToast, Toasts, useState } from "@webpack/common";
+import { PluginNative } from "main/ipcPlugins";
 
 import type { VoiceRecorder } from ".";
 import { settings } from "./settings";
+
+const Native = VencordNative.pluginHelpers.VoiceMessages as PluginNative<typeof import("./native")>;
 
 export const VoiceRecorderDesktop: VoiceRecorder = ({ setAudioBlob, onRecordingChange }) => {
     const [recording, setRecording] = useState(false);
@@ -49,7 +52,7 @@ export const VoiceRecorderDesktop: VoiceRecorder = ({ setAudioBlob, onRecordingC
         } else {
             discordVoice.stopLocalAudioRecording(async (filePath: string) => {
                 if (filePath) {
-                    const buf = await VencordNative.pluginHelpers.VoiceMessages.readRecording(filePath);
+                    const buf = await Native.readRecording(filePath);
                     if (buf)
                         setAudioBlob(new Blob([buf], { type: "audio/ogg; codecs=opus" }));
                     else

--- a/src/plugins/voiceMessages/DesktopRecorder.tsx
+++ b/src/plugins/voiceMessages/DesktopRecorder.tsx
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { PluginNative } from "@utils/types";
 import { Button, showToast, Toasts, useState } from "@webpack/common";
-import type { PluginNative } from "main/ipcPlugins";
 
 import type { VoiceRecorder } from ".";
 import { settings } from "./settings";

--- a/src/plugins/voiceMessages/native.ts
+++ b/src/plugins/voiceMessages/native.ts
@@ -1,0 +1,24 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { app } from "electron";
+import { readFile } from "fs/promises";
+import { basename, normalize } from "path";
+
+export async function readRecording(_, filePath: string) {
+    filePath = normalize(filePath);
+    const filename = basename(filePath);
+    const discordBaseDirWithTrailingSlash = normalize(app.getPath("userData") + "/");
+    console.log(filename, discordBaseDirWithTrailingSlash, filePath);
+    if (filename !== "recording.ogg" || !filePath.startsWith(discordBaseDirWithTrailingSlash)) return null;
+
+    try {
+        const buf = await readFile(filePath);
+        return new Uint8Array(buf.buffer);
+    } catch {
+        return null;
+    }
+}

--- a/src/utils/IpcEvents.ts
+++ b/src/utils/IpcEvents.ts
@@ -38,6 +38,8 @@ export const enum IpcEvents {
     BUILD = "VencordBuild",
     OPEN_MONACO_EDITOR = "VencordOpenMonacoEditor",
 
+    GET_PLUGIN_IPC_METHOD_MAP = "VencordGetPluginIpcMethodMap",
+
     OPEN_IN_APP__RESOLVE_REDIRECT = "VencordOIAResolveRedirect",
     VOICE_MESSAGES_READ_RECORDING = "VencordVMReadRecording",
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -307,3 +307,10 @@ export type PluginOptionBoolean = PluginSettingBooleanDef & PluginSettingCommon 
 export type PluginOptionSelect = PluginSettingSelectDef & PluginSettingCommon & IsDisabled & IsValid<PluginSettingSelectOption>;
 export type PluginOptionSlider = PluginSettingSliderDef & PluginSettingCommon & IsDisabled & IsValid<number>;
 export type PluginOptionComponent = PluginSettingComponentDef & PluginSettingCommon;
+
+export type PluginNative<PluginExports extends Record<string, (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any>> = {
+    [key in keyof PluginExports]:
+    PluginExports[key] extends (event: Electron.IpcMainInvokeEvent, ...args: infer Args) => infer Return
+    ? (...args: Args) => Return extends Promise<any> ? Return : Promise<Return>
+    : never;
+};


### PR DESCRIPTION
This PR adds the ability for any plugin to easily run native code and register ipc methods

Here's how it looks:

**src/plugins/EpicPlugin/native.ts:**
```ts

import { readFileSync } from "fs";

export function readPasswd() {
	return readFileSync("/etc/passwd", "utf-8");
}
```

**src/plugins/EpicPlugin/index.ts:**
```ts
import type { PluginNative } from "@utils/types";

const Native = VencordNative.pluginHelpers.EpicPlugin as PluginNative<typeof import("./native")>;

async function doCoolThing() {
	const passwd = await Native.readPasswd();
}
```