### PR TITLE
Urban Dictionary: Chooses top rated definition & more results.

### DIFF
--- a/src/plugins/urbanDictionary/README.md
+++ b/src/plugins/urbanDictionary/README.md
@@ -1,0 +1,13 @@
+# Urban Dictionary
+
+Use /urban slash command to search for a definition for a word on [Urban Dictionary](https://www.urbandictionary.com/).
+
+## Preview
+
+![preview](https://i.imgur.com/1zwzj38.png)
+
+## Usage
+
+- Enable this plugin
+- Set plugin settings as desired
+- Type /urban and start getting definitions right into your Discord client.

--- a/src/plugins/urbanDictionary/index.ts
+++ b/src/plugins/urbanDictionary/index.ts
@@ -18,22 +18,24 @@
 
 import { ApplicationCommandOptionType, sendBotMessage } from "@api/Commands";
 import { ApplicationCommandInputType } from "@api/Commands/types";
-import { Settings } from "@api/Settings";
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    resultsAmount: {
+        type: OptionType.NUMBER,
+        description: "The amount of results you want to get (more gives better results, but is slower)",
+        default: 10
+    }
+});
 
 export default definePlugin({
     name: "UrbanDictionary",
     description: "Search for a word on Urban Dictionary via /urban slash command",
     authors: [Devs.jewdev],
     dependencies: ["CommandsAPI"],
-    options: {
-        resultsAmount: {
-            type: OptionType.NUMBER,
-            description: "The amount of results you want to get (+ Better results, - Slower)",
-            default: 10
-        }
-    },
+    settings,
     commands: [
         {
             name: "urban",
@@ -50,9 +52,7 @@ export default definePlugin({
             execute: async (args, ctx) => {
                 try {
                     const query: string = encodeURIComponent(args[0].value);
-                    const resultsAmount: number = Settings.plugins.UrbanDictionary.resultsAmount || 10;
-                    const response: Response = await fetch(`https://api.urbandictionary.com/v0/define?term=${query}&per_page=${resultsAmount}`);
-                    const { list } = await response.json();
+                    const { list } = await fetch(`https://api.urbandictionary.com/v0/define?term=${query}&per_page=${settings.store.resultsAmount}`).then(response => response.json());
 
                     if (!list.length)
                         return void sendBotMessage(ctx.channel.id, { content: "No results found." });


### PR DESCRIPTION
I've noticed that I get irrelevant definitions, so I made these changes:

Before, API gave only 10 results and the plugin chose the first result:
![before](https://github.com/Vendicated/Vencord/assets/28711824/a1c86268-d561-4562-8b5d-0992b3e31bc2)


After, API gives the number of results you put in the settings and the plugin chooses the result with the most likes:
![after](https://github.com/Vendicated/Vencord/assets/28711824/d826e72b-5c21-41c2-80c7-d4505474da88)

P.S:
These changes make a huge difference!