### PR TITLE
ClearURLs: Add igsh

### DIFF
--- a/src/plugins/clearURLs/defaultRules.ts
+++ b/src/plugins/clearURLs/defaultRules.ts
@@ -153,5 +153,6 @@ export const defaultRules = [
     "utm_term",
     "si@open.spotify.com",
     "igshid",
+    "igsh",
     "share_id@reddit.com",
 ];


### PR DESCRIPTION
Added "igsh" to the list, I believe Instagram may have replaced igshid with igsh, so it may not be necessary to have them both, but better safe than sorry.

![image](https://github.com/Vendicated/Vencord/assets/64427742/74968536-c42a-40d3-8982-a824b9490a90)
