### PR TITLE
ReactErrorDecoder: fix using wrong react version's error map

### DIFF
--- a/src/plugins/reactErrorDecoder/index.ts
+++ b/src/plugins/reactErrorDecoder/index.ts
@@ -38,7 +38,6 @@ export default definePlugin({
     ],
 
     async start() {
-        // Moved this into start function because we can't use React top-level, too early
         const CODES_URL = `https://raw.githubusercontent.com/facebook/react/v${React.version}/scripts/error-codes/codes.json`;
 
         ERROR_CODES = await fetch(CODES_URL)

--- a/src/plugins/reactErrorDecoder/index.ts
+++ b/src/plugins/reactErrorDecoder/index.ts
@@ -18,27 +18,29 @@
 
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
+import { React } from "@webpack/common";
 
 let ERROR_CODES: any;
-const CODES_URL =
-    "https://raw.githubusercontent.com/facebook/react/17.0.2/scripts/error-codes/codes.json";
 
 export default definePlugin({
     name: "ReactErrorDecoder",
     description: 'Replaces "Minifed React Error" with the actual error.',
-    authors: [Devs.Cyn],
+    authors: [Devs.Cyn, Devs.maisymoe],
     patches: [
         {
             find: '"https://reactjs.org/docs/error-decoder.html?invariant="',
             replacement: {
                 match: /(function .\(.\)){(for\(var .="https:\/\/reactjs\.org\/docs\/error-decoder\.html\?invariant="\+.,.=1;.<arguments\.length;.\+\+\).\+="&args\[\]="\+encodeURIComponent\(arguments\[.\]\);return"Minified React error #"\+.\+"; visit "\+.\+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings.")}/,
                 replace: (_, func, original) =>
-                    `${func}{var decoded=Vencord.Plugins.plugins.ReactErrorDecoder.decodeError.apply(null, arguments);if(decoded)return decoded;${original}}`,
+                    `${func}{var decoded=$self.decodeError.apply(null, arguments);if(decoded)return decoded;${original}}`,
             },
         },
     ],
 
     async start() {
+        // Moved this into start function because we can't use React top-level, too early
+        const CODES_URL = `https://raw.githubusercontent.com/facebook/react/v${React.version}/scripts/error-codes/codes.json`;
+
         ERROR_CODES = await fetch(CODES_URL)
             .then(res => res.json())
             .catch(e => console.error("[ReactErrorDecoder] Failed to fetch React error codes\n", e));

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -395,6 +395,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Korbo",
         id: 455856406420258827n
     },
+    maisymoe: {
+        name: "maisy",
+        id: 257109471589957632n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
* make use of `$self` (probably didn't before because old?)
* fetch errors for the *current* React version, not a hardcoded one
* add myself to `Devs` (if my changes aren't fit for this, i can remove)

<hr>

i noticed this (and checked if desktop was the same):
![Vendetta debugger, showing a newer React version](https://github.com/Vendicated/Vencord/assets/61095277/7e1422d7-0be4-45c5-995d-7fbfe5eea45f)

given i was already making this PR, i thought i would make a few other small changes too :>