### PR TITLE
SpotifyControls: export album cover as CSS variable for themes

### DIFF
--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -349,7 +349,7 @@ function Info({ track }: { track: Track; }) {
     );
 }
 
-export function Player() {
+export function Player({ useBg }: { useBg: Boolean; }) {
     const track = useStateFromStores(
         [SpotifyStore],
         () => SpotifyStore.track,
@@ -388,7 +388,7 @@ export function Player() {
             </div>
         )}>
             <div id={cl("player")}>
-                <Background track={track} />
+                {useBg && <Background track={track} />}
                 <Info track={track} />
                 <SeekBar />
                 <Controls />

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -262,11 +262,11 @@ function makeLinkProps(name: string, condition: unknown, path: string) {
         onContextMenu: makeContextMenu(name, path)
     } satisfies React.HTMLAttributes<HTMLElement>;
 }
-function Background({ track }: { track: Track; }) {
+function Background({ track, rotate = false }: { track: Track; rotate?: Boolean; }) {
     const img = track?.album?.image;
     return (
         <>
-            {img && (<img id={cl("background-image")} src={img.url} alt="Album Image Background" />)
+            {img && (<img id={cl("background-image")} className={rotate ? cl("rotate") : ""} src={img.url} alt="Album Image Background" />)
             }
         </>
     );
@@ -349,7 +349,7 @@ function Info({ track }: { track: Track; }) {
     );
 }
 
-export function Player({ useBg }: { useBg: Boolean; }) {
+export function Player({ useBg, rotateBg }: { useBg: Boolean; rotateBg: Boolean; }) {
     const track = useStateFromStores(
         [SpotifyStore],
         () => SpotifyStore.track,
@@ -389,6 +389,7 @@ export function Player({ useBg }: { useBg: Boolean; }) {
         )}>
             <div id={cl("player")}>
                 {useBg && <Background track={track} />}
+                {(useBg && rotateBg) && <Background track={track} rotate={true} />}
                 <Info track={track} />
                 <SeekBar />
                 <Controls />

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -262,15 +262,6 @@ function makeLinkProps(name: string, condition: unknown, path: string) {
         onContextMenu: makeContextMenu(name, path)
     } satisfies React.HTMLAttributes<HTMLElement>;
 }
-function Background({ track, rotate = false }: { track: Track; rotate?: Boolean; }) {
-    const img = track?.album?.image;
-    return (
-        <>
-            {img && (<img id={cl("background-image")} className={rotate ? cl("rotate") : ""} src={img.url} alt="Album Image Background" />)
-            }
-        </>
-    );
-}
 
 function Info({ track }: { track: Track; }) {
     const img = track?.album?.image;
@@ -349,7 +340,7 @@ function Info({ track }: { track: Track; }) {
     );
 }
 
-export function Player({ useBg, rotateBg }: { useBg: Boolean; rotateBg: Boolean; }) {
+export function Player() {
     const track = useStateFromStores(
         [SpotifyStore],
         () => SpotifyStore.track,
@@ -380,6 +371,10 @@ export function Player({ useBg, rotateBg }: { useBg: Boolean; rotateBg: Boolean;
     if (!track || !device?.is_active || shouldHide)
         return null;
 
+    const exportTrackImageStyle = {
+        "--vc-spotify-track-image": `url(${track?.album?.image?.url || ""})`,
+    } as React.CSSProperties;
+
     return (
         <ErrorBoundary fallback={() => (
             <div className="vc-spotify-fallback">
@@ -387,9 +382,7 @@ export function Player({ useBg, rotateBg }: { useBg: Boolean; rotateBg: Boolean;
                 <p >Check the console for errors</p>
             </div>
         )}>
-            <div id={cl("player")}>
-                {useBg && <Background track={track} />}
-                {(useBg && rotateBg) && <Background track={track} rotate={true} />}
+            <div id={cl("player")} style={exportTrackImageStyle}>
                 <Info track={track} />
                 <SeekBar />
                 <Controls />

--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -262,6 +262,15 @@ function makeLinkProps(name: string, condition: unknown, path: string) {
         onContextMenu: makeContextMenu(name, path)
     } satisfies React.HTMLAttributes<HTMLElement>;
 }
+function Background({ track }: { track: Track; }) {
+    const img = track?.album?.image;
+    return (
+        <>
+            {img && (<img id={cl("background-image")} src={img.url} alt="Album Image Background" />)
+            }
+        </>
+    );
+}
 
 function Info({ track }: { track: Track; }) {
     const img = track?.album?.image;
@@ -379,6 +388,7 @@ export function Player() {
             </div>
         )}>
             <div id={cl("player")}>
+                <Background track={track} />
                 <Info track={track} />
                 <SeekBar />
                 <Controls />

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -48,6 +48,11 @@ export default definePlugin({
             type: OptionType.BOOLEAN,
             description: "Use the album cover as a background",
             default: true
+        },
+        rotateBackground: {
+            type: OptionType.BOOLEAN,
+            description: "Slowly rotates the background if activated ",
+            default: true
         }
     },
     patches: [
@@ -84,5 +89,5 @@ export default definePlugin({
         }
     ],
     start: () => toggleHoverControls(Settings.plugins.SpotifyControls.hoverControls),
-    renderPlayer: () => <Player useBg={Settings.plugins.SpotifyControls.useCoverAsBackground} />
+    renderPlayer: () => <Player useBg={Settings.plugins.SpotifyControls.useCoverAsBackground} rotateBg={Settings.plugins.SpotifyControls.rotateBackground} />
 });

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -31,7 +31,7 @@ function toggleHoverControls(value: boolean) {
 export default definePlugin({
     name: "SpotifyControls",
     description: "Adds a Spotify player above the account panel",
-    authors: [Devs.Ven, Devs.afn, Devs.KraXen72],
+    authors: [Devs.Ven, Devs.afn, Devs.KraXen72, Devs.Av32000],
     options: {
         hoverControls: {
             description: "Show controls on hover",
@@ -43,6 +43,11 @@ export default definePlugin({
             type: OptionType.BOOLEAN,
             description: "Open Spotify URIs instead of Spotify URLs. Will only work if you have Spotify installed and might not work on all platforms",
             default: false
+        },
+        useCoverAsBackground: {
+            type: OptionType.BOOLEAN,
+            description: "Use the album cover as a background",
+            default: true
         }
     },
     patches: [
@@ -79,5 +84,5 @@ export default definePlugin({
         }
     ],
     start: () => toggleHoverControls(Settings.plugins.SpotifyControls.hoverControls),
-    renderPlayer: () => <Player />
+    renderPlayer: () => <Player useBg={Settings.plugins.SpotifyControls.useCoverAsBackground} />
 });

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -43,16 +43,6 @@ export default definePlugin({
             type: OptionType.BOOLEAN,
             description: "Open Spotify URIs instead of Spotify URLs. Will only work if you have Spotify installed and might not work on all platforms",
             default: false
-        },
-        useCoverAsBackground: {
-            type: OptionType.BOOLEAN,
-            description: "Use the album cover as a background",
-            default: true
-        },
-        rotateBackground: {
-            type: OptionType.BOOLEAN,
-            description: "Slowly rotates the background if activated ",
-            default: true
         }
     },
     patches: [
@@ -89,5 +79,5 @@ export default definePlugin({
         }
     ],
     start: () => toggleHoverControls(Settings.plugins.SpotifyControls.hoverControls),
-    renderPlayer: () => <Player useBg={Settings.plugins.SpotifyControls.useCoverAsBackground} rotateBg={Settings.plugins.SpotifyControls.rotateBackground} />
+    renderPlayer: () => <Player />
 });

--- a/src/plugins/spotifyControls/spotifyStyles.css
+++ b/src/plugins/spotifyControls/spotifyStyles.css
@@ -1,16 +1,22 @@
 #vc-spotify-player {
     padding: 0.375rem 0.5rem;
     border-bottom: 1px solid var(--background-modifier-accent);
+    position: relative;
+    overflow: hidden;
 
-    --vc-spotify-green: #1db954; /* so custom themes can easily change it */
+    --vc-spotify-green: #1db954;
+
+    /* so custom themes can easily change it */
 }
 
-.theme-light #vc-spotify-player {
-    background: var(--bg-overlay-3, var(--background-secondary-alt));
-}
-
-.theme-dark #vc-spotify-player {
-    background: var(--bg-overlay-1, var(--background-secondary-alt));
+#vc-spotify-background-image {
+    position: absolute;
+    top: -10px;
+    left: -10px;
+    height: 120%;
+    width: 120%;
+    filter: blur(30px) brightness(0.75);
+    z-index: -1;
 }
 
 .vc-spotify-button {
@@ -35,8 +41,8 @@
     width: 24px;
 }
 
-[class*="vc-spotify-shuffle"] > svg,
-[class*="vc-spotify-repeat"] > svg {
+[class*="vc-spotify-shuffle"]>svg,
+[class*="vc-spotify-repeat"]>svg {
     width: 22px;
     height: 22px;
 }
@@ -156,17 +162,17 @@
     margin-bottom: 5px;
 }
 
-#vc-spotify-progress-bar > [class^="slider"] {
+#vc-spotify-progress-bar>[class^="slider"] {
     flex-grow: 1;
     width: 100%;
     padding: 0 !important;
 }
 
-#vc-spotify-progress-bar > [class^="slider"] [class^="bar-"] {
+#vc-spotify-progress-bar>[class^="slider"] [class^="bar-"] {
     height: 4px !important;
 }
 
-#vc-spotify-progress-bar > [class^="slider"] [class^="grabber"] {
+#vc-spotify-progress-bar>[class^="slider"] [class^="grabber"] {
     /* these importants are necessary, it applies a width and height through inline styles */
     height: 10px !important;
     width: 10px !important;

--- a/src/plugins/spotifyControls/spotifyStyles.css
+++ b/src/plugins/spotifyControls/spotifyStyles.css
@@ -20,7 +20,8 @@
 }
 
 .vc-spotify-rotate {
-    animation: vc-spotify-rotate-anim 15s infinite;
+    transform-origin: center;
+    animation: vc-spotify-rotate-anim 15s linear infinite;
 }
 
 .vc-spotify-button {

--- a/src/plugins/spotifyControls/spotifyStyles.css
+++ b/src/plugins/spotifyControls/spotifyStyles.css
@@ -2,9 +2,7 @@
     padding: 0.375rem 0.5rem;
     border-bottom: 1px solid var(--background-modifier-accent);
 
-    --vc-spotify-green: #1db954;
-
-    /* so custom themes can easily change it */
+    --vc-spotify-green: #1db954; /* so custom themes can easily change it */
 }
 
 .theme-light #vc-spotify-player {
@@ -37,8 +35,8 @@
     width: 24px;
 }
 
-[class*="vc-spotify-shuffle"]>svg,
-[class*="vc-spotify-repeat"]>svg {
+[class*="vc-spotify-shuffle"] > svg,
+[class*="vc-spotify-repeat"] > svg {
     width: 22px;
     height: 22px;
 }
@@ -158,17 +156,17 @@
     margin-bottom: 5px;
 }
 
-#vc-spotify-progress-bar>[class^="slider"] {
+#vc-spotify-progress-bar > [class^="slider"] {
     flex-grow: 1;
     width: 100%;
     padding: 0 !important;
 }
 
-#vc-spotify-progress-bar>[class^="slider"] [class^="bar-"] {
+#vc-spotify-progress-bar > [class^="slider"] [class^="bar-"] {
     height: 4px !important;
 }
 
-#vc-spotify-progress-bar>[class^="slider"] [class^="grabber"] {
+#vc-spotify-progress-bar > [class^="slider"] [class^="grabber"] {
     /* these importants are necessary, it applies a width and height through inline styles */
     height: 10px !important;
     width: 10px !important;

--- a/src/plugins/spotifyControls/spotifyStyles.css
+++ b/src/plugins/spotifyControls/spotifyStyles.css
@@ -19,6 +19,10 @@
     z-index: -1;
 }
 
+.vc-spotify-rotate {
+    animation: vc-spotify-rotate-anim 15s infinite;
+}
+
 .vc-spotify-button {
     background: none;
     color: var(--interactive-normal);
@@ -202,4 +206,14 @@
 .vc-spotify-fallback {
     padding: 0.5em;
     color: var(--text-normal);
+}
+
+@keyframes vc-spotify-rotate-anim {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
 }

--- a/src/plugins/spotifyControls/spotifyStyles.css
+++ b/src/plugins/spotifyControls/spotifyStyles.css
@@ -1,27 +1,18 @@
 #vc-spotify-player {
     padding: 0.375rem 0.5rem;
     border-bottom: 1px solid var(--background-modifier-accent);
-    position: relative;
-    overflow: hidden;
 
     --vc-spotify-green: #1db954;
 
     /* so custom themes can easily change it */
 }
 
-#vc-spotify-background-image {
-    position: absolute;
-    top: -10px;
-    left: -10px;
-    height: 120%;
-    width: 120%;
-    filter: blur(30px) brightness(0.75);
-    z-index: -1;
+.theme-light #vc-spotify-player {
+    background: var(--bg-overlay-3, var(--background-secondary-alt));
 }
 
-.vc-spotify-rotate {
-    transform-origin: center;
-    animation: vc-spotify-rotate-anim 15s linear infinite;
+.theme-dark #vc-spotify-player {
+    background: var(--bg-overlay-1, var(--background-secondary-alt));
 }
 
 .vc-spotify-button {
@@ -207,14 +198,4 @@
 .vc-spotify-fallback {
     padding: 0.5em;
     color: var(--text-normal);
-}
-
-@keyframes vc-spotify-rotate-anim {
-    from {
-        transform: rotate(0deg);
-    }
-
-    to {
-        transform: rotate(360deg);
-    }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -410,6 +410,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     coolelectronics: {
         name: "coolelectronics",
         id: 696392247205298207n,
+    },
+    Av32000: {
+        name: "Av32000",
+        id: 593436735380127770n,
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
I've added (as an option) the cover of the album/track currently playing to the SpotifyControl plugin player
Preview : 
![image](https://github.com/Vendicated/Vencord/assets/59660601/2cd43a8d-e347-40a8-9b98-bc419cd9c45e)
