### PR TITLE
MemberCount: Fix error when not in a channel

### DIFF
--- a/src/plugins/memberCount/MemberCount.tsx
+++ b/src/plugins/memberCount/MemberCount.tsx
@@ -27,7 +27,7 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
 
     const { groups } = useStateFromStores(
         [ChannelMemberStore],
-        () => ChannelMemberStore.getProps(guildId, currentChannel.id)
+        () => ChannelMemberStore.getProps(guildId, currentChannel?.id)
     );
 
     if (!isTooltip && (groups.length >= 1 || groups[0].id !== "unknown")) {


### PR DESCRIPTION
When you select the DMs page in discord MemberCount wont load the count at all due to not having a channel loaded and as such will spam console.

Fix:
Adding the ? let it load the count when in the DMs page and stop console spam from it not being able to load the count because no channel is loaded.