### PR TITLE
feat(plugin): FixYoutubeEmbeds - fix UMG blocked embeds

### DIFF
--- a/src/plugins/fixYoutubeEmbeds.desktop/README.md
+++ b/src/plugins/fixYoutubeEmbeds.desktop/README.md
@@ -1,0 +1,6 @@
+# FixYoutubeEmbeds
+
+Bypasses youtube videos being blocked from display on Discord (for example by UMG)
+
+https://github.com/Vendicated/Vencord/assets/58010778/05594b02-7a3c-4783-86c4-64ea2a6ab7bf
+

--- a/src/plugins/fixYoutubeEmbeds.desktop/README.md
+++ b/src/plugins/fixYoutubeEmbeds.desktop/README.md
@@ -2,5 +2,10 @@
 
 Bypasses youtube videos being blocked from display on Discord (for example by UMG)
 
+Before:
+https://github.com/Vendicated/Vencord/assets/58010778/8446c556-fa36-4d60-8a85-4c40d075968f
+
+After:
 https://github.com/Vendicated/Vencord/assets/58010778/05594b02-7a3c-4783-86c4-64ea2a6ab7bf
 
+The plugin reloads the youtube embed's window to prevent detection as coming from discord.

--- a/src/plugins/fixYoutubeEmbeds.desktop/README.md
+++ b/src/plugins/fixYoutubeEmbeds.desktop/README.md
@@ -2,10 +2,4 @@
 
 Bypasses youtube videos being blocked from display on Discord (for example by UMG)
 
-Before:
-https://github.com/Vendicated/Vencord/assets/58010778/8446c556-fa36-4d60-8a85-4c40d075968f
-
-After:
-https://github.com/Vendicated/Vencord/assets/58010778/05594b02-7a3c-4783-86c4-64ea2a6ab7bf
-
-The plugin reloads the youtube embed's window to prevent detection as coming from discord.
+![](https://github.com/Vendicated/Vencord/assets/45497981/7a5fdcaa-217c-4c63-acae-f0d6af2f79be)

--- a/src/plugins/fixYoutubeEmbeds.desktop/index.ts
+++ b/src/plugins/fixYoutubeEmbeds.desktop/index.ts
@@ -9,6 +9,6 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "FixYoutubeEmbeds",
-    description: "Fixes youtube embeds from being blocked",
+    description: "Bypasses youtube videos being blocked from display on Discord (for example by UMG)",
     authors: [Devs.coolelectronics]
 });

--- a/src/plugins/fixYoutubeEmbeds.desktop/index.ts
+++ b/src/plugins/fixYoutubeEmbeds.desktop/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "FixYoutubeEmbeds",
+    description: "Fixes youtube embeds from being blocked",
+    authors: [Devs.coolelectronics]
+});

--- a/src/plugins/fixYoutubeEmbeds.desktop/native.ts
+++ b/src/plugins/fixYoutubeEmbeds.desktop/native.ts
@@ -1,0 +1,26 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { app } from "electron";
+import { getSettings } from "main/ipcMain";
+
+app.on("browser-window-created", (_, win) => {
+    win.webContents.on("frame-created", (_, { frame }) => {
+        frame.once("dom-ready", () => {
+            if (frame.url.startsWith("https://www.youtube.com/")) {
+                const settings = getSettings().plugins?.FixYoutubeEmbeds;
+                if (!settings?.enabled) return;
+
+                frame.executeJavaScript(`
+                new MutationObserver(() => {
+                    let err = document.querySelector(".ytp-error-content-wrap-subreason span")?.textContent;
+                    if (err && err.includes("blocked it from display")) window.location.reload()
+                }).observe(document.body, { childList: true, subtree:true });
+                `);
+            }
+        });
+    });
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -407,6 +407,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Samwich",
         id: 976176454511509554n,
     },
+    coolelectronics: {
+        name: "coolelectronics",
+        id: 696392247205298207n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Allows embedded youtube videos to be played when they're usually blocked.

I *believe* youtube uses window.location.ancestorOrigins to detect this, and it's unreasonably hard to overwrite it. Instead I just reload the frame which clears ancestorOrigins and shouldn't break randomly if the frontend updates.