### PR TITLE
feat(plugin) BetterBios

### DIFF
--- a/src/plugins/BetterBios/index.tsx
+++ b/src/plugins/BetterBios/index.tsx
@@ -1,0 +1,23 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+
+export default definePlugin({
+    name: "BetterBios",
+    description: "Removes the readable line limit on user profiles.",
+    authors: [Devs.Byron],
+    patches: [{
+        find:
+            "-webkit-line-clamp: 6;",
+        replacement: {
+            match: /"-webkit-line-clamp: 6;"/,
+            replace: "-webkit-line-clamp: 99 !important;"
+        }
+
+    }]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -426,6 +426,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Elvyra: {
         name: "Elvyra",
         id: 708275751816003615n,
+    },
+    Byron: {
+        name: "byron",
+        id: 639577344276692992n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
Removes the readable line limit on user profiles, it gets extremely annoying and this plugin takes it away. 

**Before:**
![image](https://github.com/Vendicated/Vencord/assets/47872200/31390b8f-789e-4e56-a2b2-5507858531a7)

**After:**
![image](https://github.com/Vendicated/Vencord/assets/47872200/9cdccc9d-6332-4b80-a79e-9a847c3b9966)

This is still marked as a draft because I feel like this plugin is too bare bones to be marked as an official plugin. I'm open to suggestions and additional features to make it better.
