### PR TITLE
feat(plugin): RedirectYouTube

### DIFF
--- a/src/plugins/redirectYouTube.desktop/index.ts
+++ b/src/plugins/redirectYouTube.desktop/index.ts
@@ -1,0 +1,37 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+export default definePlugin({
+    name: "RedirectYouTube",
+    description: "Replace all YouTube embeds with an embed from an third-party YouTube frontend, such as Invidious or Piped.",
+    authors: [Devs.katlyn],
+    settings: definePluginSettings({
+        instances: {
+            type: OptionType.STRING,
+            description: "A comma-separated list of alternate YouTube frontends (including protocol such as https). If multiple frontends are specified, one will be chosen at random.",
+            restartNeeded: true,
+            default: "https://invidious.fdn.fr/, https://vid.puffyan.us/, https://invidious.nerdvpn.de/, https://invidious.projectsegfau.lt/, https://invidious.flokinet.to/"
+        }
+    }),
+    patches: [{
+        find: "case\"YouTube\":",
+        replacement: {
+            match: /(let{src:\i,autoMute:\i.{10,200}src:)(\i)/,
+            replace: "$1 $self.rewriteUrl($2)"
+        }
+    }],
+    getRandomInstance() {
+        const instances = this.settings.store.instances.split(",").map(s => new URL(s.trim()).origin);
+        return instances[Math.floor(Math.random() * instances.length)];
+    },
+    rewriteUrl(url: string) {
+        return url.replace(/^https:\/\/www.youtube.com/, this.getRandomInstance());
+    }
+});

--- a/src/plugins/redirectYouTube.desktop/native.ts
+++ b/src/plugins/redirectYouTube.desktop/native.ts
@@ -1,0 +1,19 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { app } from "electron";
+import { patchCspDirective } from "main";
+import { getSettings } from "main/ipcMain";
+
+// For some reason I don't really understand getSettings returns an empty object if we call it too close to startup, so
+// delay it slightly by waiting for a window to be created.
+app.once("browser-window-created", () => {
+    const settings = getSettings().plugins?.RedirectYouTube;
+    if (settings?.enabled && settings.instances) {
+        const instanceHosts = settings.instances.split(",").map(v => new URL(v.trim()).origin);
+        patchCspDirective("frame-src", instanceHosts);
+    }
+});


### PR DESCRIPTION
This plugin replaces YouTube embeds with sn embed from an alternate third party frontend, such as Invidious or Piped.

This is more of an experiment than anything else, and I'm not really sure if the way that the `patchCspDirective` function is done is a way that fits well with the rest of vencord's codebase - in any case though, I decided that making a draft PR would be good to get feedback and potentially discuss other options.

I'm fairly hesitant about the currently hardcoded instances, perhaps the defaults could be updated every so often if needed. There is an API we could query as well but this is very much a quick implementation so I didn't bother with that yet.