### PR TITLE
fix(ServerProfile): crop banner to prevent overflow

### DIFF
--- a/src/plugins/serverProfile/styles.css
+++ b/src/plugins/serverProfile/styles.css
@@ -4,8 +4,13 @@
 }
 
 .vc-gp-banner {
-    width: 100%;
     cursor: pointer;
+    aspect-ratio: auto 240 / 135;
+    height: 334px;
+    width: 100%;
+    object-fit: cover;
+    overflow: clip;
+    overflow-clip-margin: content-box;
 }
 
 .vc-gp-header {


### PR DESCRIPTION
discord doesnt crop the banner server-side, so you can upload a tall image and [cause serverprofile's modal layout to explode.](https://files.catbox.moe/g5w1up.png)
this fixes that by cropping the server banner image in (almost) the same way that discord does
![Discord_9P10FLqjKY](https://github.com/Vendicated/Vencord/assets/96925398/3d9ef756-3400-4b26-b257-85c4592bbab0)
