### PR TITLE
Add a delete modifier key in messageClickActions plugin

### DIFF
--- a/src/plugins/messageClickActions/index.ts
+++ b/src/plugins/messageClickActions/index.ts
@@ -24,15 +24,32 @@ import { findByPropsLazy } from "@webpack";
 import { FluxDispatcher, PermissionsBits, PermissionStore, UserStore } from "@webpack/common";
 
 let isDeletePressed = false;
-const keydown = (e: KeyboardEvent) => e.key === "Backspace" && (isDeletePressed = true);
-const keyup = (e: KeyboardEvent) => e.key === "Backspace" && (isDeletePressed = false);
+const keydown = (e: KeyboardEvent) => e.key === settings.store.changeDeleteModifier && (isDeletePressed = true);
+const keyup = (e: KeyboardEvent) => e.key === settings.store.changeDeleteModifier && (isDeletePressed = false);
 
+const enum Modifiers {
+    SHIFT = "Shift",
+    CTRL = "Control",
+    ALT = "Alt",
+    BACKSPACE = "Backspace"
+}
 
 const settings = definePluginSettings({
     enableDeleteOnClick: {
         type: OptionType.BOOLEAN,
         description: "Enable delete on click while holding backspace",
         default: true
+    },
+    changeDeleteModifier: {
+        type: OptionType.SELECT,
+        description: "Change the modifier for delete on click",
+        default: Modifiers.BACKSPACE,
+        options: [
+            { label: "Backspace Key", value: Modifiers.BACKSPACE, default: true },
+            { label: "Shift Key", value: Modifiers.SHIFT },
+            { label: "Ctrl Key", value: Modifiers.CTRL },
+            { label: "Alt Key", value: Modifiers.ALT },
+        ]
     },
     enableDoubleClickToEdit: {
         type: OptionType.BOOLEAN,


### PR DESCRIPTION
Added a modifier for the messageClickActions plugin which allows users to change the modifier key for deleting messages.
![Discord_IDK4dzjpYI](https://github.com/Vendicated/Vencord/assets/72959444/a16e1a9c-0694-4989-8b4c-a699e9f770d0)
