### PR TITLE
Fix Message Link Embeds on @me guilds

### DIFF
--- a/src/plugins/messageLinkEmbeds/index.tsx
+++ b/src/plugins/messageLinkEmbeds/index.tsx
@@ -226,7 +226,9 @@ function MessageEmbedAccessory({ message }: { message: Message; }) {
 
     let match = null as RegExpMatchArray | null;
     while ((match = messageLinkRegex.exec(message.content!)) !== null) {
-        const [_, guildID, channelID, messageID] = match;
+        const [_, __, channelID, messageID] = match;
+        let guildID = match[1];
+
         if (embeddedBy.includes(messageID)) {
             continue;
         }
@@ -234,6 +236,11 @@ function MessageEmbedAccessory({ message }: { message: Message; }) {
         const linkedChannel = ChannelStore.getChannel(channelID);
         if (!linkedChannel || (guildID !== "@me" && !PermissionStore.can(1024n /* view channel */, linkedChannel))) {
             continue;
+        }
+
+        if (linkedChannel.guild_id && GuildStore.getGuild(linkedChannel.guild_id) && guildID === "@me") {
+            guildID = linkedChannel.guild_id;
+            // done to fix messages that use @me as the guild, which discord supports
         }
 
         const { listMode, idList } = settings.store;


### PR DESCRIPTION
this fixes bots such as Make a Quote attempting to use @me as a guild, which discord supports (for some reason).
my method for the guildID var was a bit hacky, but there seem to be strict const/let structures.

> this is my first time contributing, so lmk if i did something wrong