### PR TITLE
feat(plugin): CopyEmojiAsFormattedString

### DIFF
--- a/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
+++ b/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
@@ -32,7 +32,7 @@ interface Emoji {
 
 export default definePlugin({
     name: "CopyEmojiAsFormattedString",
-    description: "Add's button to copy emoji as formatted string!",
+    description: "Adds button to copy emoji as formatted string!",
     authors: [Devs.HAPPY_ENDERMAN],
     expressionPickerPatch(children, props) {
         if (!children.find(element=>element.props.id === "copy-formatted-string")) {

--- a/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
+++ b/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
@@ -35,7 +35,7 @@ export default definePlugin({
     description: "Add's button to copy emoji as formatted string!",
     authors: [Devs.HAPPY_ENDERMAN],
     expressionPickerPatch(children, props) {
-        if (!props.alreadyPatched) {
+        if (!children.find(element=>element.props.id === "copy-formatted-string")) {
             let data = props.target.dataset as Emoji;
             const firstChild = props.target.firstChild as HTMLImageElement;
 

--- a/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
+++ b/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
@@ -36,10 +36,9 @@ export default definePlugin({
     authors: [Devs.HAPPY_ENDERMAN],
     expressionPickerPatch(children, props) {
         if (!children.find(element=>element.props.id === "copy-formatted-string")) {
-            let data = props.target.dataset as Emoji;
+            const data = props.target.dataset as Emoji;
             const firstChild = props.target.firstChild as HTMLImageElement;
-
-            let isAnimated = firstChild && new URL(firstChild.src).pathname.endsWith(".gif");;
+            const isAnimated = firstChild && new URL(firstChild.src).pathname.endsWith(".gif");;
             if (data.type === "emoji" && data.id) {
 
                 children.push(<Menu.MenuItem

--- a/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
+++ b/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
@@ -34,23 +34,6 @@ export default definePlugin({
     name: "CopyEmojiAsFormattedString",
     description: "Add's button to copy emoji as formatted string!",
     authors: [Devs.HAPPY_ENDERMAN],
-
-    patches: [
-        {
-            find: "window.localStorage",
-            replacement: {
-                match: /delete window.localStorage/,
-                replace: "" // hell naw discord aint removing localstorage
-            }
-        },
-        {
-            find: "1081004946872352958",
-            replacement: {
-                match: /1081004946872352958/,
-                replace: "0" // hell naw discord aint removing localstorage
-            }
-        }
-    ],
     expressionPickerPatch(children, props) {
         if (!props.alreadyPatched) {
             let data = props.target.dataset as Emoji;

--- a/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
+++ b/src/plugins/CopyEmojiAsFormattedString/CopyEmojiAsFormattedString.tsx
@@ -1,0 +1,84 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { addContextMenuPatch, removeContextMenuPatch } from "@api/ContextMenu";
+import {  Menu, React, Toasts, Clipboard } from "@webpack/common";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { showToast } from "@webpack/common";
+
+
+
+interface Emoji {
+    type: "emoji",
+    id: string,
+    name: string;
+}
+
+export default definePlugin({
+    name: "CopyEmojiAsFormattedString",
+    description: "Add's button to copy emoji as formatted string!",
+    authors: [Devs.HAPPY_ENDERMAN],
+
+    patches: [
+        {
+            find: "window.localStorage",
+            replacement: {
+                match: /delete window.localStorage/,
+                replace: "" // hell naw discord aint removing localstorage
+            }
+        },
+        {
+            find: "1081004946872352958",
+            replacement: {
+                match: /1081004946872352958/,
+                replace: "0" // hell naw discord aint removing localstorage
+            }
+        }
+    ],
+    expressionPickerPatch(children, props) {
+        if (!props.alreadyPatched) {
+            let data = props.target.dataset as Emoji;
+            const firstChild = props.target.firstChild as HTMLImageElement;
+
+            let isAnimated = firstChild && new URL(firstChild.src).pathname.endsWith(".gif");;
+            if (data.type === "emoji" && data.id) {
+
+                children.push(<Menu.MenuItem
+                    id="copy-formatted-string"
+                    key="copy-formatted-string"
+                    label={`Copy as formatted string`}
+                    action={() => {
+                        const formatted_emoji_string = `${isAnimated ? "<a:" : "<:"}${data.name}:${data.id}>`;
+                        Clipboard.copy(formatted_emoji_string);
+                        showToast("Success! Copied to clipboard as formatted string.", Toasts.Type.SUCCESS);
+                    }}
+                />);
+            }
+            props.alreadyPatched = true;
+        }
+    },
+    start() {
+        addContextMenuPatch("expression-picker", this.expressionPickerPatch);
+    },
+    stop() {
+        removeContextMenuPatch("expression-picker", this.expressionPickerPatch);
+    }
+
+
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -426,6 +426,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Elvyra: {
         name: "Elvyra",
         id: 708275751816003615n,
+    },
+    HAPPY_ENDERMAN: {
+        name: "Happy enderman",
+        id: 1083437693347827764n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
- Add's a button to copy an emoji as a formatted string: 
Example formatted string: `<:blessing:1216442476148293722>`

![image](https://github.com/Vendicated/Vencord/assets/66224387/162318d7-eef4-411c-9c26-4e5dc74fafb7)
![image](https://github.com/Vendicated/Vencord/assets/66224387/2dbfa083-2f8b-4388-b48f-76bc537fdb53)