### PR TITLE
new plugin UnlockedAvatarZoom: allows crop zooming in further

### DIFF
--- a/src/plugins/unlockedAvatarZoom/README.md
+++ b/src/plugins/unlockedAvatarZoom/README.md
@@ -1,2 +1,3 @@
 # UnlockedAvatarZoom
-Unlocks and allows you to use custom multipliers for the zoom slider in the \"Edit Image\" modal (aka, while cropping a profile picture)
+
+Unlocks and allows you to use custom multipliers for the zoom slider in the "Edit Image" modal (aka, while cropping a profile picture)

--- a/src/plugins/unlockedAvatarZoom/README.md
+++ b/src/plugins/unlockedAvatarZoom/README.md
@@ -1,3 +1,5 @@
 # UnlockedAvatarZoom
 
 Allows you to zoom in further in the image crop tool when changing your avatar
+
+![](https://raw.githubusercontent.com/Vencord/plugin-assets/main/UnlockedAvatarZoom/demo.avif)

--- a/src/plugins/unlockedAvatarZoom/README.md
+++ b/src/plugins/unlockedAvatarZoom/README.md
@@ -1,0 +1,2 @@
+# UnlockedAvatarZoom
+Unlocks and allows you to use custom multipliers for the zoom slider in the \"Edit Image\" modal (aka, while cropping a profile picture)

--- a/src/plugins/unlockedAvatarZoom/README.md
+++ b/src/plugins/unlockedAvatarZoom/README.md
@@ -1,3 +1,3 @@
 # UnlockedAvatarZoom
 
-Unlocks and allows you to use custom multipliers for the zoom slider in the "Edit Image" modal (aka, while cropping a profile picture)
+Allows you to zoom in further in the image crop tool when changing your avatar

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -20,7 +20,7 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "UnlockedAvatarZoom",
-    description: "Unlocks the zoom mutliplier on the avatar modal",
+    description: "Unlocks the avatar zoom slider on the edit avatar modal",
     authors: [Devs.nakoyasha],
     settings,
     patches: [

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -5,15 +5,13 @@
  */
 
 import { definePluginSettings } from "@api/Settings";
-import { makeRange } from "@components/PluginSettings/components";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
 const settings = definePluginSettings({
     zoomMultiplier: {
-        type: OptionType.SLIDER,
+        type: OptionType.NUMBER,
         description: "Zoom multiplier",
-        markers: makeRange(2, 16),
         default: 2,
     },
 });

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { makeRange } from "@components/PluginSettings/components";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    zoomMultiplier: {
+        type: OptionType.SLIDER,
+        description: "Zoom multiplier",
+        markers: makeRange(2, 16),
+        default: 2,
+    },
+});
+
+export default definePlugin({
+    name: "UnlockedAvatarZoom",
+    description: "Unlocks the zoom mutliplier on the avatar modal",
+    authors: [Devs.nakoyasha],
+    settings,
+    patches: [
+        {
+            find: "\"aria-label\":I.default.Messages.FORM_LABEL_AVATAR_SIZE",
+            replacement: {
+                match: /(maxValue:(\w))/,
+                replace: "maxValue:$self.settings.store.zoomMultiplier",
+            }
+        }
+    ]
+});

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -27,7 +27,7 @@ export default definePlugin({
         {
             find: ".Messages.AVATAR_UPLOAD_EDIT_MEDIA",
             replacement: {
-                match: /(maxValue:(\w))/,
+                match: /maxValue:\d/,
                 replace: "maxValue:$self.settings.store.zoomMultiplier",
             }
         }

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -20,7 +20,7 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "UnlockedAvatarZoom",
-    description: "Unlocks and allows you to use custom multipliers for the zoom slider in the \"Edit Image\" modal (aka while cropping a profile picture)",
+    description: "Allows you to zoom in further in the image crop tool when changing your avatar",
     authors: [Devs.nakoyasha],
     settings,
     patches: [

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -5,13 +5,15 @@
  */
 
 import { definePluginSettings } from "@api/Settings";
+import { makeRange } from "@components/PluginSettings/components";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
 const settings = definePluginSettings({
     zoomMultiplier: {
-        type: OptionType.NUMBER,
+        type: OptionType.SLIDER,
         description: "Zoom multiplier",
+        markers: makeRange(2, 16),
         default: 4,
     },
 });

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -18,7 +18,7 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "UnlockedAvatarZoom",
-    description: "Unlocks the avatar zoom slider on the edit avatar modal",
+    description: "Unlocks and allows you to use custom multipliers for the zoom slider in the \"Edit Image\" modal (aka while cropping a profile picture)",
     authors: [Devs.nakoyasha],
     settings,
     patches: [

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -25,7 +25,7 @@ export default definePlugin({
     settings,
     patches: [
         {
-            find: "\"aria-label\":I.default.Messages.FORM_LABEL_AVATAR_SIZE",
+            find: ".Messages.AVATAR_UPLOAD_EDIT_MEDIA",
             replacement: {
                 match: /(maxValue:(\w))/,
                 replace: "maxValue:$self.settings.store.zoomMultiplier",

--- a/src/plugins/unlockedAvatarZoom/index.ts
+++ b/src/plugins/unlockedAvatarZoom/index.ts
@@ -12,7 +12,7 @@ const settings = definePluginSettings({
     zoomMultiplier: {
         type: OptionType.NUMBER,
         description: "Zoom multiplier",
-        default: 2,
+        default: 4,
     },
 });
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -425,6 +425,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     newwares: {
         name: "newwares",
         id: 421405303951851520n
+    },
+    nakoyasha: {
+        name: "nakoyasha",
+        id: 222069018507345921n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
Unlocks and allows you to use custom multipliers for the zoom slider in the Edit Avatar modal as the default 2 is "barely enough"