### PR TITLE
Fix multilanguage in fixYoutubeEmbeds

### DIFF
--- a/src/plugins/fixYoutubeEmbeds.desktop/native.ts
+++ b/src/plugins/fixYoutubeEmbeds.desktop/native.ts
@@ -17,7 +17,7 @@ app.on("browser-window-created", (_, win) => {
                 frame.executeJavaScript(`
                 new MutationObserver(() => {
                     if(
-                        document.querySelector('div.ytp-error-content-wrap-subreason a[href^="https://www.youtube.com/watch?v="]')
+                        document.querySelector('div.ytp-error-content-wrap-subreason a[href*="www.youtube.com/watch?v="]')
                     ) location.reload()
                 }).observe(document.body, { childList: true, subtree:true });
                 `);


### PR DESCRIPTION
In my case attribute starts with `http` and querySelector cant find it.
![image](https://github.com/Vendicated/Vencord/assets/49125075/33d10110-2a08-4563-9333-cdf50593b0ec)

