### PR TITLE
feat(plugin): Added returnToRequests

### DIFF
--- a/src/plugins/returnToRequests/index.tsx
+++ b/src/plugins/returnToRequests/index.tsx
@@ -57,7 +57,7 @@ export function removeContextMenus() {
 
 export default definePlugin({
     name: "ReturnToRequests",
-    description: "Right-click any DM and select 'Move to Message Requests' to return DMs to the Message Requests queue. This works similarly to ignoring incoming message requests, where any new messages from the sender will appear in the Message Requests queue. Will appear in the Message Requests queue.",
+    description: "Right-click any DM and select 'Move to Message Requests' to return DMs to the Message Requests queue. This works similarly to ignoring incoming message requests, where any new messages from the sender will appear in Message Requests.",
     authors: [Devs.SUDO],
 
     start: addContextMenus,

--- a/src/plugins/returnToRequests/index.tsx
+++ b/src/plugins/returnToRequests/index.tsx
@@ -19,7 +19,7 @@
 import { Menu, RestAPI } from "@webpack/common";
 import definePlugin from "@utils/types";
 import { Devs } from "@utils/constants";
-import { NavContextMenuPatchCallback, addContextMenuPatch, findGroupChildrenByChildId } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback, addContextMenuPatch, findGroupChildrenByChildId, removeContextMenuPatch } from "@api/ContextMenu";
 
 async function returnDMtoRequests(id: string) {
     await RestAPI.delete({
@@ -51,10 +51,15 @@ export function addContextMenus() {
     addContextMenuPatch("user-context", UserContext);
 }
 
+export function removeContextMenus() {
+    removeContextMenuPatch("user-context", UserContext);
+}
+
 export default definePlugin({
     name: "ReturnToRequests",
     description: "Adds a right click option to Close a DM, as well as send it back into the Message Requests queue.",
     authors: [Devs.SUDO],
 
-    start: addContextMenus
+    start: addContextMenus,
+    stop: removeContextMenus
 });

--- a/src/plugins/returnToRequests/index.tsx
+++ b/src/plugins/returnToRequests/index.tsx
@@ -32,7 +32,7 @@ function rtrMenuItem(channelId: string) {
         <>
             <Menu.MenuItem
                 id="car-dm"
-                label="Return DM to Requests"
+                label="Move to Message Requests"
                 action={() => returnDMtoRequests(channelId)}
             />
         </>
@@ -57,7 +57,7 @@ export function removeContextMenus() {
 
 export default definePlugin({
     name: "ReturnToRequests",
-    description: "Adds a right click option to Close a DM, as well as send it back into the Message Requests queue.",
+    description: "Right-click any DM and select 'Move to Message Requests' to return DMs to the Message Requests queue. This works similarly to ignoring incoming message requests, where any new messages from the sender will appear in the Message Requests queue. Will appear in the Message Requests queue.",
     authors: [Devs.SUDO],
 
     start: addContextMenus,

--- a/src/plugins/returnToRequests/index.tsx
+++ b/src/plugins/returnToRequests/index.tsx
@@ -1,0 +1,60 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Menu, RestAPI } from "@webpack/common";
+import definePlugin from "@utils/types";
+import { Devs } from "@utils/constants";
+import { NavContextMenuPatchCallback, addContextMenuPatch, findGroupChildrenByChildId } from "@api/ContextMenu";
+
+async function returnDMtoRequests(id: string) {
+    await RestAPI.delete({
+        url: `/channels/${id}/recipients/@me`,
+    });
+}
+
+function rtrMenuItem(channelId: string) {
+    return (
+        <>
+            <Menu.MenuItem
+                id="car-dm"
+                label="Return DM to Requests"
+                action={() => returnDMtoRequests(channelId)}
+            />
+        </>
+    );
+}
+
+const UserContext: NavContextMenuPatchCallback = (children, props) => () => {
+    const container = findGroupChildrenByChildId("close-dm", children);
+    if (container) {
+        const idx = container.findIndex(c => c?.props?.id === "close-dm");
+        container.splice(idx, 0, rtrMenuItem(props.channel.id));
+    }
+};
+
+export function addContextMenus() {
+    addContextMenuPatch("user-context", UserContext);
+}
+
+export default definePlugin({
+    name: "ReturnToRequests",
+    description: "Adds a right click option to Close a DM, as well as send it back into the Message Requests queue.",
+    authors: [Devs.SUDO],
+
+    start: addContextMenus
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -410,6 +410,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     coolelectronics: {
         name: "coolelectronics",
         id: 696392247205298207n,
+    },
+    SUDO:{
+        name:"SUDO",
+        id: 480495309491798037n,
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
This is a straightforward plugin that provides an option in the DM ContextMenu to close the DM and send it back to the Message Requests Queue. This is useful for quickly answering questions and then closing the DM, so that it does not reappear in the sidebar.

![image](https://github.com/Vendicated/Vencord/assets/56691830/2e727754-57f8-46c5-8b61-bc3158a59f32)
