### PR TITLE
Fix QuickMention not working in DMs

### DIFF
--- a/src/plugins/quickMention/index.tsx
+++ b/src/plugins/quickMention/index.tsx
@@ -31,7 +31,7 @@ export default definePlugin({
     start() {
         addButton("QuickMention", msg => {
             const channel = ChannelStore.getChannel(msg.channel_id);
-            if (!PermissionStore.can(PermissionsBits.SEND_MESSAGES, channel)) return null;
+            if (!channel.guild_id || !PermissionStore.can(PermissionsBits.SEND_MESSAGES, channel)) return null;
 
             return {
                 label: "Quick Mention",

--- a/src/plugins/quickMention/index.tsx
+++ b/src/plugins/quickMention/index.tsx
@@ -31,7 +31,7 @@ export default definePlugin({
     start() {
         addButton("QuickMention", msg => {
             const channel = ChannelStore.getChannel(msg.channel_id);
-            if (!channel.guild_id || !PermissionStore.can(PermissionsBits.SEND_MESSAGES, channel)) return null;
+            if (channel.guild_id && !PermissionStore.can(PermissionsBits.SEND_MESSAGES, channel)) return null;
 
             return {
                 label: "Quick Mention",


### PR DESCRIPTION
Fix the check added in #1746 to make the button show up in direct messages.
One remaining issue is the official Discord DM where the button should not show up but I don't know what's the best way to deal with it. First PR, forgive me if something's wrong :p