### PR TITLE
feat(plugin): Additional setting for TypingIndicator

### DIFF
--- a/src/plugins/typingIndicator/index.tsx
+++ b/src/plugins/typingIndicator/index.tsx
@@ -19,7 +19,6 @@
 import { definePluginSettings, Settings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
-import { getCurrentChannel } from "@utils/discord";
 import definePlugin, { OptionType } from "@utils/types";
 import { findExportedComponentLazy, findStoreLazy } from "@webpack";
 import { ChannelStore, GuildMemberStore, i18n, RelationshipStore, SelectedChannelStore, Tooltip, UserStore, useStateFromStores } from "@webpack/common";

--- a/src/plugins/typingIndicator/index.tsx
+++ b/src/plugins/typingIndicator/index.tsx
@@ -19,9 +19,10 @@
 import { definePluginSettings, Settings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
+import { getCurrentChannel } from "@utils/discord";
 import definePlugin, { OptionType } from "@utils/types";
 import { findExportedComponentLazy, findStoreLazy } from "@webpack";
-import { ChannelStore, GuildMemberStore, i18n, RelationshipStore, Tooltip, UserStore, useStateFromStores } from "@webpack/common";
+import { ChannelStore, GuildMemberStore, i18n, RelationshipStore, SelectedChannelStore, Tooltip, UserStore, useStateFromStores } from "@webpack/common";
 
 import { buildSeveralUsers } from "../typingTweaks";
 
@@ -47,12 +48,16 @@ function TypingIndicator({ channelId }: { channelId: string; }) {
             return oldKeys.length === currentKeys.length && currentKeys.every(key => old[key] != null);
         }
     );
-
+    const { id: currentChannelId, guild_id: currentGuildId } = useStateFromStores([SelectedChannelStore], () => getCurrentChannel());
     const guildId = ChannelStore.getChannel(channelId).guild_id;
 
     if (!settings.store.includeMutedChannels) {
         const isChannelMuted = UserGuildSettingsStore.isChannelMuted(guildId, channelId);
         if (isChannelMuted) return null;
+    }
+
+    if (!settings.store.includeCurrentChannel) {
+        if (currentChannelId == channelId) return null;
     }
 
     const myId = UserStore.getCurrentUser()?.id;
@@ -101,6 +106,11 @@ function TypingIndicator({ channelId }: { channelId: string; }) {
 }
 
 const settings = definePluginSettings({
+    includeCurrentChannel: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to show the typing indicator for the currently selected channel",
+        default: true
+    },
     includeMutedChannels: {
         type: OptionType.BOOLEAN,
         description: "Whether to show the typing indicator for muted channels.",

--- a/src/plugins/typingIndicator/index.tsx
+++ b/src/plugins/typingIndicator/index.tsx
@@ -47,7 +47,7 @@ function TypingIndicator({ channelId }: { channelId: string; }) {
             return oldKeys.length === currentKeys.length && currentKeys.every(key => old[key] != null);
         }
     );
-    const { id: currentChannelId, guild_id: currentGuildId } = useStateFromStores([SelectedChannelStore], () => getCurrentChannel());
+    const id: string = useStateFromStores([SelectedChannelStore], () => SelectedChannelStore.getChannelId());
     const guildId = ChannelStore.getChannel(channelId).guild_id;
 
     if (!settings.store.includeMutedChannels) {

--- a/src/plugins/typingIndicator/index.tsx
+++ b/src/plugins/typingIndicator/index.tsx
@@ -47,7 +47,7 @@ function TypingIndicator({ channelId }: { channelId: string; }) {
             return oldKeys.length === currentKeys.length && currentKeys.every(key => old[key] != null);
         }
     );
-    const id: string = useStateFromStores([SelectedChannelStore], () => SelectedChannelStore.getChannelId());
+    const currentChannelId: string = useStateFromStores([SelectedChannelStore], () => SelectedChannelStore.getChannelId());
     const guildId = ChannelStore.getChannel(channelId).guild_id;
 
     if (!settings.store.includeMutedChannels) {

--- a/src/plugins/typingIndicator/index.tsx
+++ b/src/plugins/typingIndicator/index.tsx
@@ -56,7 +56,7 @@ function TypingIndicator({ channelId }: { channelId: string; }) {
     }
 
     if (!settings.store.includeCurrentChannel) {
-        if (currentChannelId == channelId) return null;
+        if (currentChannelId === channelId) return null;
     }
 
     const myId = UserStore.getCurrentUser()?.id;


### PR DESCRIPTION
This PR allows the user to choose whether or not the plugin's typing indicator appears on the channel sidebar of the currently selected channel.

The default value is `TRUE`, as to maintain the same functionality as previous versions of the plugin.

![TypingIndicator](https://github.com/Vendicated/Vencord/assets/57331134/50fc9902-d8d5-476f-b97d-88e591ec130c)
