### PR TITLE
feat(plugin): Toggle sidebar hotkeys

### DIFF
--- a/src/plugins/sidebarToggle/index.ts
+++ b/src/plugins/sidebarToggle/index.ts
@@ -1,0 +1,37 @@
+import definePlugin from "@utils/types";
+
+function toggleView(el) {
+    if (el.style.display === "" || el.style.display === "flex") {
+        el.style.display = "none";
+    } else {
+        el.style.display = "flex";
+    }
+}
+
+function handler(event) {
+    if (event.altKey && event.key.toLowerCase() === "s") {
+        // WARN: not sure how to safely select classNames since these may change often
+        toggleView(document.querySelector('[aria-label="Servers sidebar"]'));
+    } else if (event.altKey && event.key.toLowerCase() === "c") {
+        // WARN: not sure how to safely select classNames since these may change often
+        toggleView(document.querySelector('.sidebar_ded4b5'));
+    }
+}
+
+export default definePlugin({
+    name: "sidebar toggle",
+    description: "Adds hotkeys to toggle the channels or server sidebar",
+    authors: [
+        {
+            id: 0n,
+            name: "CodaBool",
+        },
+    ],
+    patches: [],
+    start() {
+        document.addEventListener("keydown", handler);
+    },
+    stop() {
+        document.removeEventListener("keydown", handler);
+    }
+});


### PR DESCRIPTION
# :warning: low quality
I am a bit out of my depth on this one. This PR would require some attention and care to bring it up to other Vencord plugin standards. I am willing to work with other contributors to make this happen but won't happen overnight.

My hope is that the usefulness of this plugin will come across and others can feel inspired to help me make this happen.

If that interest doesn't materialize, this can be closed.

# :triangular_flag_on_post: Functionality
This adds a listener which will toggle either the server/guild sidebar. Or will toggle the channels sidebar.

Ideally a button is also added but that is significantly more complicated and way outside what I think I could do on my own.

Instead I rely on a listener with a hotkey. The following hotkeys are injected:

#### Alt + s 

toggle servers sidebar

#### Alt + c

toggle channel sidebar

Another obvious feature would be having this to be bindable. But I'm brand new to Vencord and again not sure how that would be done.

# :framed_picture: Screenshots

> collapsed secondary sidebar

![image](https://github.com/Vendicated/Vencord/assets/61724833/64543ce3-fe36-4ce7-ae97-f33eddfc8855)


> collapsed server/guide sidebar


![image](https://github.com/Vendicated/Vencord/assets/61724833/1dbb2601-1d68-4036-b481-f61dba0c9dbb)


> again collapsed secondary sidebar

![image](https://github.com/Vendicated/Vencord/assets/61724833/0adad1ea-0b1c-4482-b624-4b846a376e2f)


