### PR TITLE
feat(plugin) FakeNitro: Allow customising hyperlink text

### DIFF
--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -162,6 +162,11 @@ const settings = definePluginSettings({
         description: "Whether to use hyperlinks when sending fake emojis and stickers",
         type: OptionType.BOOLEAN,
         default: true
+    },
+    invisibleHyperLInks: {
+        description: "Wether it should hide hyperlinks with an empty character",
+        type: OptionType.BOOLEAN,
+        default: false
     }
 });
 
@@ -838,8 +843,8 @@ export default definePlugin({
                     url.searchParams.set("name", emoji.name);
 
                     messageObj.content = messageObj.content.replace(emojiString, (match, offset, origStr) => {
-                        // Empty character is U+2800 "Braille Pattern Blank" --------------- v
-                        return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[⠀](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
+                        // Empty character is U+2800 "Braille Pattern Blank" ------------------------------------------ v
+                        return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${s.invisibleHyperLinks ? "⠀" : emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
                     });
                 }
             }
@@ -865,8 +870,8 @@ export default definePlugin({
                 url.searchParams.set("size", s.emojiSize.toString());
                 url.searchParams.set("name", emoji.name);
 
-                // Empty character is U+2800 "Braille Pattern Blank" --------------- v
-                return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[⠀](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
+                // Empty character is U+2800 "Braille Pattern Blank" ------------------------------------------ v
+                return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${s.invisibleHyperLinks ? "⠀" : emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
             });
         });
     },

--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -163,10 +163,10 @@ const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         default: true
     },
-    invisibleHyperLInks: {
-        description: "Wether it should hide hyperlinks with an empty character",
-        type: OptionType.BOOLEAN,
-        default: false
+    hyperLinkText: {
+        description: "What text the hyperlink should use, if empty it uses the emoji name",
+        type: OptionType.STRING,
+        default: ""
     }
 });
 
@@ -843,8 +843,7 @@ export default definePlugin({
                     url.searchParams.set("name", emoji.name);
 
                     messageObj.content = messageObj.content.replace(emojiString, (match, offset, origStr) => {
-                        // Empty character is U+2800 "Braille Pattern Blank" ------------------------------------------ v
-                        return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${s.invisibleHyperLinks ? "⠀" : emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
+                        return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${s.hyperLinkText ? s.hyperLinkText : emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
                     });
                 }
             }
@@ -870,8 +869,7 @@ export default definePlugin({
                 url.searchParams.set("size", s.emojiSize.toString());
                 url.searchParams.set("name", emoji.name);
 
-                // Empty character is U+2800 "Braille Pattern Blank" ------------------------------------------ v
-                return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${s.invisibleHyperLinks ? "⠀" : emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
+                return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${s.hyperLinkText ? s.hyperLinkText : emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
             });
         });
     },

--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -838,7 +838,8 @@ export default definePlugin({
                     url.searchParams.set("name", emoji.name);
 
                     messageObj.content = messageObj.content.replace(emojiString, (match, offset, origStr) => {
-                        return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
+                        // Empty character is U+2800 "Braille Pattern Blank" --------------- v
+                        return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[⠀](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
                     });
                 }
             }
@@ -864,7 +865,8 @@ export default definePlugin({
                 url.searchParams.set("size", s.emojiSize.toString());
                 url.searchParams.set("name", emoji.name);
 
-                return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
+                // Empty character is U+2800 "Braille Pattern Blank" --------------- v
+                return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[⠀](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
             });
         });
     },

--- a/src/plugins/fakeNitro/index.ts
+++ b/src/plugins/fakeNitro/index.ts
@@ -164,9 +164,9 @@ const settings = definePluginSettings({
         default: true
     },
     hyperLinkText: {
-        description: "What text the hyperlink should use, if empty it uses the emoji name",
+        description: "What text the hyperlink should use.",
         type: OptionType.STRING,
-        default: ""
+        default: "{{NAME}}"
     }
 });
 
@@ -842,8 +842,10 @@ export default definePlugin({
                     url.searchParams.set("size", s.emojiSize.toString());
                     url.searchParams.set("name", emoji.name);
 
+                    const linkText = s.hyperLinkText.replace(/\{\{NAME\}\}/g, emoji.name);
+                    
                     messageObj.content = messageObj.content.replace(emojiString, (match, offset, origStr) => {
-                        return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${s.hyperLinkText ? s.hyperLinkText : emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
+                        return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${linkText}](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
                     });
                 }
             }
@@ -869,7 +871,9 @@ export default definePlugin({
                 url.searchParams.set("size", s.emojiSize.toString());
                 url.searchParams.set("name", emoji.name);
 
-                return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${s.hyperLinkText ? s.hyperLinkText : emoji.name}](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
+                const linkText = s.hyperLinkText.replace(/\{\{NAME\}\}/g, emoji.name);
+
+                return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${linkText}](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
             });
         });
     },

--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -162,7 +162,7 @@ const settings = definePluginSettings({
         default: true
     },
     hyperLinkText: {
-        description: "What text the hyperlink should use.",
+        description: "What text the hyperlink should use. {{NAME}} will be replaced with the emoji name.",
         type: OptionType.STRING,
         default: "{{NAME}}"
     }
@@ -885,7 +885,7 @@ export default definePlugin({
                     url.searchParams.set("size", s.emojiSize.toString());
                     url.searchParams.set("name", emoji.name);
 
-                    const linkText = s.hyperLinkText.replace(/\{\{NAME\}\}/g, emoji.name);
+                    const linkText = s.hyperLinkText.replaceAll("{{NAME}}", emoji.name);
 
                     messageObj.content = messageObj.content.replace(emojiString, (match, offset, origStr) => {
                         return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${linkText}](${url})` : url}${getWordBoundary(origStr, offset + match.length)}`;
@@ -924,7 +924,7 @@ export default definePlugin({
                 url.searchParams.set("size", s.emojiSize.toString());
                 url.searchParams.set("name", emoji.name);
 
-                const linkText = s.hyperLinkText.replace(/\{\{NAME\}\}/g, emoji.name);
+                const linkText = s.hyperLinkText.replaceAll("{{NAME}}", emoji.name);
 
                 return `${getWordBoundary(origStr, offset - 1)}${s.useHyperLinks ? `[${linkText}](${url})` : url}${getWordBoundary(origStr, offset + emojiStr.length)}`;
             });


### PR DESCRIPTION
If you use U+2800 then links will essentially be invisible which imo looks way cleaner. Image below is how it should look with the fix.

![ksnip_20240218-163048](https://github.com/Vendicated/Vencord/assets/58912038/19626125-75cc-4f54-8b75-bdc9548ef863)
