### PR TITLE
GameActivityToggle icon match other toggles

### DIFF
--- a/src/plugins/gameActivityToggle/index.tsx
+++ b/src/plugins/gameActivityToggle/index.tsx
@@ -28,21 +28,22 @@ import style from "./style.css?managed";
 const Button = findComponentByCodeLazy("Button.Sizes.NONE,disabled:");
 
 function makeIcon(showCurrentGame?: boolean) {
+    const controllerIcon = "M3.06 20.4q-1.53 0-2.37-1.065T.06 16.74l1.26-9q.27-1.8 1.605-2.97T6.06 3.6h11.88q1.8 0 3.135 1.17t1.605 2.97l1.26 9q.21 1.53-.63 2.595T20.94 20.4q-.63 0-1.17-.225T18.78 19.5l-2.7-2.7H7.92l-2.7 2.7q-.45.45-.99.675t-1.17.225Zm14.94-7.2q.51 0 .855-.345T19.2 12q0-.51-.345-.855T18 10.8q-.51 0-.855.345T16.8 12q0 .51.345 .855T18 13.2Zm-2.4-3.6q.51 0 .855-.345T16.8 8.4q0-.51-.345-.855T15.6 7.2q-.51 0-.855.345T14.4 8.4q0 .51.345 .855T15.6 9.6ZM6.9 13.2h1.8v-2.1h2.1v-1.8h-2.1v-2.1h-1.8v2.1h-2.1v1.8h2.1v2.1Z";
     return function () {
         return (
-            <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-            >
-                <path fill="currentColor" mask="url(#gameActivityMask)" d="M3.06 20.4q-1.53 0-2.37-1.065T.06 16.74l1.26-9q.27-1.8 1.605-2.97T6.06 3.6h11.88q1.8 0 3.135 1.17t1.605 2.97l1.26 9q.21 1.53-.63 2.595T20.94 20.4q-.63 0-1.17-.225T18.78 19.5l-2.7-2.7H7.92l-2.7 2.7q-.45.45-.99.675t-1.17.225Zm14.94-7.2q.51 0 .855-.345T19.2 12q0-.51-.345-.855T18 10.8q-.51 0-.855.345T16.8 12q0 .51.345 .855T18 13.2Zm-2.4-3.6q.51 0 .855-.345T16.8 8.4q0-.51-.345-.855T15.6 7.2q-.51 0-.855.345T14.4 8.4q0 .51.345 .855T15.6 9.6ZM6.9 13.2h1.8v-2.1h2.1v-1.8h-2.1v-2.1h-1.8v2.1h-2.1v1.8h2.1v2.1Z" />
-                {!showCurrentGame && <>
-                    <mask id="gameActivityMask" >
-                        <rect fill="white" x="0" y="0" width="24" height="24" />
-                        <path fill="black" d="M23.27 4.54 19.46.73 .73 19.46 4.54 23.27 23.27 4.54Z" />
-                    </mask>
-                    <path fill="var(--status-danger)" d="M23 2.27 21.73 1 1 21.73 2.27 23 23 2.27Z" />
-                </>}
+            <svg width="20" height="20" viewBox="0 0 24 24">
+                {showCurrentGame ? (
+                    <path fill="currentColor" d={controllerIcon} />
+                ) : (
+                    <>
+                        <mask id="gameActivityMask" >
+                            <rect fill="white" x="0" y="0" width="24" height="24" />
+                            <path fill="black" d="M23.27 4.73 19.27 .73 -.27 20.27 3.73 24.27Z" />
+                        </mask>
+                        <path fill="var(--status-danger)" mask="url(#gameActivityMask)" d={controllerIcon} />
+                        <path fill="var(--status-danger)" d="M22.7 2.7a1 1 0 0 0-1.4-1.4l-20 20a1 1 0 1 0 1.4 1.4Z" />
+                    </>
+                )}
             </svg>
         );
     };


### PR DESCRIPTION
**Summary of changes**
- Update `GameActivityToggle` icon to match new mute, deafen icons.
  - Before:
![image](https://github.com/Vendicated/Vencord/assets/126130342/a5cf481a-24fa-40f8-b6a4-8ed4d506eab5)
  - After:
![image](https://github.com/Vendicated/Vencord/assets/126130342/73b08082-061e-4156-a27a-23bb6978b2b5)

**Why this is needed**
- Discord recently updated mute and deafen icons, so they no longer match.

**Fun details**
- The new slashes used in the mute and deafen icons are identical SVG data. Consequently, all 3 slashes can match, whereas previously they were all unique to account for apparent icon sizes.