### PR TITLE
Add HTTPHook plugin

### DIFF
--- a/src/plugins/HTTPHooks/index.ts
+++ b/src/plugins/HTTPHooks/index.ts
@@ -1,0 +1,71 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { getCurrentChannel, openPrivateChannel } from "@utils/discord";
+import definePlugin, { OptionType, PluginNative } from "@utils/types";
+
+const Native = VencordNative.pluginHelpers.HTTPHooks as PluginNative<typeof import("./native")>;
+
+const settings = definePluginSettings({
+    serverPort: {
+        type: OptionType.NUMBER,
+        description: "The port the HTTP server should listen on",
+        target: "DESKTOP",
+        default: 1675,
+        restartNeeded: true,
+        async onChange() {
+            await Native.stopServer();
+        }
+    }
+});
+
+export default definePlugin({
+    name: "HTTPHooks",
+    description: "Plugin that supports controlling Discord via HTTP endpoints",
+    authors: [{
+        id: 549866818269872138n,
+        name: "lockieluke3389"
+    }],
+    settings,
+    async start() {
+        if (!IS_DISCORD_DESKTOP) {
+            console.error("HTTPHooks is only available in the Desktop client");
+            return;
+        }
+        await Native.startServer(settings.store.serverPort);
+        console.log("HTTPHooks enabled");
+
+        window.httphooks = {
+            startVC: (userId: string) => {
+                openPrivateChannel(userId);
+
+                const timer = setInterval(() => {
+                    const joinVC = document.querySelector("#app-mount > div.appAsidePanelWrapper__714a6 > div.notAppAsidePanel__9d124 > div.app_b1f720 > div > div.layers__1c917.layers_a23c37 > div > div > div > div > div.chat__52833 > section > div > div.toolbar__88c63 > div:nth-child(1)");
+                    const currentChannel = getCurrentChannel();
+                    if (joinVC && currentChannel.isDM() && currentChannel.recipients.includes(userId)) {
+                        (joinVC as HTMLElement).click();
+                        clearInterval(timer);
+                    }
+                }, 200);
+            },
+            endVC: () => {
+                const leaveVC = document.querySelector("#app-mount > div.appAsidePanelWrapper__714a6 > div.notAppAsidePanel__9d124 > div.app_b1f720 > div > div.layers__1c917.layers_a23c37 > div > div > div > div > div.sidebar_ded4b5 > section > div.wrapper__0ed4a > div > div.flex_f5fbb7.horizontal__992f6.justifyStart__42744.alignCenter__84269.noWrap__5c413.connection__5bb32 > div.flex_f5fbb7.horizontal__992f6.justifyStart__42744.alignStretch_e239ef.noWrap__5c413 > button:nth-child(2)");
+                if (leaveVC)
+                    (leaveVC as HTMLElement).click();
+            }
+        };
+    },
+    async stop() {
+        await Native.stopServer();
+        console.log("HTTPHooks disabled");
+    },
+    beforeSave(options: Record<string, any>) {
+        if (options.serverPort < 0 || options.serverPort > 65535)
+            return "Port must be between 0 and 65535";
+        return true;
+    }
+});

--- a/src/plugins/HTTPHooks/native.ts
+++ b/src/plugins/HTTPHooks/native.ts
@@ -1,0 +1,51 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { BrowserWindow } from "electron";
+import * as http from "http";
+
+let server: http.Server;
+
+export function startServer(_, port: number = 1675) {
+    const mainWindow = BrowserWindow.getAllWindows().filter(window => (new URL(window.webContents.getURL())).hostname === "discord.com")[0];
+
+    server = http.createServer(async (req, res) => {
+        const { searchParams, pathname } = new URL(req.url ?? "", "http://localhost");
+
+        switch (pathname) {
+            case "/":
+                res.writeHead(200, { "Content-Type": "text/html" });
+                res.write("<h1>Vencord HTTP Hooks Plugin</h1>");
+                break;
+
+            case "/start-vc":
+                const userId = searchParams.get("userId");
+                await mainWindow.webContents.executeJavaScript(`window.httphooks.startVC("${userId}")`);
+                res.writeHead(200, { "Content-Type": "text/plain" });
+                res.write("Started VC");
+                break;
+
+            case "/end-vc":
+                await mainWindow.webContents.executeJavaScript("window.httphooks.endVC()");
+                res.writeHead(200, { "Content-Type": "text/plain" });
+                res.write("Ended VC");
+                break;
+
+            default:
+                res.writeHead(404, { "Content-Type": "text/plain" });
+                res.write("404 Not Found");
+                break;
+        }
+
+        res.end();
+    });
+
+    server.listen(port);
+}
+
+export function stopServer() {
+    server.close();
+}


### PR DESCRIPTION
This plugin allows users to control their Discord client via HTTP endpoints, currently there are two endpoints:

`/start-vc`: used with `userId` query param to start a call with another user
`/end-vc`: used to end an ongoing voice call

No code is executed dynamically which means there's no way to hijack the client remotely, server only runs on localhost(port 1675 by default), security should be okay!

Use cases:
- [Raycast](https://www.raycast.com/) extension for controlling Discord(mute, unmute, joining a VC)
- Interoperability with Minecraft mods so they can control your Discord client too