### PR TITLE
Make `Queue#unshift` constant time

### DIFF
--- a/src/utils/Queue.ts
+++ b/src/utils/Queue.ts
@@ -34,7 +34,7 @@ export class Queue {
     private promise?: Promise<any>;
 
     private next() {
-        const func = this.queue.shift();
+        const func = this.queue.pop();
         if (func)
             this.promise = Promise.resolve()
                 .then(func)
@@ -55,9 +55,9 @@ export class Queue {
      */
     push<T>(func: () => Promisable<T>) {
         if (this.size >= this.maxSize)
-            this.queue.shift();
+            this.queue.pop();
 
-        this.queue.push(func);
+        this.queue.unshift(func);
         this.run();
     }
 
@@ -68,9 +68,9 @@ export class Queue {
      */
     unshift<T>(func: () => Promisable<T>) {
         if (this.size >= this.maxSize)
-            this.queue.pop();
+            this.queue.shift();
 
-        this.queue.unshift(func);
+        this.queue.push(func);
         this.run();
     }
 


### PR DESCRIPTION
Before this commit, `Queue#push` was using an constant time array push, while `Queue#unshift` - and most importantly - `Queue#next` were using O(n) array (un)shifts.
However, as both `push()` and `unshift()` called `run()`, which called `next()` - _all_ methods were O(n).

Swap the time complexity of these methods by reversing the order of the underlying array.
`Queue#unshift` is now constant time, and `Queue#push` is now O(n) - which is the same as before, as it previously called an O(n) `run()`. This speeds up users of `Queue#unshift`, such as WhoReacted and ValidUser.