### PR TITLE
fix(SpotifyControls): Requests double-sending when using Spotify Connect

### DIFF
--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -55,13 +55,19 @@ export default definePlugin({
                 replace: "return [$self.renderPlayer(),$1]"
             }
         },
-        // Adds POST and a Marker to the SpotifyAPI (so we can easily find it)
         {
             find: ".PLAYER_DEVICES",
-            replacement: {
+            replacement: [{
+                // Adds POST and a Marker to the SpotifyAPI (so we can easily find it)
                 match: /get:(\i)\.bind\(null,(\i\.\i)\.get\)/,
                 replace: "post:$1.bind(null,$2.post),$&"
-            }
+            },
+            {
+                // Spotify Connect API returns status 202 instead of 204 when skipping tracks.
+                // Discord rejects 202 which causes the request to send twice. This patch prevents this.
+                match: /202===\i\.status/,
+                replace: "false",
+            }]
         },
         // Discord doesn't give you the repeat kind, only a boolean
         {
@@ -70,7 +76,7 @@ export default definePlugin({
                 match: /repeat:"off"!==(.{1,3}),/,
                 replace: "actual_repeat:$1,$&"
             }
-        }
+        },
     ],
     start: () => toggleHoverControls(Settings.plugins.SpotifyControls.hoverControls),
     renderPlayer: () => <Player />


### PR DESCRIPTION
Fixes https://github.com/Vendicated/Vencord/issues/2022

Disables the check for status 202 which causes the promise to reject.