### PR TITLE
Refactor ContextMenuAPI

### DIFF
--- a/src/api/ContextMenu.ts
+++ b/src/api/ContextMenu.ts
@@ -169,7 +169,10 @@ function cloneMenuChildren(obj: ReactElement | Array<ReactElement | null> | null
     if (React.isValidElement(obj)) {
         obj = React.cloneElement(obj);
 
-        if (obj?.props?.children && obj?.type !== Menu.MenuControlItem) {
+        if (
+            obj?.props?.children &&
+            (obj.type !== Menu.MenuControlItem || obj.type === Menu.MenuControlItem && obj.props.control != null)
+        ) {
             obj.props.children = cloneMenuChildren(obj.props.children);
         }
     }

--- a/src/api/ContextMenu.ts
+++ b/src/api/ContextMenu.ts
@@ -17,7 +17,7 @@
 */
 
 import { Logger } from "@utils/Logger";
-import { lodash } from "@webpack/common";
+import { Menu, React } from "@webpack/common";
 import type { ReactElement } from "react";
 
 type ContextMenuPatchCallbackReturn = (() => void) | void;
@@ -131,7 +131,10 @@ interface ContextMenuProps {
 const patchedMenus = new WeakSet();
 
 export function _usePatchContextMenu(props: ContextMenuProps) {
-    props = lodash.cloneDeep(props);
+    props = {
+        ...props,
+        children: cloneMenuChildren(props.children),
+    };
     props.contextMenuApiArguments ??= [];
     const contextMenuPatches = navPatches.get(props.navId);
 
@@ -160,4 +163,15 @@ export function _usePatchContextMenu(props: ContextMenuProps) {
     patchedMenus.add(props);
 
     return props;
+}
+
+function cloneMenuChildren(obj) {
+    if (Array.isArray(obj)) {
+        obj = obj.map(cloneMenuChildren);
+    } else if (React.isValidElement(obj)) {
+        obj = React.cloneElement(obj);
+        if (obj.props.children && obj.type !== Menu.MenuControlItem)
+            obj.props.children = cloneMenuChildren(obj.props.children);
+    }
+    return obj;
 }

--- a/src/api/ContextMenu.ts
+++ b/src/api/ContextMenu.ts
@@ -17,6 +17,7 @@
 */
 
 import { Logger } from "@utils/Logger";
+import { lodash } from "@webpack/common";
 import type { ReactElement } from "react";
 
 type ContextMenuPatchCallbackReturn = (() => void) | void;
@@ -126,9 +127,11 @@ interface ContextMenuProps {
     onClose: (callback: (...args: Array<any>) => any) => void;
 }
 
+// TODO this should be phased out eventually
 const patchedMenus = new WeakSet();
 
-export function _patchContextMenu(props: ContextMenuProps) {
+export function _usePatchContextMenu(props: ContextMenuProps) {
+    props = lodash.cloneDeep(props);
     props.contextMenuApiArguments ??= [];
     const contextMenuPatches = navPatches.get(props.navId);
 
@@ -155,4 +158,6 @@ export function _patchContextMenu(props: ContextMenuProps) {
     }
 
     patchedMenus.add(props);
+
+    return props;
 }

--- a/src/plugins/_api/contextMenu.ts
+++ b/src/plugins/_api/contextMenu.ts
@@ -29,7 +29,7 @@ export default definePlugin({
         {
             find: "♫ (つ｡◕‿‿◕｡)つ ♪",
             replacement: {
-                match: /(?<=function \i\((\i)\){.*?)(?=let{navId:)/,
+                match: /(?=let{navId:)(?<=function \i\((\i)\).+?)/,
                 replace: "$1=Vencord.Api.ContextMenu._usePatchContextMenu($1);"
             }
         },

--- a/src/plugins/_api/contextMenu.ts
+++ b/src/plugins/_api/contextMenu.ts
@@ -22,7 +22,7 @@ import definePlugin from "@utils/types";
 export default definePlugin({
     name: "ContextMenuAPI",
     description: "API for adding/removing items to/from context menus.",
-    authors: [Devs.Nuckyz, Devs.Ven],
+    authors: [Devs.Nuckyz, Devs.Ven, Devs.Kyuuhachi],
     required: true,
 
     patches: [

--- a/src/plugins/_api/contextMenu.ts
+++ b/src/plugins/_api/contextMenu.ts
@@ -38,7 +38,7 @@ export default definePlugin({
             all: true,
             replacement: {
                 match: /Menu,{(?<=\.jsxs?\)\(\i\.Menu,{)/g,
-                replace: "$&contextMenuApiArguments:typeof arguments!=='undefined'?[...arguments]:[],"
+                replace: "$&contextMenuApiArguments:typeof arguments!=='undefined'?arguments:[],"
             }
         }
     ]

--- a/src/plugins/_api/contextMenu.ts
+++ b/src/plugins/_api/contextMenu.ts
@@ -29,8 +29,8 @@ export default definePlugin({
         {
             find: "♫ (つ｡◕‿‿◕｡)つ ♪",
             replacement: {
-                match: /let{navId:/,
-                replace: "Vencord.Api.ContextMenu._patchContextMenu(arguments[0]);$&"
+                match: /(?<=function \i\((\i)\){.*?)(?=let{navId:)/,
+                replace: "$1=Vencord.Api.ContextMenu._usePatchContextMenu($1);"
             }
         },
         {
@@ -38,7 +38,7 @@ export default definePlugin({
             all: true,
             replacement: {
                 match: /Menu,{(?<=\.jsxs?\)\(\i\.Menu,{)/g,
-                replace: "$&contextMenuApiArguments:typeof arguments!=='undefined'?arguments:[],"
+                replace: "$&contextMenuApiArguments:typeof arguments!=='undefined'?[...arguments]:[],"
             }
         }
     ]

--- a/src/plugins/_core/settings.tsx
+++ b/src/plugins/_core/settings.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { findGroupChildrenByChildId } from "@api/ContextMenu";
 import { Settings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
@@ -36,11 +37,11 @@ export default definePlugin({
         // sections to manually use SettingsRouter (which only works on desktop
         // but the context menu is usually not available on mobile anyway)
         "user-settings-cog"(children) {
-            const section = children.find(c => Array.isArray(c) && c.some(it => it?.props?.id === "VencordSettings")) as any;
+            const section = findGroupChildrenByChildId("VencordSettings", children);
             section?.forEach(c => {
                 const id = c?.props?.id;
                 if (id?.startsWith("Vencord") || id?.startsWith("Vesktop")) {
-                    c.props.action = () => SettingsRouter.open(id);
+                    c!.props.action = () => SettingsRouter.open(id);
                 }
             });
         }

--- a/src/plugins/_core/settings.tsx
+++ b/src/plugins/_core/settings.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch } from "@api/ContextMenu";
 import { Settings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
@@ -30,13 +29,13 @@ export default definePlugin({
     authors: [Devs.Ven, Devs.Megu],
     required: true,
 
-    start() {
+    contextMenus: {
         // The settings shortcuts in the user settings cog context menu
         // read the elements from a hardcoded map which for obvious reason
         // doesn't contain our sections. This patches the actions of our
         // sections to manually use SettingsRouter (which only works on desktop
         // but the context menu is usually not available on mobile anyway)
-        addContextMenuPatch("user-settings-cog", children => () => {
+        "user-settings-cog"(children) {
             const section = children.find(c => Array.isArray(c) && c.some(it => it?.props?.id === "VencordSettings")) as any;
             section?.forEach(c => {
                 const id = c?.props?.id;
@@ -44,7 +43,7 @@ export default definePlugin({
                     c.props.action = () => SettingsRouter.open(id);
                 }
             });
-        });
+        }
     },
 
     patches: [{

--- a/src/plugins/biggerStreamPreview/index.tsx
+++ b/src/plugins/biggerStreamPreview/index.tsx
@@ -91,6 +91,6 @@ export default definePlugin({
     authors: [Devs.phil],
     contextMenus: {
         "user-context": userContextPatch,
-        "stream-context": streamContextPatch,
+        "stream-context": streamContextPatch
     }
 });

--- a/src/plugins/biggerStreamPreview/index.tsx
+++ b/src/plugins/biggerStreamPreview/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { ScreenshareIcon } from "@components/Icons";
 import { Devs } from "@utils/constants";
 import { openImageModal } from "@utils/discord";
@@ -60,7 +60,7 @@ export const handleViewPreview = async ({ guildId, channelId, ownerId }: Applica
     openImageModal(previewUrl);
 };
 
-export const addViewStreamContext: NavContextMenuPatchCallback = (children, { userId }: { userId: string | bigint; }) => () => {
+export const addViewStreamContext: NavContextMenuPatchCallback = (children, { userId }: { userId: string | bigint; }) => {
     const stream = ApplicationStreamingStore.getAnyStreamForUser(userId);
     if (!stream) return;
 
@@ -89,12 +89,8 @@ export default definePlugin({
     name: "BiggerStreamPreview",
     description: "This plugin allows you to enlarge stream previews",
     authors: [Devs.phil],
-    start: () => {
-        addContextMenuPatch("user-context", userContextPatch);
-        addContextMenuPatch("stream-context", streamContextPatch);
-    },
-    stop: () => {
-        removeContextMenuPatch("user-context", userContextPatch);
-        removeContextMenuPatch("stream-context", streamContextPatch);
+    contextMenus: {
+        "user-context": userContextPatch,
+        "stream-context": streamContextPatch,
     }
 });

--- a/src/plugins/copyUserURLs/index.tsx
+++ b/src/plugins/copyUserURLs/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { LinkIcon } from "@components/Icons";
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
@@ -29,7 +29,7 @@ interface UserContextProps {
     user: User;
 }
 
-const UserContextMenuPatch: NavContextMenuPatchCallback = (children, { user }: UserContextProps) => () => {
+const UserContextMenuPatch: NavContextMenuPatchCallback = (children, { user }: UserContextProps) => {
     if (!user) return;
 
     children.push(
@@ -46,12 +46,7 @@ export default definePlugin({
     name: "CopyUserURLs",
     authors: [Devs.castdrian],
     description: "Adds a 'Copy User URL' option to the user context menu.",
-
-    start() {
-        addContextMenuPatch("user-context", UserContextMenuPatch);
-    },
-
-    stop() {
-        removeContextMenuPatch("user-context", UserContextMenuPatch);
-    },
+    contextMenus: {
+        "user-context": UserContextMenuPatch
+    }
 });

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { CheckedTextInput } from "@components/CheckedTextInput";
 import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
@@ -312,7 +312,7 @@ function isGifUrl(url: string) {
     return new URL(url).pathname.endsWith(".gif");
 }
 
-const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => () => {
+const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
     const { favoriteableId, itemHref, itemSrc, favoriteableType } = props ?? {};
 
     if (!favoriteableId) return;
@@ -341,7 +341,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
         findGroupChildrenByChildId("copy-link", children)?.push(menuItem);
 };
 
-const expressionPickerPatch: NavContextMenuPatchCallback = (children, props: { target: HTMLElement; }) => () => {
+const expressionPickerPatch: NavContextMenuPatchCallback = (children, props: { target: HTMLElement; }) => {
     const { id, name, type } = props?.target?.dataset ?? {};
     if (!id) return;
 
@@ -363,14 +363,8 @@ export default definePlugin({
     description: "Allows you to clone Emotes & Stickers to your own server (right click them)",
     tags: ["StickerCloner"],
     authors: [Devs.Ven, Devs.Nuckyz],
-
-    start() {
-        addContextMenuPatch("message", messageContextMenuPatch);
-        addContextMenuPatch("expression-picker", expressionPickerPatch);
-    },
-
-    stop() {
-        removeContextMenuPatch("message", messageContextMenuPatch);
-        removeContextMenuPatch("expression-picker", expressionPickerPatch);
+    contextMenus: {
+        "message": messageContextMenuPatch,
+        "expression-picker": expressionPickerPatch
     }
 });

--- a/src/plugins/imageZoom/index.tsx
+++ b/src/plugins/imageZoom/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { definePluginSettings } from "@api/Settings";
 import { disableStyle, enableStyle } from "@api/Styles";
 import { makeRange } from "@components/PluginSettings/components";
@@ -80,7 +80,7 @@ export const settings = definePluginSettings({
 });
 
 
-const imageContextMenuPatch: NavContextMenuPatchCallback = children => () => {
+const imageContextMenuPatch: NavContextMenuPatchCallback = children => {
     children.push(
         <Menu.MenuGroup id="image-zoom">
             <Menu.MenuCheckboxItem
@@ -196,6 +196,9 @@ export default definePlugin({
     ],
 
     settings,
+    contextMenus: {
+        "image-context": imageContextMenuPatch
+    },
 
     // to stop from rendering twice /shrug
     currentMagnifierElement: null as React.FunctionComponentElement<MagnifierProps & JSX.IntrinsicAttributes> | null,
@@ -245,7 +248,6 @@ export default definePlugin({
 
     start() {
         enableStyle(styles);
-        addContextMenuPatch("image-context", imageContextMenuPatch);
         this.element = document.createElement("div");
         this.element.classList.add("MagnifierContainer");
         document.body.appendChild(this.element);
@@ -256,6 +258,5 @@ export default definePlugin({
         // so componenetWillUnMount gets called if Magnifier component is still alive
         this.root && this.root.unmount();
         this.element?.remove();
-        removeContextMenuPatch("image-context", imageContextMenuPatch);
     }
 });

--- a/src/plugins/imageZoom/index.tsx
+++ b/src/plugins/imageZoom/index.tsx
@@ -23,7 +23,7 @@ import { makeRange } from "@components/PluginSettings/components";
 import { Devs } from "@utils/constants";
 import { debounce } from "@utils/debounce";
 import definePlugin, { OptionType } from "@utils/types";
-import { ContextMenuApi, Menu, React, ReactDOM } from "@webpack/common";
+import { Menu, React, ReactDOM } from "@webpack/common";
 import type { Root } from "react-dom/client";
 
 import { Magnifier, MagnifierProps } from "./components/Magnifier";
@@ -81,24 +81,24 @@ export const settings = definePluginSettings({
 
 
 const imageContextMenuPatch: NavContextMenuPatchCallback = children => {
+    const { square, nearestNeighbour } = settings.use(["square", "nearestNeighbour"]);
+
     children.push(
         <Menu.MenuGroup id="image-zoom">
             <Menu.MenuCheckboxItem
                 id="vc-square"
                 label="Square Lens"
-                checked={settings.store.square}
+                checked={square}
                 action={() => {
-                    settings.store.square = !settings.store.square;
-                    ContextMenuApi.closeContextMenu();
+                    settings.store.square = !square;
                 }}
             />
             <Menu.MenuCheckboxItem
                 id="vc-nearest-neighbour"
                 label="Nearest Neighbour"
-                checked={settings.store.nearestNeighbour}
+                checked={nearestNeighbour}
                 action={() => {
-                    settings.store.nearestNeighbour = !settings.store.nearestNeighbour;
-                    ContextMenuApi.closeContextMenu();
+                    settings.store.nearestNeighbour = !nearestNeighbour;
                 }}
             />
             <Menu.MenuControlItem

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -156,9 +156,8 @@ export const startPlugin = traceFunction("startPlugin", function startPlugin(p: 
     }
 
     if (contextMenus) {
-        for (const [k, v] of Object.entries(contextMenus)) {
-            console.log(k, v);
-            addContextMenuPatch(k, v);
+        for (const navId in contextMenus) {
+            addContextMenuPatch(navId, contextMenus[navId]);
         }
     }
 
@@ -201,8 +200,8 @@ export const stopPlugin = traceFunction("stopPlugin", function stopPlugin(p: Plu
     }
 
     if (contextMenus) {
-        for (const [k, v] of Object.entries(contextMenus)) {
-            removeContextMenuPatch(k, v);
+        for (const navId in contextMenus) {
+            removeContextMenuPatch(navId, contextMenus[navId]);
         }
     }
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -17,6 +17,7 @@
 */
 
 import { registerCommand, unregisterCommand } from "@api/Commands";
+import { addContextMenuPatch, removeContextMenuPatch } from "@api/ContextMenu";
 import { Settings } from "@api/Settings";
 import { Logger } from "@utils/Logger";
 import { Patch, Plugin, StartAt } from "@utils/types";
@@ -119,7 +120,7 @@ export function startDependenciesRecursive(p: Plugin) {
 }
 
 export const startPlugin = traceFunction("startPlugin", function startPlugin(p: Plugin) {
-    const { name, commands, flux } = p;
+    const { name, commands, flux, contextMenus } = p;
 
     if (p.start) {
         logger.info("Starting plugin", name);
@@ -154,11 +155,18 @@ export const startPlugin = traceFunction("startPlugin", function startPlugin(p: 
         }
     }
 
+    if (contextMenus) {
+        for (const [k, v] of Object.entries(contextMenus)) {
+            console.log(k, v);
+            addContextMenuPatch(k, v);
+        }
+    }
+
     return true;
 }, p => `startPlugin ${p.name}`);
 
 export const stopPlugin = traceFunction("stopPlugin", function stopPlugin(p: Plugin) {
-    const { name, commands, flux } = p;
+    const { name, commands, flux, contextMenus } = p;
     if (p.stop) {
         logger.info("Stopping plugin", name);
         if (!p.started) {
@@ -189,6 +197,12 @@ export const stopPlugin = traceFunction("stopPlugin", function stopPlugin(p: Plu
     if (flux) {
         for (const event in flux) {
             FluxDispatcher.unsubscribe(event as FluxEvents, flux[event]);
+        }
+    }
+
+    if (contextMenus) {
+        for (const [k, v] of Object.entries(contextMenus)) {
+            removeContextMenuPatch(k, v);
         }
     }
 

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -93,8 +93,9 @@ export default definePlugin({
     name: "MessageLogger",
     description: "Temporarily logs deleted and edited messages.",
     authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN],
+
     contextMenus: {
-        "message": patchMessageContextMenu,
+        "message": patchMessageContextMenu
     },
 
     start() {

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -18,7 +18,7 @@
 
 import "./messageLogger.css";
 
-import { addContextMenuPatch, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Settings } from "@api/Settings";
 import { disableStyle, enableStyle } from "@api/Styles";
 import ErrorBoundary from "@components/ErrorBoundary";
@@ -45,7 +45,7 @@ function addDeleteStyle() {
 
 const REMOVE_HISTORY_ID = "ml-remove-history";
 const TOGGLE_DELETE_STYLE_ID = "ml-toggle-style";
-const patchMessageContextMenu: NavContextMenuPatchCallback = (children, props) => () => {
+const patchMessageContextMenu: NavContextMenuPatchCallback = (children, props) => {
     const { message } = props;
     const { deleted, editHistory, id, channel_id } = message;
 
@@ -93,14 +93,12 @@ export default definePlugin({
     name: "MessageLogger",
     description: "Temporarily logs deleted and edited messages.",
     authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN],
+    contextMenus: {
+        "message": patchMessageContextMenu,
+    },
 
     start() {
         addDeleteStyle();
-        addContextMenuPatch("message", patchMessageContextMenu);
-    },
-
-    stop() {
-        removeContextMenuPatch("message", patchMessageContextMenu);
     },
 
     renderEdit(edit: { timestamp: any, content: string; }) {

--- a/src/plugins/permissionsViewer/index.tsx
+++ b/src/plugins/permissionsViewer/index.tsx
@@ -18,7 +18,7 @@
 
 import "./styles.css";
 
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
@@ -125,10 +125,10 @@ function MenuItem(guildId: string, id?: string, type?: MenuItemParentType) {
 }
 
 function makeContextMenuPatch(childId: string | string[], type?: MenuItemParentType): NavContextMenuPatchCallback {
-    return (children, props) => () => {
+    return (children, props) => {
         if (!props) return;
         if ((type === MenuItemParentType.User && !props.user) || (type === MenuItemParentType.Guild && !props.guild) || (type === MenuItemParentType.Channel && (!props.channel || !props.guild)))
-            return children;
+            return;
 
         const group = findGroupChildrenByChildId(childId, children);
 
@@ -173,19 +173,10 @@ export default definePlugin({
 
     UserPermissions: (guild: Guild, guildMember: GuildMember | undefined, showBoder: boolean) => !!guildMember && <UserPermissions guild={guild} guildMember={guildMember} showBorder={showBoder} />,
 
-    userContextMenuPatch: makeContextMenuPatch("roles", MenuItemParentType.User),
-    channelContextMenuPatch: makeContextMenuPatch(["mute-channel", "unmute-channel"], MenuItemParentType.Channel),
-    guildContextMenuPatch: makeContextMenuPatch("privacy", MenuItemParentType.Guild),
-
-    start() {
-        addContextMenuPatch("user-context", this.userContextMenuPatch);
-        addContextMenuPatch("channel-context", this.channelContextMenuPatch);
-        addContextMenuPatch(["guild-context", "guild-header-popout"], this.guildContextMenuPatch);
-    },
-
-    stop() {
-        removeContextMenuPatch("user-context", this.userContextMenuPatch);
-        removeContextMenuPatch("channel-context", this.channelContextMenuPatch);
-        removeContextMenuPatch(["guild-context", "guild-header-popout"], this.guildContextMenuPatch);
-    },
+    contextMenus: {
+        "user-context": makeContextMenuPatch("roles", MenuItemParentType.User),
+        "channel-context": makeContextMenuPatch(["mute-channel", "unmute-channel"], MenuItemParentType.Channel),
+        "guild-context": makeContextMenuPatch("privacy", MenuItemParentType.Guild),
+        "guild-header-popout": makeContextMenuPatch("privacy", MenuItemParentType.Guild)
+    }
 });

--- a/src/plugins/pinDms/contextMenus.tsx
+++ b/src/plugins/pinDms/contextMenus.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Menu } from "@webpack/common";
 
 import { isPinned, movePin, PinOrder, settings, snapshotArray, togglePin } from "./settings";
@@ -50,13 +50,13 @@ function PinMenuItem(channelId: string) {
     );
 }
 
-const GroupDMContext: NavContextMenuPatchCallback = (children, props) => () => {
+const GroupDMContext: NavContextMenuPatchCallback = (children, props) => {
     const container = findGroupChildrenByChildId("leave-channel", children);
     if (container)
         container.unshift(PinMenuItem(props.channel.id));
 };
 
-const UserContext: NavContextMenuPatchCallback = (children, props) => () => {
+const UserContext: NavContextMenuPatchCallback = (children, props) => {
     const container = findGroupChildrenByChildId("close-dm", children);
     if (container) {
         const idx = container.findIndex(c => c?.props?.id === "close-dm");
@@ -64,12 +64,7 @@ const UserContext: NavContextMenuPatchCallback = (children, props) => () => {
     }
 };
 
-export function addContextMenus() {
-    addContextMenuPatch("gdm-context", GroupDMContext);
-    addContextMenuPatch("user-context", UserContext);
-}
-
-export function removeContextMenus() {
-    removeContextMenuPatch("gdm-context", GroupDMContext);
-    removeContextMenuPatch("user-context", UserContext);
-}
+export const contextMenus = {
+    "gdm-context": GroupDMContext,
+    "user-context": UserContext
+};

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -20,7 +20,7 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { Channel } from "discord-types/general";
 
-import { addContextMenus, removeContextMenus } from "./contextMenus";
+import { contextMenus } from "./contextMenus";
 import { getPinAt, isPinned, settings, snapshotArray, sortedSnapshot, usePinnedDms } from "./settings";
 
 export default definePlugin({
@@ -29,9 +29,7 @@ export default definePlugin({
     authors: [Devs.Ven, Devs.Strencher],
 
     settings,
-
-    start: addContextMenus,
-    stop: removeContextMenus,
+    contextMenus,
 
     usePinCount(channelIds: string[]) {
         const pinnedDms = usePinnedDms();

--- a/src/plugins/resurrectHome/index.tsx
+++ b/src/plugins/resurrectHome/index.tsx
@@ -30,6 +30,12 @@ const settings = definePluginSettings({
     }
 });
 
+function useForceServerHome() {
+    const { forceServerHome } = settings.use(["forceServerHome"]);
+
+    return forceServerHome;
+}
+
 export default definePlugin({
     name: "ResurrectHome",
     description: "Re-enables the Server Home tab when there isn't a Server Guide. Also has an option to force the Server Home over the Server Guide, which is accessible through right-clicking the Server Guide.",
@@ -89,9 +95,12 @@ export default definePlugin({
         }
     ],
 
+    useForceServerHome,
+
     contextMenus: {
         "guild-context"(children, props) {
-            settings.use(["forceServerHome"]);
+            const forceServerHome = useForceServerHome();
+
             if (!props?.guild) return;
 
             const group = findGroupChildrenByChildId("hide-muted-channels", children);
@@ -101,16 +110,10 @@ export default definePlugin({
                     key="force-server-home"
                     id="force-server-home"
                     label="Force Server Home"
-                    checked={settings.store.forceServerHome}
-                    action={() => settings.store.forceServerHome = !settings.store.forceServerHome }
+                    checked={forceServerHome}
+                    action={() => settings.store.forceServerHome = !forceServerHome}
                 />
             );
         }
-    },
-
-    useForceServerHome() {
-        const { forceServerHome } = settings.use(["forceServerHome"]);
-
-        return forceServerHome;
     }
 });

--- a/src/plugins/resurrectHome/index.tsx
+++ b/src/plugins/resurrectHome/index.tsx
@@ -30,7 +30,8 @@ const settings = definePluginSettings({
     }
 });
 
-const contextMenuPatch: NavContextMenuPatchCallback = (children, props) => () => {
+const contextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
+    settings.use(["forceServerHome"]);
     if (!props?.guild) return;
 
     const group = findGroupChildrenByChildId("hide-muted-channels", children);
@@ -41,12 +42,8 @@ const contextMenuPatch: NavContextMenuPatchCallback = (children, props) => () =>
             id="force-server-home"
             label="Force Server Home"
             checked={settings.store.forceServerHome}
-            action={() => {
-                settings.store.forceServerHome = !settings.store.forceServerHome;
-                ContextMenuApi.closeContextMenu();
-            }}
+            action={() => settings.store.forceServerHome = !settings.store.forceServerHome }
         />
-
     );
 };
 

--- a/src/plugins/resurrectHome/index.tsx
+++ b/src/plugins/resurrectHome/index.tsx
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId } from "@api/ContextMenu";
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
-import { ContextMenuApi, Menu } from "@webpack/common";
+import { Menu } from "@webpack/common";
 
 const settings = definePluginSettings({
     forceServerHome: {
@@ -29,23 +29,6 @@ const settings = definePluginSettings({
         default: false
     }
 });
-
-const contextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
-    settings.use(["forceServerHome"]);
-    if (!props?.guild) return;
-
-    const group = findGroupChildrenByChildId("hide-muted-channels", children);
-
-    group?.unshift(
-        <Menu.MenuCheckboxItem
-            key="force-server-home"
-            id="force-server-home"
-            label="Force Server Home"
-            checked={settings.store.forceServerHome}
-            action={() => settings.store.forceServerHome = !settings.store.forceServerHome }
-        />
-    );
-};
 
 export default definePlugin({
     name: "ResurrectHome",
@@ -106,12 +89,23 @@ export default definePlugin({
         }
     ],
 
-    start() {
-        addContextMenuPatch("guild-context", contextMenuPatch);
-    },
+    contextMenus: {
+        "guild-context"(children, props) {
+            settings.use(["forceServerHome"]);
+            if (!props?.guild) return;
 
-    stop() {
-        removeContextMenuPatch("guild-context", contextMenuPatch);
+            const group = findGroupChildrenByChildId("hide-muted-channels", children);
+
+            group?.unshift(
+                <Menu.MenuCheckboxItem
+                    key="force-server-home"
+                    id="force-server-home"
+                    label="Force Server Home"
+                    checked={settings.store.forceServerHome}
+                    action={() => settings.store.forceServerHome = !settings.store.forceServerHome }
+                />
+            );
+        }
     },
 
     useForceServerHome() {

--- a/src/plugins/reverseImageSearch/index.tsx
+++ b/src/plugins/reverseImageSearch/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Flex } from "@components/Flex";
 import { OpenExternalIcon } from "@components/Icons";
 import { Devs } from "@utils/constants";
@@ -84,7 +84,7 @@ function makeSearchItem(src: string) {
     );
 }
 
-const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => () => {
+const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
     if (props?.reverseImageSearchType !== "img") return;
 
     const src = props.itemHref ?? props.itemSrc;
@@ -93,7 +93,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
     group?.push(makeSearchItem(src));
 };
 
-const imageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => () => {
+const imageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
     if (!props?.src) return;
 
     const group = findGroupChildrenByChildId("copy-native-link", children) ?? children;
@@ -115,14 +115,8 @@ export default definePlugin({
             }
         }
     ],
-
-    start() {
-        addContextMenuPatch("message", messageContextMenuPatch);
-        addContextMenuPatch("image-context", imageContextMenuPatch);
-    },
-
-    stop() {
-        removeContextMenuPatch("message", messageContextMenuPatch);
-        removeContextMenuPatch("image-context", imageContextMenuPatch);
+    contextMenus: {
+        "message": messageContextMenuPatch,
+        "image-context": imageContextMenuPatch
     }
 });

--- a/src/plugins/reviewDB/index.tsx
+++ b/src/plugins/reviewDB/index.tsx
@@ -18,7 +18,7 @@
 
 import "./style.css";
 
-import { addContextMenuPatch, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import ErrorBoundary from "@components/ErrorBoundary";
 import ExpandableHeader from "@components/ExpandableHeader";
 import { OpenExternalIcon } from "@components/Icons";
@@ -36,7 +36,7 @@ import { getCurrentUserInfo, readNotification } from "./reviewDbApi";
 import { settings } from "./settings";
 import { showToast } from "./utils";
 
-const guildPopoutPatch: NavContextMenuPatchCallback = (children, props: { guild: Guild, onClose(): void; }) => () => {
+const guildPopoutPatch: NavContextMenuPatchCallback = (children, props: { guild: Guild, onClose(): void; }) => {
     children.push(
         <Menu.MenuItem
             label="View Reviews"
@@ -53,6 +53,9 @@ export default definePlugin({
     authors: [Devs.mantikafasi, Devs.Ven],
 
     settings,
+    contextMenus: {
+        "guild-header-popout": guildPopoutPatch
+    },
 
     patches: [
         {
@@ -69,8 +72,6 @@ export default definePlugin({
     },
 
     async start() {
-        addContextMenuPatch("guild-header-popout", guildPopoutPatch);
-
         const s = settings.store;
         const { lastReviewId, notifyReviews } = s;
 
@@ -125,10 +126,6 @@ export default definePlugin({
                 readNotification(user.notification.id);
             }
         }, 4000);
-    },
-
-    stop() {
-        removeContextMenuPatch("guild-header-popout", guildPopoutPatch);
     },
 
     getReviewsComponent: ErrorBoundary.wrap((user: User) => {

--- a/src/plugins/searchReply/index.tsx
+++ b/src/plugins/searchReply/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { ReplyIcon } from "@components/Icons";
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
@@ -27,7 +27,7 @@ import { Message } from "discord-types/general";
 
 const messageUtils = findByPropsLazy("replyToMessage");
 
-const messageContextMenuPatch: NavContextMenuPatchCallback = (children, { message }: { message: Message; }) => () => {
+const messageContextMenuPatch: NavContextMenuPatchCallback = (children, { message }: { message: Message; }) => {
     // make sure the message is in the selected channel
     if (SelectedChannelStore.getChannelId() !== message.channel_id) return;
     const channel = ChannelStore.getChannel(message?.channel_id);
@@ -38,7 +38,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, { messag
     const dmGroup = findGroupChildrenByChildId("pin", children);
     if (dmGroup && !dmGroup.some(child => child?.props?.id === "reply")) {
         const pinIndex = dmGroup.findIndex(c => c?.props.id === "pin");
-        return dmGroup.splice(pinIndex + 1, 0, (
+        dmGroup.splice(pinIndex + 1, 0, (
             <Menu.MenuItem
                 id="reply"
                 label={i18n.Messages.MESSAGE_ACTION_REPLY}
@@ -46,12 +46,13 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, { messag
                 action={(e: React.MouseEvent) => messageUtils.replyToMessage(channel, message, e)}
             />
         ));
+        return;
     }
 
     // servers
     const serverGroup = findGroupChildrenByChildId("mark-unread", children);
     if (serverGroup && !serverGroup.some(child => child?.props?.id === "reply")) {
-        return serverGroup.unshift((
+        serverGroup.unshift((
             <Menu.MenuItem
                 id="reply"
                 label={i18n.Messages.MESSAGE_ACTION_REPLY}
@@ -59,6 +60,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, { messag
                 action={(e: React.MouseEvent) => messageUtils.replyToMessage(channel, message, e)}
             />
         ));
+        return;
     }
 };
 
@@ -67,12 +69,7 @@ export default definePlugin({
     name: "SearchReply",
     description: "Adds a reply button to search results",
     authors: [Devs.Aria],
-
-    start() {
-        addContextMenuPatch("message", messageContextMenuPatch);
-    },
-
-    stop() {
-        removeContextMenuPatch("message", messageContextMenuPatch);
+    contextMenus: {
+        "message": messageContextMenuPatch,
     }
 });

--- a/src/plugins/searchReply/index.tsx
+++ b/src/plugins/searchReply/index.tsx
@@ -70,6 +70,6 @@ export default definePlugin({
     description: "Adds a reply button to search results",
     authors: [Devs.Aria],
     contextMenus: {
-        "message": messageContextMenuPatch,
+        "message": messageContextMenuPatch
     }
 });

--- a/src/plugins/serverProfile/index.tsx
+++ b/src/plugins/serverProfile/index.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { Menu } from "@webpack/common";
@@ -12,7 +12,7 @@ import { Guild } from "discord-types/general";
 
 import { openGuildProfileModal } from "./GuildProfileModal";
 
-const Patch: NavContextMenuPatchCallback = (children, { guild }: { guild: Guild; }) => () => {
+const Patch: NavContextMenuPatchCallback = (children, { guild }: { guild: Guild; }) => {
     const group = findGroupChildrenByChildId("privacy", children);
 
     group?.push(
@@ -29,12 +29,8 @@ export default definePlugin({
     description: "Allows you to view info about a server by right clicking it in the server list",
     authors: [Devs.Ven, Devs.Nuckyz],
     tags: ["guild", "info"],
-
-    start() {
-        addContextMenuPatch(["guild-context", "guild-header-popout"], Patch);
-    },
-
-    stop() {
-        removeContextMenuPatch(["guild-context", "guild-header-popout"], Patch);
+    contextMenus: {
+        "guild-context": Patch,
+        "guild-header-popout": Patch
     }
 });

--- a/src/plugins/translate/index.tsx
+++ b/src/plugins/translate/index.tsx
@@ -19,7 +19,7 @@
 import "./styles.css";
 
 import { addChatBarButton, removeChatBarButton } from "@api/ChatButtons";
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { addAccessory, removeAccessory } from "@api/MessageAccessories";
 import { addPreSendListener, removePreSendListener } from "@api/MessageEvents";
 import { addButton, removeButton } from "@api/MessagePopover";
@@ -32,7 +32,7 @@ import { TranslateChatBarIcon, TranslateIcon } from "./TranslateIcon";
 import { handleTranslate, TranslationAccessory } from "./TranslationAccessory";
 import { translate } from "./utils";
 
-const messageCtxPatch: NavContextMenuPatchCallback = (children, { message }) => () => {
+const messageCtxPatch: NavContextMenuPatchCallback = (children, { message }) => {
     if (!message.content) return;
 
     const group = findGroupChildrenByChildId("copy-text", children);
@@ -57,13 +57,15 @@ export default definePlugin({
     authors: [Devs.Ven],
     dependencies: ["MessageAccessoriesAPI", "MessagePopoverAPI", "MessageEventsAPI", "ChatInputButtonAPI"],
     settings,
+    contextMenus: {
+        "message": messageCtxPatch
+    },
     // not used, just here in case some other plugin wants it or w/e
     translate,
 
     start() {
         addAccessory("vc-translation", props => <TranslationAccessory message={props.message} />);
 
-        addContextMenuPatch("message", messageCtxPatch);
         addChatBarButton("vc-translate", TranslateChatBarIcon);
 
         addButton("vc-translate", message => {
@@ -91,7 +93,6 @@ export default definePlugin({
 
     stop() {
         removePreSendListener(this.preSend);
-        removeContextMenuPatch("message", messageCtxPatch);
         removeChatBarButton("vc-translate");
         removeButton("vc-translate");
         removeAccessory("vc-translation");

--- a/src/plugins/unsuppressEmbeds/index.tsx
+++ b/src/plugins/unsuppressEmbeds/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { ImageInvisible, ImageVisible } from "@components/Icons";
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
@@ -24,7 +24,7 @@ import { Menu, PermissionsBits, PermissionStore, RestAPI, UserStore } from "@web
 
 const EMBED_SUPPRESSED = 1 << 2;
 
-const messageContextMenuPatch: NavContextMenuPatchCallback = (children, { channel, message: { author, embeds, flags, id: messageId } }) => () => {
+const messageContextMenuPatch: NavContextMenuPatchCallback = (children, { channel, message: { author, embeds, flags, id: messageId } }) => {
     const isEmbedSuppressed = (flags & EMBED_SUPPRESSED) !== 0;
     if (!isEmbedSuppressed && !embeds.length) return;
 
@@ -56,12 +56,7 @@ export default definePlugin({
     name: "UnsuppressEmbeds",
     authors: [Devs.rad, Devs.HypedDomi],
     description: "Allows you to unsuppress embeds in messages",
-
-    start() {
-        addContextMenuPatch("message", messageContextMenuPatch);
-    },
-
-    stop() {
-        removeContextMenuPatch("message", messageContextMenuPatch);
-    },
+    contextMenus: {
+        "message": messageContextMenuPatch
+    }
 });

--- a/src/plugins/vencordToolbox/index.tsx
+++ b/src/plugins/vencordToolbox/index.tsx
@@ -19,7 +19,7 @@
 import "./index.css";
 
 import { openNotificationLogModal } from "@api/Notifications/notificationLog";
-import { Settings } from "@api/Settings";
+import { Settings, useSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
@@ -30,6 +30,8 @@ import type { ReactNode } from "react";
 const HeaderBarIcon = findExportedComponentLazy("Icon", "Divider");
 
 function VencordPopout(onClose: () => void) {
+    const { useQuickCss } = useSettings();
+
     const pluginEntries = [] as ReactNode[];
 
     for (const plugin of Object.values(Vencord.Plugins.plugins)) {
@@ -68,11 +70,10 @@ function VencordPopout(onClose: () => void) {
             />
             <Menu.MenuCheckboxItem
                 id="vc-toolbox-quickcss-toggle"
-                checked={Settings.useQuickCss}
+                checked={useQuickCss}
                 label={"Enable QuickCSS"}
                 action={() => {
-                    Settings.useQuickCss = !Settings.useQuickCss;
-                    onClose();
+                    Settings.useQuickCss = !useQuickCss;
                 }}
             />
             <Menu.MenuItem

--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { definePluginSettings } from "@api/Settings";
 import { ImageIcon } from "@components/Icons";
 import { Devs } from "@utils/constants";
@@ -80,7 +80,7 @@ function openImage(url: string) {
     });
 }
 
-const UserContext: NavContextMenuPatchCallback = (children, { user, guildId }: UserContextProps) => () => {
+const UserContext: NavContextMenuPatchCallback = (children, { user, guildId }: UserContextProps) => {
     if (!user) return;
     const memberAvatar = GuildMemberStore.getMember(guildId!, user.id)?.avatar || null;
 
@@ -109,7 +109,7 @@ const UserContext: NavContextMenuPatchCallback = (children, { user, guildId }: U
     ));
 };
 
-const GuildContext: NavContextMenuPatchCallback = (children, { guild }: GuildContextProps) => () => {
+const GuildContext: NavContextMenuPatchCallback = (children, { guild }: GuildContextProps) => {
     if (!guild) return;
 
     const { id, icon, banner } = guild;
@@ -153,17 +153,12 @@ export default definePlugin({
 
     settings,
 
+    contextMenus: {
+        "user-context": UserContext,
+        "guild-context": GuildContext,
+    },
+
     openImage,
-
-    start() {
-        addContextMenuPatch("user-context", UserContext);
-        addContextMenuPatch("guild-context", GuildContext);
-    },
-
-    stop() {
-        removeContextMenuPatch("user-context", UserContext);
-        removeContextMenuPatch("guild-context", GuildContext);
-    },
 
     patches: [
         // Make pfps clickable

--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -153,12 +153,12 @@ export default definePlugin({
 
     settings,
 
+    openImage,
+
     contextMenus: {
         "user-context": UserContext,
-        "guild-context": GuildContext,
+        "guild-context": GuildContext
     },
-
-    openImage,
 
     patches: [
         // Make pfps clickable

--- a/src/plugins/viewRaw/index.tsx
+++ b/src/plugins/viewRaw/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { addContextMenuPatch, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { addButton, removeButton } from "@api/MessagePopover";
 import { definePluginSettings } from "@api/Settings";
 import { CodeBlock } from "@components/CodeBlock";
@@ -117,8 +117,8 @@ const settings = definePluginSettings({
     }
 });
 
-function MakeContextCallback(name: "Guild" | "User" | "Channel") {
-    const callback: NavContextMenuPatchCallback = (children, props) => () => {
+function MakeContextCallback(name: "Guild" | "User" | "Channel"): NavContextMenuPatchCallback {
+    return (children, props) => {
         const value = props[name.toLowerCase()];
         if (!value) return;
         if (props.label === i18n.Messages.CHANNEL_ACTIONS_MENU_LABEL) return; // random shit like notification settings
@@ -141,9 +141,7 @@ function MakeContextCallback(name: "Guild" | "User" | "Channel") {
             />
         );
     };
-    return callback;
 }
-
 
 export default definePlugin({
     name: "ViewRaw",
@@ -151,6 +149,11 @@ export default definePlugin({
     authors: [Devs.KingFish, Devs.Ven, Devs.rad, Devs.ImLvna],
     dependencies: ["MessagePopoverAPI"],
     settings,
+    contextMenus: {
+        "guild-context": MakeContextCallback("Guild"),
+        "channel-context": MakeContextCallback("Channel"),
+        "user-context": MakeContextCallback("User")
+    },
 
     start() {
         addButton("ViewRaw", msg => {
@@ -187,16 +190,9 @@ export default definePlugin({
                 onContextMenu: handleContextMenu
             };
         });
-
-        addContextMenuPatch("guild-context", MakeContextCallback("Guild"));
-        addContextMenuPatch("channel-context", MakeContextCallback("Channel"));
-        addContextMenuPatch("user-context", MakeContextCallback("User"));
     },
 
     stop() {
-        removeButton("CopyRawMessage");
-        removeContextMenuPatch("guild-context", MakeContextCallback("Guild"));
-        removeContextMenuPatch("channel-context", MakeContextCallback("Channel"));
-        removeContextMenuPatch("user-context", MakeContextCallback("User"));
+        removeButton("ViewRaw");
     }
 });

--- a/src/plugins/voiceMessages/index.tsx
+++ b/src/plugins/voiceMessages/index.tsx
@@ -18,7 +18,7 @@
 
 import "./styles.css";
 
-import { addContextMenuPatch, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Microphone } from "@components/Icons";
 import { Link } from "@components/Link";
 import { Devs } from "@utils/constants";
@@ -48,18 +48,30 @@ export type VoiceRecorder = ComponentType<{
 
 const VoiceRecorder = IS_DISCORD_DESKTOP ? VoiceRecorderDesktop : VoiceRecorderWeb;
 
+const ctxMenuPatch: NavContextMenuPatchCallback = (children, props) => {
+    if (props.channel.guild_id && !(PermissionStore.can(PermissionsBits.SEND_VOICE_MESSAGES, props.channel) && PermissionStore.can(PermissionsBits.SEND_MESSAGES, props.channel))) return;
+
+    children.push(
+        <Menu.MenuItem
+            id="vc-send-vmsg"
+            label={
+                <div className={OptionClasses.optionLabel}>
+                    <Microphone className={OptionClasses.optionIcon} height={24} width={24} />
+                    <div className={OptionClasses.optionName}>Send voice message</div>
+                </div>
+            }
+            action={() => openModal(modalProps => <Modal modalProps={modalProps} />)}
+        />
+    );
+};
+
 export default definePlugin({
     name: "VoiceMessages",
     description: "Allows you to send voice messages like on mobile. To do so, right click the upload button and click Send Voice Message",
     authors: [Devs.Ven, Devs.Vap, Devs.Nickyux],
     settings,
-
-    start() {
-        addContextMenuPatch("channel-attach", ctxMenuPatch);
-    },
-
-    stop() {
-        removeContextMenuPatch("channel-attach", ctxMenuPatch);
+    contextMenus: {
+        "channel-attach": ctxMenuPatch
     }
 });
 
@@ -234,20 +246,3 @@ function Modal({ modalProps }: { modalProps: ModalProps; }) {
         </ModalRoot>
     );
 }
-
-const ctxMenuPatch: NavContextMenuPatchCallback = (children, props) => () => {
-    if (props.channel.guild_id && !(PermissionStore.can(PermissionsBits.SEND_VOICE_MESSAGES, props.channel) && PermissionStore.can(PermissionsBits.SEND_MESSAGES, props.channel))) return;
-
-    children.push(
-        <Menu.MenuItem
-            id="vc-send-vmsg"
-            label={
-                <div className={OptionClasses.optionLabel}>
-                    <Microphone className={OptionClasses.optionIcon} height={24} width={24} />
-                    <div className={OptionClasses.optionName}>Send voice message</div>
-                </div>
-            }
-            action={() => openModal(modalProps => <Modal modalProps={modalProps} />)}
-        />
-    );
-};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -418,6 +418,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Av32000: {
         name: "Av32000",
         id: 593436735380127770n,
+    },
+    Kyuuhachi: {
+        name: "Kyuuhachi",
+        id: 236588665420251137n,
     }
 } satisfies Record<string, Dev>);
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -17,6 +17,7 @@
 */
 
 import { Command } from "@api/Commands";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { FluxEvents } from "@webpack/types";
 import { Promisable } from "type-fest";
 
@@ -114,6 +115,12 @@ export interface PluginDef {
      */
     flux?: {
         [E in FluxEvents]?: (event: any) => void;
+    };
+    /**
+     * Allows you to manipulate context menus
+     */
+    contextMenus?: {
+        [navId: string]: NavContextMenuPatchCallback;
     };
     /**
      * Allows you to add custom actions to the Vencord Toolbox.

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -119,9 +119,7 @@ export interface PluginDef {
     /**
      * Allows you to manipulate context menus
      */
-    contextMenus?: {
-        [navId: string]: NavContextMenuPatchCallback;
-    };
+    contextMenus?: Record<string, NavContextMenuPatchCallback>;
     /**
      * Allows you to add custom actions to the Vencord Toolbox.
      * The key will be used as text for the button


### PR DESCRIPTION
Clones the context menu props so that they are not mutated (React doesn't like it when you mutate stuff). This makes it safe to run context menu patches at every rerender, so the thing with returning a closure which is run once is removed.[^useEffect] Additionally, since I had to edit all plugins that use context menu patches, I took the opportunity to add a `contextMenus` key to the plugin definition, and made all plugins use that.

[^useEffect]: if you need things that actually do run once, use `useEffect`.