### PR TITLE
feat(plugin): FixEmojiCrash

### DIFF
--- a/src/plugins/fixEmojiCrash/index.ts
+++ b/src/plugins/fixEmojiCrash/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "FixEmojiCrash",
+    authors: [Devs.AutumnVN],
+    description: "Fix emoji has name 'default' causing crash",
+    patches: [
+        {
+            find: "getTermsForEmoji:function",
+            replacement: {
+                match: /getTermsForEmoji:function\((\i)\){/,
+                replace: "$& if ($1 === 'default') return [];"
+            }
+        }]
+});


### PR DESCRIPTION
fix emoji has name `default` cause discord explod

step to reproduce:
1. create emoji with name `default`
2. search some emoji in chat by typing something like `:abcdef`
3. watch your discord explod :trollface: 