### PR TITLE
fixYoutubeEmbeds - Support HTTP href URLs

### DIFF
--- a/src/plugins/fixYoutubeEmbeds.desktop/native.ts
+++ b/src/plugins/fixYoutubeEmbeds.desktop/native.ts
@@ -17,7 +17,7 @@ app.on("browser-window-created", (_, win) => {
                 frame.executeJavaScript(`
                 new MutationObserver(() => {
                     if(
-                        document.querySelector('div.ytp-error-content-wrap-subreason a[href^="https://www.youtube.com/watch?v="]')
+                        document.querySelector('div.ytp-error-content-wrap-subreason a[href^="http://www.youtube.com/watch?v="], div.ytp-error-content-wrap-subreason a[href^="https://www.youtube.com/watch?v="]')
                     ) location.reload()
                 }).observe(document.body, { childList: true, subtree:true });
                 `);


### PR DESCRIPTION
So yeah, i use another locale than english and besides last fix it still didn't work on an example video i tried it with, i checked why and it appears that the href of "watch on youtube" was http, so this pr adds support for that too
![image](https://github.com/Vendicated/Vencord/assets/35699619/c52cbb7f-fe13-450b-be21-d0be3eb31394)
