### PR TITLE
feat(plugin): Change previewMessage SVG icon

### DIFF
--- a/src/plugins/previewMessage/index.tsx
+++ b/src/plugins/previewMessage/index.tsx
@@ -110,15 +110,18 @@ export function PreviewButton(chatBoxProps: Props) {
                         )}
                     size=""
                     look={ButtonLooks.BLANK}
-                    innerClassName={ButtonWrapperClasses.button}
-                    style={{ padding: "0 2px 0 0", height: "100%" }}
+                    innerClassName={ButtonWrapperClasses.button + " " + ButtonWrapperClasses.buttonWrapper}
                 >
-                    <div className={ButtonWrapperClasses.buttonWrapper}>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                        <path fill="currentColor" d="M15.56 11.77c.2-.1.44.02.44.23a4 4 0 1 1-4-4c.21 0 .33.25.23.44a2.5 2.5 0 0 0 3.32 3.32Z"></path>
-                        <path fill="currentColor" fill-rule="evenodd" d="M22.89 11.7c.07.2.07.4 0 .6C22.27 13.9 19.1 21 12 21c-7.11 0-10.27-7.11-10.89-8.7a.83.83 0 0 1 0-.6C1.73 10.1 4.9 3 12 3c7.11 0 10.27 7.11 10.89 8.7Zm-4.5-3.62A15.11 15.11 0 0 1 20.85 12c-.38.88-1.18 2.47-2.46 3.92C16.87 17.62 14.8 19 12 19c-2.8 0-4.87-1.38-6.39-3.08A15.11 15.11 0 0 1 3.15 12c.38-.88 1.18-2.47 2.46-3.92C7.13 6.38 9.2 5 12 5c2.8 0 4.87 1.38 6.39 3.08Z" clip-rule="evenodd"></path>
-                        </svg>
-                    </div>
+                    <svg
+                        fill="currentColor"
+                        fillRule="evenodd"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        style={{ padding: "4px", margin: "0 4px" }}
+                    >
+                        <path d="M22.89 11.7c.07.2.07.4 0 .6C22.27 13.9 19.1 21 12 21c-7.11 0-10.27-7.11-10.89-8.7a.83.83 0 0 1 0-.6C1.73 10.1 4.9 3 12 3c7.11 0 10.27 7.11 10.89 8.7Zm-4.5-3.62A15.11 15.11 0 0 1 20.85 12c-.38.88-1.18 2.47-2.46 3.92C16.87 17.62 14.8 19 12 19c-2.8 0-4.87-1.38-6.39-3.08A15.11 15.11 0 0 1 3.15 12c.38-.88 1.18-2.47 2.46-3.92C7.13 6.38 9.2 5 12 5c2.8 0 4.87 1.38 6.39 3.08ZM15.56 11.77c.2-.1.44.02.44.23a4 4 0 1 1-4-4c.21 0 .33.25.23.44a2.5 2.5 0 0 0 3.32 3.32Z" />
+                    </svg>
                 </Button>
             )}
         </Tooltip>

--- a/src/plugins/previewMessage/index.tsx
+++ b/src/plugins/previewMessage/index.tsx
@@ -111,16 +111,12 @@ export function PreviewButton(chatBoxProps: Props) {
                     size=""
                     look={ButtonLooks.BLANK}
                     innerClassName={ButtonWrapperClasses.button}
-                    style={{ padding: "0 2px", height: "100%" }}
+                    style={{ padding: "0 2px 0 0", height: "100%" }}
                 >
                     <div className={ButtonWrapperClasses.buttonWrapper}>
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
-                        <path d="M 0, 12 a 5.8, 9.3 0 1, 0 11.6, 0 a 5.8, 9.3 0 1, 0 -11.6, 0 Z
-                                 M 1.2, 12 a 3.3, 3.3 0 1, 0 6.6, 0 a 3.3, 3.3 0 1, 0 -6.6, 0 Z
-                                 M 12.4, 12 a 5.8, 9.3 0 1, 0 11.6, 0 a 5.8, 9.3 0 1, 0 -11.6, 0 Z
-                                 M 13.7, 12 a 3.3, 3.3 0 1, 0 6.6, 0 a 3.3, 3.3 0 1, 0 -6.6, 0 Z"
-                            fill="currentColor"
-                            fill-rule="evenodd"/>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                        <path fill="currentColor" d="M15.56 11.77c.2-.1.44.02.44.23a4 4 0 1 1-4-4c.21 0 .33.25.23.44a2.5 2.5 0 0 0 3.32 3.32Z"></path>
+                        <path fill="currentColor" fill-rule="evenodd" d="M22.89 11.7c.07.2.07.4 0 .6C22.27 13.9 19.1 21 12 21c-7.11 0-10.27-7.11-10.89-8.7a.83.83 0 0 1 0-.6C1.73 10.1 4.9 3 12 3c7.11 0 10.27 7.11 10.89 8.7Zm-4.5-3.62A15.11 15.11 0 0 1 20.85 12c-.38.88-1.18 2.47-2.46 3.92C16.87 17.62 14.8 19 12 19c-2.8 0-4.87-1.38-6.39-3.08A15.11 15.11 0 0 1 3.15 12c.38-.88 1.18-2.47 2.46-3.92C7.13 6.38 9.2 5 12 5c2.8 0 4.87 1.38 6.39 3.08Z" clip-rule="evenodd"></path>
                         </svg>
                     </div>
                 </Button>

--- a/src/plugins/previewMessage/index.tsx
+++ b/src/plugins/previewMessage/index.tsx
@@ -114,7 +114,14 @@ export function PreviewButton(chatBoxProps: Props) {
                     style={{ padding: "0 2px", height: "100%" }}
                 >
                     <div className={ButtonWrapperClasses.buttonWrapper}>
-                        <img width={24} height={24} src="https://discord.com/assets/4c5a77a89716352686f590a6f014770c.svg" />
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+                        <path d="M 0, 12 a 5.8, 9.3 0 1, 0 11.6, 0 a 5.8, 9.3 0 1, 0 -11.6, 0 Z
+                                 M 1.2, 12 a 3.3, 3.3 0 1, 0 6.6, 0 a 3.3, 3.3 0 1, 0 -6.6, 0 Z
+                                 M 12.4, 12 a 5.8, 9.3 0 1, 0 11.6, 0 a 5.8, 9.3 0 1, 0 -11.6, 0 Z
+                                 M 13.7, 12 a 3.3, 3.3 0 1, 0 6.6, 0 a 3.3, 3.3 0 1, 0 -6.6, 0 Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"/>
+                        </svg>
                     </div>
                 </Button>
             )}


### PR DESCRIPTION
This PR changes the SVG icon in the plugin previewMessage with one that attempts to closer match the style of Discord's chat bar icons.

Before:

![before_IMG](https://github.com/Vendicated/Vencord/assets/57331134/b910855b-e5c5-4831-95a9-f8c5233bcebc)

After:

![after_SVG](https://github.com/Vendicated/Vencord/assets/57331134/6ba1f468-eebc-4f24-b987-5215bc26f82d)
