### PR TITLE
feat: only show one QuickCSS editor window

### DIFF
--- a/src/main/ipcMain.ts
+++ b/src/main/ipcMain.ts
@@ -138,20 +138,26 @@ export function initIpc(mainWindow: BrowserWindow) {
     }));
 }
 
+let monacoEditorWin: BrowserWindow;
+
 ipcMain.handle(IpcEvents.OPEN_MONACO_EDITOR, async () => {
-    const win = new BrowserWindow({
-        title: "Vencord QuickCSS Editor",
-        autoHideMenuBar: true,
-        darkTheme: true,
-        webPreferences: {
-            preload: join(__dirname, IS_DISCORD_DESKTOP ? "preload.js" : "vencordDesktopPreload.js"),
-            contextIsolation: true,
-            nodeIntegration: false,
-            sandbox: false
-        }
-    });
+    if (monacoEditorWin && monacoEditorWin.focusable) {
+        monacoEditorWin.focus();
+    } else {
+        monacoEditorWin = new BrowserWindow({
+            title: "Vencord QuickCSS Editor",
+            autoHideMenuBar: true,
+            darkTheme: true,
+            webPreferences: {
+                preload: join(__dirname, IS_DISCORD_DESKTOP ? "preload.js" : "vencordDesktopPreload.js"),
+                contextIsolation: true,
+                nodeIntegration: false,
+                sandbox: false
+            }
+        });
 
-    makeLinksOpenExternally(win);
+        makeLinksOpenExternally(monacoEditorWin);
 
-    await win.loadURL(`data:text/html;base64,${monacoHtml}`);
+        await monacoEditorWin.loadURL(`data:text/html;base64,${monacoHtml}`);
+    }
 });

--- a/src/main/ipcMain.ts
+++ b/src/main/ipcMain.ts
@@ -138,11 +138,11 @@ export function initIpc(mainWindow: BrowserWindow) {
     }));
 }
 
-let monacoEditorWin: BrowserWindow;
+let monacoEditorWin: BrowserWindow | null = null;
 
 ipcMain.handle(IpcEvents.OPEN_MONACO_EDITOR, async () => {
-    if (monacoEditorWin && monacoEditorWin.focusable) {
-        monacoEditorWin.focus();
+    if (monacoEditorWin) {
+        monacoEditorWin.show();
     } else {
         monacoEditorWin = new BrowserWindow({
             title: "Vencord QuickCSS Editor",
@@ -157,6 +157,7 @@ ipcMain.handle(IpcEvents.OPEN_MONACO_EDITOR, async () => {
         });
 
         makeLinksOpenExternally(monacoEditorWin);
+        monacoEditorWin.once("close", () => { monacoEditorWin = null; });
 
         await monacoEditorWin.loadURL(`data:text/html;base64,${monacoHtml}`);
     }


### PR DESCRIPTION
Focuses an existing QuickCSS editor if it already exists when opening QuickCSS editor.
