### PR TITLE
fix cursor style plugins filter

### DIFF
--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -315,7 +315,7 @@ export default function PluginSettings() {
                 <TextInput autoFocus value={searchValue.value} placeholder="Search for a plugin..." onChange={onSearch} className={Margins.bottom20} />
                 <div className={InputStyles.inputWrapper}>
                     <Select
-                        className={InputStyles.inputDefault}
+                        className={`vc-plugins-filter-select-pointer ${InputStyles.inputDefault}`}
                         options={[
                             { label: "Show All", value: SearchStatus.ALL, default: true },
                             { label: "Show Enabled", value: SearchStatus.ENABLED },

--- a/src/components/PluginSettings/styles.css
+++ b/src/components/PluginSettings/styles.css
@@ -83,3 +83,7 @@
 .vc-plugins-info-button svg:not(:hover, :focus) {
     color: var(--text-muted);
 }
+
+.vc-plugins-filter-select-pointer {
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary

This PR fixes the cursor style for the "Show All" option in the plugin filter dropdown. Previously, the cursor would change to a text cursor when hovering over this option, which was misleading as this is a clickable element and not a text field. This PR changes the cursor to a pointer when hovering over this option to indicate that it is clickable.

## Test Plan

1. Navigate to the plugin management interface.
2. Hover over the "Show All" option in the plugin filter dropdown.
3. Observe that the cursor changes to a pointer, indicating that this option is clickable.