### PR TITLE
feat(MessageLogger): Compact display of history

### DIFF
--- a/src/plugins/messageLogger/HistoryModal.tsx
+++ b/src/plugins/messageLogger/HistoryModal.tsx
@@ -1,0 +1,68 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@api/Styles";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { closeModal, ModalCloseButton, ModalContent, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { findByPropsLazy } from "@webpack";
+import { Parser, Text, Timestamp, useState } from "@webpack/common";
+
+import type { Message } from ".";
+
+const CodeContainerClasses = findByPropsLazy("markup", "codeContainer");
+const MiscClasses = findByPropsLazy("messageContent", "markupRtl");
+
+const cl = classNameFactory("messagelogger-modal-");
+
+export function showHistory(message: Message) {
+    const key = openModal(props =>
+        <ErrorBoundary>
+            <HistoryModal
+                modalProps={props}
+                close={() => closeModal(key)}
+                message={message}
+            />
+        </ErrorBoundary>
+    );
+}
+
+export function HistoryModal({ modalProps, close, message }: { modalProps: ModalProps; close(): void; message: Message }) {
+    const [selected, selectItem] = useState(message.editHistory.length);
+    // TODO the first timestamp is not necessarily correct, I want some way to store the oldest known edited-timestamp
+    const timestamps = [message.timestamp, ...message.editHistory.map(a => a.timestamp)];
+    const contents = [...message.editHistory.map(a => a.content), message.content];
+
+    return <ModalRoot {...modalProps} size={ModalSize.LARGE}>
+        <ModalHeader className={cl("head")}>
+            <Text variant="heading-lg/semibold">Message edit history</Text>
+            <ModalCloseButton onClick={close} />
+            <div className={cl("revisions")}>
+                {...timestamps.map((timestamp, index) =>
+                    <button
+                        className={cl("revision", { "revision-active": selected === index })}
+                        onClick={() => selectItem(index)}
+                    >
+                        <Timestamp
+                            className={cl("timestamp")}
+                            timestamp={timestamp}
+                            isEdited={true}
+                            isInline={false}
+                        />
+                    </button>
+                )}
+            </div>
+        </ModalHeader>
+        <ModalContent className={cl("contents")}>
+            {...contents.map((content, index) =>
+                <div className={cl("content", { "content-active": selected === index })}>
+                    <div className={`${CodeContainerClasses.markup} ${MiscClasses.messageContent}`}>
+                        {Parser.parse(content)}
+                    </div>
+                </div>
+            )}
+        </ModalContent>
+    </ModalRoot>;
+}

--- a/src/plugins/messageLogger/HistoryModal.tsx
+++ b/src/plugins/messageLogger/HistoryModal.tsx
@@ -10,14 +10,12 @@ import { closeModal, ModalCloseButton, ModalContent, ModalHeader, ModalProps, Mo
 import { findByPropsLazy } from "@webpack";
 import { Parser, Text, Timestamp, useState } from "@webpack/common";
 
-import type { Message } from ".";
-
 const CodeContainerClasses = findByPropsLazy("markup", "codeContainer");
 const MiscClasses = findByPropsLazy("messageContent", "markupRtl");
 
 const cl = classNameFactory("messagelogger-modal-");
 
-export function showHistory(message: Message) {
+export function showHistory(message: any) {
     const key = openModal(props =>
         <ErrorBoundary>
             <HistoryModal
@@ -29,7 +27,7 @@ export function showHistory(message: Message) {
     );
 }
 
-export function HistoryModal({ modalProps, close, message }: { modalProps: ModalProps; close(): void; message: Message }) {
+export function HistoryModal({ modalProps, close, message }: { modalProps: ModalProps; close(): void; message: any }) {
     const [selected, selectItem] = useState(message.editHistory.length);
     // TODO the first timestamp is not necessarily correct, I want some way to store the oldest known edited-timestamp
     const timestamps = [message.timestamp, ...message.editHistory.map(a => a.timestamp)];

--- a/src/plugins/messageLogger/HistoryModal.tsx
+++ b/src/plugins/messageLogger/HistoryModal.tsx
@@ -29,8 +29,7 @@ export function showHistory(message: any) {
 
 export function HistoryModal({ modalProps, close, message }: { modalProps: ModalProps; close(): void; message: any }) {
     const [selected, selectItem] = useState(message.editHistory.length);
-    // TODO the first timestamp is not necessarily correct, I want some way to store the oldest known edited-timestamp
-    const timestamps = [message.timestamp, ...message.editHistory.map(a => a.timestamp)];
+    const timestamps = [message.firstEditTimestamp, ...message.editHistory.map(a => a.timestamp)];
     const contents = [...message.editHistory.map(a => a.content), message.content];
 
     return <ModalRoot {...modalProps} size={ModalSize.LARGE}>
@@ -38,6 +37,16 @@ export function HistoryModal({ modalProps, close, message }: { modalProps: Modal
             <Text variant="heading-lg/semibold">Message edit history</Text>
             <ModalCloseButton onClick={close} />
             <div className={cl("revisions")}>
+                { message.firstEditTimestamp.getTime() !== message.timestamp.getTime() ? (
+                    <button className={cl("revision-lost")} disabled>
+                        <Timestamp
+                            className={cl("timestamp")}
+                            timestamp={message.timestamp}
+                            isEdited={true}
+                            isInline={false}
+                        />
+                    </button>
+                ) : null }
                 {...timestamps.map((timestamp, index) =>
                     <button
                         className={cl("revision", { "revision-active": selected === index })}

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -29,13 +29,10 @@ import { classes } from "@utils/misc";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
 import { ChannelStore, FluxDispatcher, i18n, Menu, Parser, Timestamp, UserStore } from "@webpack/common";
-import { Message as _Message } from "discord-types/general";
 
 import overlayStyle from "./deleteStyleOverlay.css?managed";
 import textStyle from "./deleteStyleText.css?managed";
 import { showHistory } from "./HistoryModal";
-
-export type Message = _Message & { editHistory: { timestamp: any, content: string }[] };
 
 const styles = findByPropsLazy("edited", "communicationDisabled", "isSystemMessage");
 const FormattedMessage = findByPropsLazy("FormattedMessage", "setUpdateRules", "getMessage");

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -23,6 +23,7 @@ import { Settings } from "@api/Settings";
 import { disableStyle, enableStyle } from "@api/Styles";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
+import { proxyLazy } from "@utils/lazy";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
@@ -32,6 +33,7 @@ import overlayStyle from "./deleteStyleOverlay.css?managed";
 import textStyle from "./deleteStyleText.css?managed";
 
 const styles = findByPropsLazy("edited", "communicationDisabled", "isSystemMessage");
+const FormattedMessage = findByPropsLazy("FormattedMessage", "setUpdateRules", "getMessage");
 
 function addDeleteStyle() {
     if (Settings.plugins.MessageLogger.deleteStyle === "text") {
@@ -209,6 +211,10 @@ export default definePlugin({
             ignoreChannels.includes(ChannelStore.getChannel(message.channel_id)?.parent_id) ||
             ignoreGuilds.includes(ChannelStore.getChannel(message.channel_id)?.guild_id);
     },
+
+    Messages: proxyLazy(() => ({
+        DELETED_MESSAGE_COUNT: FormattedMessage.getMessage("{count, plural, =0 {No deleted messages} one {{count} deleted message} other {{count} deleted messages}}"),
+    })),
 
     // Based on canary 63b8f1b4f2025213c5cf62f0966625bee3d53136
     patches: [
@@ -394,7 +400,7 @@ export default definePlugin({
                     replace: "children:arguments[0].message.deleted?[]:$1"
                 }
             ]
-        }
+        },
 
         // {
         //     // MessageStore caching internals
@@ -408,5 +414,30 @@ export default definePlugin({
         //         // }
         //     ]
         // }
+
+        {
+            // Message grouping
+            // Module 51714
+            find: "MessageTypesSets.NON_COLLAPSIBLE.has(",
+            replacement: {
+                match: /if\((\i)\.blocked\)return \i\.ChannelStreamTypes\.MESSAGE_GROUP_BLOCKED;/,
+                replace: '$&else if($1.deleted) return"MESSAGE_GROUP_DELETED";',
+            },
+        },
+        {
+            // Message group rendering
+            // Module 221068
+            find: "Messages.NEW_MESSAGES_ESTIMATED_WITH_DATE",
+            replacement: [
+                {
+                    match: /(\i).type===\i\.ChannelStreamTypes\.MESSAGE_GROUP_BLOCKED\|\|/,
+                    replace: '$&$1.type==="MESSAGE_GROUP_DELETED"||',
+                },
+                {
+                    match: /(\i).type===\i\.ChannelStreamTypes\.MESSAGE_GROUP_BLOCKED\?.*?:/,
+                    replace: '$&$1.type==="MESSAGE_GROUP_DELETED"?$self.Messages.DELETED_MESSAGE_COUNT:',
+                },
+            ],
+        },
     ]
 });

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -111,7 +111,7 @@ export default definePlugin({
     },
 
     renderEdit(edit: { timestamp: any, content: string; }) {
-        return (
+        return Settings.plugins.MessageLogger.inlineEdits ? (
             <ErrorBoundary noop>
                 <div className="messagelogger-edited">
                     {Parser.parse(edit.content)}
@@ -124,7 +124,7 @@ export default definePlugin({
                     </Timestamp>
                 </div>
             </ErrorBoundary>
-        );
+        ) : null;
     },
 
     makeEdit(newMessage: any, oldMessage: any): any {
@@ -149,6 +149,11 @@ export default definePlugin({
             type: OptionType.BOOLEAN,
             description: "Whether to collapse deleted messages",
             default: true
+        },
+        inlineEdits: {
+            type: OptionType.BOOLEAN,
+            description: "Whether to display edit history as part of message content",
+            default: false
         },
         ignoreBots: {
             type: OptionType.BOOLEAN,

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -140,6 +140,11 @@ export default definePlugin({
             ],
             onChange: () => addDeleteStyle()
         },
+        collapseDeleted: {
+            type: OptionType.BOOLEAN,
+            description: "Whether to collapse deleted messages",
+            default: true
+        },
         ignoreBots: {
             type: OptionType.BOOLEAN,
             description: "Whether to ignore messages by bots",
@@ -421,7 +426,7 @@ export default definePlugin({
             find: "MessageTypesSets.NON_COLLAPSIBLE.has(",
             replacement: {
                 match: /if\((\i)\.blocked\)return \i\.ChannelStreamTypes\.MESSAGE_GROUP_BLOCKED;/,
-                replace: '$&else if($1.deleted) return"MESSAGE_GROUP_DELETED";',
+                replace: '$&else if($1.deleted && Vencord.Settings.plugins.MessageLogger.collapseDeleted) return"MESSAGE_GROUP_DELETED";',
             },
         },
         {

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -25,12 +25,17 @@ import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
 import { proxyLazy } from "@utils/lazy";
 import { Logger } from "@utils/Logger";
+import { classes } from "@utils/misc";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
 import { ChannelStore, FluxDispatcher, i18n, Menu, Parser, Timestamp, UserStore } from "@webpack/common";
+import { Message as _Message } from "discord-types/general";
 
 import overlayStyle from "./deleteStyleOverlay.css?managed";
 import textStyle from "./deleteStyleText.css?managed";
+import { showHistory } from "./HistoryModal";
+
+export type Message = _Message & { editHistory: { timestamp: any, content: string }[] };
 
 const styles = findByPropsLazy("edited", "communicationDisabled", "isSystemMessage");
 const FormattedMessage = findByPropsLazy("FormattedMessage", "setUpdateRules", "getMessage");
@@ -217,6 +222,19 @@ export default definePlugin({
             ignoreGuilds.includes(ChannelStore.getChannel(message.channel_id)?.guild_id);
     },
 
+    EditMarker({ message, className, children, ...props }: any) {
+        return (
+            <span
+                {...props}
+                className={classes("messagelogger-edit-marker", className)}
+                onClick={() => showHistory(message)}
+                aria-role="button"
+            >
+                {children}
+            </span>
+        );
+    },
+
     Messages: proxyLazy(() => ({
         DELETED_MESSAGE_COUNT: FormattedMessage.getMessage("{count, plural, =0 {No deleted messages} one {{count} deleted message} other {{count} deleted messages}}"),
     })),
@@ -374,6 +392,11 @@ export default definePlugin({
                     // Render editHistory in the deepest div for message content
                     match: /(\)\("div",\{id:.+?children:\[)/,
                     replace: "$1 (arguments[0].message.editHistory?.length > 0 ? arguments[0].message.editHistory.map(edit => $self.renderEdit(edit)) : null), "
+                },
+                {
+                    // Make edit marker clickable
+                    match: /"span",\{/,
+                    replace: "$self.EditMarker,{message:arguments[0].message,"
                 }
             ]
         },

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -94,7 +94,7 @@ const patchMessageContextMenu: NavContextMenuPatchCallback = (children, props) =
 export default definePlugin({
     name: "MessageLogger",
     description: "Temporarily logs deleted and edited messages.",
-    authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN],
+    authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN, Devs.Kyuuhachi],
 
     start() {
         addDeleteStyle();

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -297,7 +297,8 @@ export default definePlugin({
                     match: /this\.customRenderedContent=(\i)\.customRenderedContent,/,
                     replace: "this.customRenderedContent = $1.customRenderedContent," +
                         "this.deleted = $1.deleted || false," +
-                        "this.editHistory = $1.editHistory || [],"
+                        "this.editHistory = $1.editHistory || []," +
+                        "this.firstEditTimestamp = $1.firstEditTimestamp || this.timestamp,"
                 }
             ]
         },
@@ -319,7 +320,8 @@ export default definePlugin({
                         "interactionData:$1.interactionData," +
                         "deleted:$1.deleted," +
                         "editHistory:$1.editHistory," +
-                        "attachments:$1.attachments"
+                        "attachments:$1.attachments," +
+                        "firstEditTimestamp:$1.firstEditTimestamp"
                 },
 
                 // {
@@ -343,7 +345,8 @@ export default definePlugin({
                         "   return $2;" +
                         "})())," +
                         "deleted: arguments[1]?.deleted," +
-                        "editHistory: arguments[1]?.editHistory"
+                        "editHistory: arguments[1]?.editHistory," +
+                        "firstEditTimestamp: new Date(arguments[1]?.firstEditTimestamp ?? $2.edited_timestamp ?? $2.timestamp)"
                 },
                 {
                     // Preserve deleted attribute on attachments

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -75,6 +75,12 @@
     gap: 0.5em;
 }
 
+.messagelogger-modal-revision-lost {
+    cursor: unset;
+    color: var(--icon-muted); /* interactive-muted is hard to see on dark background. This one looks good on both dark and light theme. */
+    background: none;
+}
+
 .messagelogger-modal-revision {
     cursor: pointer;
     color: var(--interactive-normal);

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -43,9 +43,9 @@
 .messagelogger-modal-head {
     display: grid;
     grid-template:
-         "t x" auto
-         "r r" 1fr
-         / 1fr auto;
+        "t x" auto
+        "r r" 1fr
+        / 1fr auto;
 }
 
 .messagelogger-modal-head:nth-child(1) { grid-area: "t"; }
@@ -71,8 +71,7 @@
 
 .messagelogger-modal-revisions {
     display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    flex-flow: row wrap;
     gap: 0.5em;
 }
 

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -35,3 +35,63 @@
 .theme-light .messagelogger-edited {
     opacity: 0.5;
 }
+
+.messagelogger-edit-marker {
+    cursor: pointer;
+}
+
+.messagelogger-modal-head {
+    display: grid;
+    grid-template:
+         "t x" auto
+         "r r" 1fr
+         / 1fr auto;
+}
+
+.messagelogger-modal-head:nth-child(1) { grid-area: "t"; }
+.messagelogger-modal-head:nth-child(2) { grid-area: "x"; }
+.messagelogger-modal-head:nth-child(3) { grid-area: "r"; }
+
+/* For correct sizing, the revisions are all stacked in a 1x1 grid, with all but one being invisible */
+.messagelogger-modal-contents {
+    padding-top: 1em;
+    height: 25em;
+    max-height: 90%;
+    display: grid;
+    grid-template: "a" 1fr / 1fr;
+}
+
+.messagelogger-modal-content {
+    grid-area: a;
+}
+
+.messagelogger-modal-content:not(.messagelogger-modal-content-active) {
+    visibility: hidden;
+}
+
+.messagelogger-modal-revisions {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5em;
+}
+
+.messagelogger-modal-revision {
+    cursor: pointer;
+    color: var(--interactive-normal);
+    background: none;
+}
+
+.messagelogger-modal-timestamp {
+    cursor: unset;
+}
+
+.messagelogger-modal-revision:hover {
+    color: var(--interactive-hover);
+    background-color: var(--background-modifier-hover)
+}
+
+.messagelogger-modal-revision-active {
+    color: var(--interactive-active);
+    background-color: var(--background-modifier-active)
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -410,7 +410,11 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     coolelectronics: {
         name: "coolelectronics",
         id: 696392247205298207n,
-    }
+    },
+    Kyuuhachi: {
+        name: "Kyuuhachi",
+        id: 236588665420251137n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Deleted messages take a lot of space, and in many cases they're deleted for a good reason, such as being spam or containing gore. So let's collapse them!

![3 deleted messages — Show messages](https://github.com/Vendicated/Vencord/assets/1547062/b1039aa1-aeb8-4a27-bc8d-844060da9766)

Not sure if the way I handle the formatted string is any good, but hey, it works.

