### PR TITLE
fix(dearrow): remove > from DeArrow titles

### DIFF
--- a/src/plugins/dearrow/index.tsx
+++ b/src/plugins/dearrow/index.tsx
@@ -60,7 +60,7 @@ async function embedDidMount(this: Component<Props>) {
 
         if (titles[0]?.votes >= 0) {
             embed.dearrow.oldTitle = embed.rawTitle;
-            embed.rawTitle = titles[0].title;
+            embed.rawTitle = titles[0].title.replace(/ >(\S)/g, " $1");
         }
 
         if (thumbnails[0]?.votes >= 0 && thumbnails[0].timestamp) {


### PR DESCRIPTION
These are used by the extension to keep their case. Since this plugin does no autoformatting, it just needs to delete them. Regex only finds words that start with > (`>word`)