### PR TITLE
Fix discord-types package not being updated to the most recent version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
         "diff": "^5.1.0",
-        "discord-types": "^1.3.26",
+        "discord-types": "github:Swishilicous/discord-types",
         "esbuild": "^0.15.18",
         "eslint": "^8.46.0",
         "eslint-import-resolver-alias": "^1.1.2",


### PR DESCRIPTION
pretty self-explanatory, vencord currently uses version 1.3.26 from the npm registry, but the newest version of discord-types is only on GitHub and not on the npm registry. you can solve this by just adding the GitHub repo as the source of the package instead of the npmjs version.