### PR TITLE
New Plugin added: hideBlockedPeople

### DIFF
--- a/src/plugins/hideBlockedPeople/index.ts
+++ b/src/plugins/hideBlockedPeople/index.ts
@@ -1,0 +1,34 @@
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+let interval: NodeJS.Timeout;
+export default definePlugin({
+    name: "hideBlockedPeople",
+    description: "Completely hide the blocked people like they doesn't exist",
+    authors: [Devs.rhaymDev],
+    start() {
+        const divs = document.querySelectorAll("div[class='groupStart__56db5']");
+        divs.forEach((div) => {
+            if (div instanceof HTMLElement) {
+                div.style.display = "none";
+            }
+        });
+        interval = setInterval(() => {
+            const divs = document.querySelectorAll("div[class='groupStart__56db5']");
+            divs.forEach((div) => {
+                if (div instanceof HTMLElement) {
+                    div.style.display = "none";
+                }
+            });
+        }, 0);
+    },
+    stop() {
+        clearInterval(interval);
+        const divs = document.querySelectorAll("div[class='groupStart__56db5']");
+        divs.forEach((div) => {
+            if (div instanceof HTMLElement) {
+                div.style.display = 'block';
+            }
+        });
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -399,6 +399,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "maisy",
         id: 257109471589957632n,
     },
+    rhaymDev: {
+        name: "rhaym.dev",
+        id: 702949304507170887n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This plugin completely hides the blocked people like they doesn't exist!
Before:
![image](https://github.com/Vendicated/Vencord/assets/43763935/2d165511-dff1-45d7-942d-725c23f289c6)
After:
![image](https://github.com/Vendicated/Vencord/assets/43763935/3d1e553b-533e-44b4-8582-1d6e5970267d)

PSA: this still an initial version, more improvements are coming soon

TODO:

- [x] Hide blocked members messages
- [ ] Hide blocked members completely from server's members list 
- [ ] Rename their mentions from `@username` to `@blocked`, and real tag can be viewed by hovering on it