### PR TITLE
LastfmRichPresence: Add an option to hide the Last.fm logo

### DIFF
--- a/src/plugins/lastfm/index.tsx
+++ b/src/plugins/lastfm/index.tsx
@@ -170,6 +170,11 @@ const settings = definePluginSettings({
             }
         ],
     },
+    showLastFmLogo: {
+        description: "show the Last.fm logo by the album cover",
+        type: OptionType.BOOLEAN,
+        default: true,
+    }
 });
 
 export default definePlugin({
@@ -276,8 +281,9 @@ export default definePlugin({
             {
                 large_image: await getApplicationAsset(largeImage),
                 large_text: trackData.album || undefined,
-                small_image: await getApplicationAsset("lastfm-small"),
-                small_text: "Last.fm",
+                ...(settings.store.showLastFmLogo && {
+                    small_image: await getApplicationAsset("lastfm-small"), small_text: "Last.fm"
+                }),
             } : {
                 large_image: await getApplicationAsset("lastfm-large"),
                 large_text: trackData.album || undefined,

--- a/src/plugins/lastfm/index.tsx
+++ b/src/plugins/lastfm/index.tsx
@@ -282,7 +282,8 @@ export default definePlugin({
                 large_image: await getApplicationAsset(largeImage),
                 large_text: trackData.album || undefined,
                 ...(settings.store.showLastFmLogo && {
-                    small_image: await getApplicationAsset("lastfm-small"), small_text: "Last.fm"
+                    small_image: await getApplicationAsset("lastfm-small"),
+                    small_text: "Last.fm"
                 }),
             } : {
                 large_image: await getApplicationAsset("lastfm-large"),


### PR DESCRIPTION
Just adds an option in the plugin's settings to toggle the last.fm logo. Not much else to say!

With the logo:
![image](https://github.com/Vendicated/Vencord/assets/58575812/1d586516-4455-4a41-a812-b4859b8211fa)

Without the logo:
![image](https://github.com/Vendicated/Vencord/assets/58575812/c0254a4c-59a3-4e25-ae5f-e152c71743fc)
