### PR TITLE
fix issue with non apng gif stickers being uploaded

### DIFF
--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -787,7 +787,13 @@ export default definePlugin({
                 if (sticker.available !== false && (canUseStickers || sticker.guild_id === guildId))
                     break stickerBypass;
 
-                const link = this.getStickerLink(sticker.id);
+                // [12/12/2023] 
+                // Work around an annoying bug where discord API will return StickerType.GIF
+                // but give us a normal non animated png for no reason?
+                let link = this.getStickerLink(sticker.id);
+                if (sticker.format_type == StickerType.GIF && link.includes(".png")) {
+                    link = link.replaceAll(".png", ".gif");
+                }
                 if (sticker.format_type === StickerType.APNG) {
                     this.sendAnimatedSticker(link, sticker.id, channelId);
                     return { cancel: true };

--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -787,7 +787,7 @@ export default definePlugin({
                 if (sticker.available !== false && (canUseStickers || sticker.guild_id === guildId))
                     break stickerBypass;
 
-                // [12/12/2023] 
+                // [12/12/2023]
                 // Work around an annoying bug where getStickerLink will return StickerType.GIF,
                 // but will give us a normal non animated png for no reason
                 // TODO: Remove this workaround when it's not needed anymore

--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -791,7 +791,7 @@ export default definePlugin({
                 // Work around an annoying bug where getStickerLink will return StickerType.GIF,
                 // but will give us a normal non animated png for no reason
                 let link = this.getStickerLink(sticker.id);
-                if (sticker.format_type == StickerType.GIF && link.includes(".png")) {
+                if (sticker.format_type === StickerType.GIF && link.includes(".png")) {
                     link = link.replace(".png", ".gif");
                 }
                 if (sticker.format_type === StickerType.APNG) {

--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -790,6 +790,7 @@ export default definePlugin({
                 // [12/12/2023] 
                 // Work around an annoying bug where getStickerLink will return StickerType.GIF,
                 // but will give us a normal non animated png for no reason
+                // TODO: Remove this workaround when it's not needed anymore
                 let link = this.getStickerLink(sticker.id);
                 if (sticker.format_type === StickerType.GIF && link.includes(".png")) {
                     link = link.replace(".png", ".gif");

--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -788,11 +788,11 @@ export default definePlugin({
                     break stickerBypass;
 
                 // [12/12/2023] 
-                // Work around an annoying bug where discord API will return StickerType.GIF
-                // but give us a normal non animated png for no reason?
+                // Work around an annoying bug where getStickerLink will return StickerType.GIF,
+                // but will give us a normal non animated png for no reason
                 let link = this.getStickerLink(sticker.id);
                 if (sticker.format_type == StickerType.GIF && link.includes(".png")) {
-                    link = link.replaceAll(".png", ".gif");
+                    link = link.replace(".png", ".gif");
                 }
                 if (sticker.format_type === StickerType.APNG) {
                     this.sendAnimatedSticker(link, sticker.id, channelId);


### PR DESCRIPTION
It seems that `getStickerLink` will occasionally give back a `.png` on a gif sticker, despite the `.png` not even being an APNG. I don't know if this is a discord bug or not, I haven't dug that deep, but it seems like this is the simplest solution.

Apologies if this is poor style, I don't write much TS/JS.

Thanks
Sappho