### PR TITLE
favGifSearch: don't error on favourited non-urls

### DIFF
--- a/src/plugins/favGifSearch/index.tsx
+++ b/src/plugins/favGifSearch/index.tsx
@@ -200,23 +200,28 @@ function SearchBar({ instance, SearchBarComponent }: { instance: Instance; Searc
 
 
 export function getTargetString(urlStr: string) {
-    const url = new URL(urlStr);
-    switch (settings.store.searchOption) {
-        case "url":
-            return url.href;
-        case "path":
-            if (url.host === "media.discordapp.net" || url.host === "tenor.com")
-                // /attachments/899763415290097664/1095711736461537381/attachment-1.gif -> attachment-1.gif
-                // /view/some-gif-hi-24248063 -> some-gif-hi-24248063
-                return url.pathname.split("/").at(-1) ?? url.pathname;
-            return url.pathname;
-        case "hostandpath":
-            if (url.host === "media.discordapp.net" || url.host === "tenor.com")
-                return `${url.host} ${url.pathname.split("/").at(-1) ?? url.pathname}`;
-            return `${url.host} ${url.pathname}`;
-
-        default:
-            return "";
+    try {
+        const url = new URL(urlStr);
+        switch (settings.store.searchOption) {
+            case "url":
+                return url.href;
+            case "path":
+                if (url.host === "media.discordapp.net" || url.host === "tenor.com")
+                    // /attachments/899763415290097664/1095711736461537381/attachment-1.gif -> attachment-1.gif
+                    // /view/some-gif-hi-24248063 -> some-gif-hi-24248063
+                    return url.pathname.split("/").at(-1) ?? url.pathname;
+                return url.pathname;
+            case "hostandpath":
+                if (url.host === "media.discordapp.net" || url.host === "tenor.com")
+                    return `${url.host} ${url.pathname.split("/").at(-1) ?? url.pathname}`;
+                return `${url.host} ${url.pathname}`;
+    
+            default:
+                return "";
+        }
+    } catch (err) {
+        // Can't resolve URL, return as-is
+        return urlStr;
     }
 }
 

--- a/src/plugins/favGifSearch/index.tsx
+++ b/src/plugins/favGifSearch/index.tsx
@@ -200,7 +200,7 @@ function SearchBar({ instance, SearchBarComponent }: { instance: Instance; Searc
 
 
 export function getTargetString(urlStr: string) {
-    let url;
+    let url: URL;
     try {
         url = new URL(urlStr);
     } catch (err) {

--- a/src/plugins/favGifSearch/index.tsx
+++ b/src/plugins/favGifSearch/index.tsx
@@ -200,28 +200,30 @@ function SearchBar({ instance, SearchBarComponent }: { instance: Instance; Searc
 
 
 export function getTargetString(urlStr: string) {
+    let url;
     try {
-        const url = new URL(urlStr);
-        switch (settings.store.searchOption) {
-            case "url":
-                return url.href;
-            case "path":
-                if (url.host === "media.discordapp.net" || url.host === "tenor.com")
-                    // /attachments/899763415290097664/1095711736461537381/attachment-1.gif -> attachment-1.gif
-                    // /view/some-gif-hi-24248063 -> some-gif-hi-24248063
-                    return url.pathname.split("/").at(-1) ?? url.pathname;
-                return url.pathname;
-            case "hostandpath":
-                if (url.host === "media.discordapp.net" || url.host === "tenor.com")
-                    return `${url.host} ${url.pathname.split("/").at(-1) ?? url.pathname}`;
-                return `${url.host} ${url.pathname}`;
-    
-            default:
-                return "";
-        }
+        url = new URL(urlStr);
     } catch (err) {
         // Can't resolve URL, return as-is
         return urlStr;
+    }
+
+    switch (settings.store.searchOption) {
+        case "url":
+            return url.href;
+        case "path":
+            if (url.host === "media.discordapp.net" || url.host === "tenor.com")
+                // /attachments/899763415290097664/1095711736461537381/attachment-1.gif -> attachment-1.gif
+                // /view/some-gif-hi-24248063 -> some-gif-hi-24248063
+                return url.pathname.split("/").at(-1) ?? url.pathname;
+            return url.pathname;
+        case "hostandpath":
+            if (url.host === "media.discordapp.net" || url.host === "tenor.com")
+                return `${url.host} ${url.pathname.split("/").at(-1) ?? url.pathname}`;
+            return `${url.host} ${url.pathname}`;
+
+        default:
+            return "";
     }
 }
 


### PR DESCRIPTION
It's possible to save any arbitrary string of text inside of the favourited gif picker, instead of just URLs. This causes favGifSearch to fail with this error:
```
Uncaught TypeError: Failed to construct 'URL': Invalid URL
    at Sb (index.tsx:203:17)
    at index.tsx:163:67
    at Array.map (<anonymous>)
    at index.tsx:162:18
    at handleOnChange (29062.2bb468e49a2eee40cded.js:1:2798047)
    at Object.eI (2541.b44fafd1acac6bd12301.js:1:797772)
    at eU (2541.b44fafd1acac6bd12301.js:1:797926)
    at 2541.b44fafd1acac6bd12301.js:1:816235
    at re (2541.b44fafd1acac6bd12301.js:1:816334)
    at rt (2541.b44fafd1acac6bd12301.js:1:816748)
```

This PR simply provides error handling on the URL resolution code, returning the favourited text as-is on failure.

This is obviously very niche behaviour, but would enable compatibility with any other plugin or utility that allows users to add arbitrary content to their gif picker.