### PR TITLE
feat(plugin): FXTwitter

### DIFF
--- a/src/plugins/fxTwitter/index.ts
+++ b/src/plugins/fxTwitter/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { addPreSendListener, removePreSendListener } from "@api/MessageEvents";
+import definePlugin from "@utils/types";
+import { Message } from "discord-types/general";
+
+interface IMessageCreate {
+    type: "MESSAGE_CREATE";
+    optimistic: boolean;
+    channelId: string;
+    message: Message;
+}
+
+var fxtwtListener;
+
+export default definePlugin({
+    name: "FXTwitter",
+    description: "Automatically replaces x.com and twitter.com links with fxtwitter links.",
+    authors: [
+        {
+            id: 541332458801725460n,
+            name: "PinkSickle",
+        },
+    ],
+
+    start() {
+
+        const twregex = /https:\/\/twitter\.com/;
+        const xregex = /https:\/\/x\.com/;
+
+        fxtwtListener = addPreSendListener((_, ctx) => {
+            // console.log(ctx);
+            if (twregex.test(ctx.content) || xregex.test(ctx.content)) {
+                ctx.content = ctx.content.replace(twregex, "https://fxtwitter.com");
+                ctx.content = ctx.content.replace(xregex, "https://fxtwitter.com");
+            }
+        });
+    },
+    stop() {
+        removePreSendListener(fxtwtListener);
+    }
+});

--- a/src/plugins/fxTwitter/index.ts
+++ b/src/plugins/fxTwitter/index.ts
@@ -34,10 +34,8 @@ export default definePlugin({
 
         fxtwtListener = addPreSendListener((_, ctx) => {
             // console.log(ctx);
-            if (twregex.test(ctx.content) || xregex.test(ctx.content)) {
-                ctx.content = ctx.content.replace(twregex, "https://fxtwitter.com");
-                ctx.content = ctx.content.replace(xregex, "https://fxtwitter.com");
-            }
+            ctx.content = ctx.content.replace(twregex, "https://fxtwitter.com");
+            ctx.content = ctx.content.replace(xregex, "https://fxtwitter.com");
         });
     },
     stop() {


### PR DESCRIPTION
# Functionality

This plugin automatically replaces twitter.com and x.com links in messages with fxtwitter.com links. 

It uses a presend listener to capture and edit messages. It's very simple, but particularly convenient now that normal embeds from Twitter/X no longer work.

# Demo
[demo_gif](https://i.imgur.com/ehzhxqf.gif)