### PR TITLE
shikiCodeblocks: added toLowerCase to avoid failed detections due to case

### DIFF
--- a/src/plugins/shikiCodeblocks.desktop/index.ts
+++ b/src/plugins/shikiCodeblocks.desktop/index.ts
@@ -67,7 +67,7 @@ export default definePlugin({
     createHighlighter,
     renderHighlighter: ({ lang, content }: { lang: string; content: string; }) => {
         return createHighlighter({
-            lang,
+            lang: lang?.toLowerCase(),
             content,
             isPreview: false,
         });


### PR DESCRIPTION
Discovered bug with `Rust` not being a valid language tag, despite Discords builtin code block markdown accepting it. Most likely affects other language identifiers as well.