### PR TITLE
Add a mention of permission bypassing to FakeNitro settings

### DIFF
--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -112,7 +112,7 @@ const hyperLinkRegex = /\[.+?\]\((https?:\/\/.+?)\)/;
 
 const settings = definePluginSettings({
     enableEmojiBypass: {
-        description: "Allow sending fake emojis",
+        description: "Allow sending fake emojis, bypass \"use external\" permissions",
         type: OptionType.BOOLEAN,
         default: true,
         restartNeeded: true
@@ -130,7 +130,7 @@ const settings = definePluginSettings({
         restartNeeded: true
     },
     enableStickerBypass: {
-        description: "Allow sending fake stickers",
+        description: "Allow sending fake stickers, bypass \"use external\" permissions",
         type: OptionType.BOOLEAN,
         default: true,
         restartNeeded: true


### PR DESCRIPTION
I don't think I'd ever figure out that these settings do bypass these permissions if I didn't investigate what's the behavior in order to make #2173. As per the issue, sticker bypass is affected by *both* permissions, so I chose universal wording for both instead of doing an ugly "external emojis/stickers" kind of thing.

Marked as draft until I get any official opinion about that issue.