### PR TITLE
Add date to filename in settings backup

### DIFF
--- a/src/utils/settingsSync.ts
+++ b/src/utils/settingsSync.ts
@@ -49,7 +49,8 @@ export async function exportSettings({ minify }: { minify?: boolean; } = {}) {
 }
 
 export async function downloadSettingsBackup() {
-    const filename = "vencord-settings-backup.json";
+    // The date is formatted as yyyy-mm-dd.
+    const filename = `vencord-settings-backup-${(new Date).toLocaleDateString('ky')}.json`;
     const backup = await exportSettings();
     const data = new TextEncoder().encode(backup);
 


### PR DESCRIPTION
When exporting settings, the file name is always `vencord-settings-backup.json`. This small change adds the date to the filename, to make it easier when exporting if there is already a `vencord-settings-backup.json` in the folder chosen.

I tried all the locales available, and `ky` was the only one that printed it in the format `yyyy-mm-dd`. Feel free to change the format if necessary.