### PR TITLE
Add TeX plugin

### DIFF
--- a/src/plugins/tex/README.md
+++ b/src/plugins/tex/README.md
@@ -1,0 +1,5 @@
+# TeX
+
+Renders $\LaTeX$ formulas. `` `$\sin x$` `` renders as $\sin x$, `` `$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$` `` renders as $\displaystyle x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$. The latter is intentionally set to an inline-block instead of a block, to save space.
+
+This plugin requires external libraries, which will not work in the userscript version of Vencord without additional workarounds.

--- a/src/plugins/tex/index.tsx
+++ b/src/plugins/tex/index.tsx
@@ -1,0 +1,108 @@
+import "./style.css";
+
+import { Devs } from "@utils/constants";
+import { makeLazy } from "@utils/lazy";
+import { classes } from "@utils/misc";
+import definePlugin from "@utils/types";
+import { React, Tooltip, useMemo } from "@webpack/common";
+import { useEffect, useState } from "@webpack/common";
+
+const SCRIPT_URL = "https://unpkg.com/katex@0.16.9/dist/katex.mjs";
+const STYLE_URL = "https://unpkg.com/katex@0.16.9/dist/katex.min.css";
+
+let theKatex: undefined | any = undefined;
+export const loadKatex = makeLazy(async () => {
+    const style = document.createElement("link");
+    style.setAttribute("rel", "stylesheet");
+    style.setAttribute("href", STYLE_URL);
+    document.head.appendChild(style);
+    return theKatex = (await import(SCRIPT_URL)).default;
+});
+
+export function useKatex() {
+    const [katex, setKatex] = useState(theKatex);
+    useEffect(() => {
+        if(katex === undefined)
+            loadKatex().then(setKatex);
+    });
+    return katex;
+}
+
+export default definePlugin({
+    name: "TeX",
+    description: "Typesets math in messages, written as `$x$` or `$$x$$`.",
+    authors: [Devs.Kyuuhachi],
+
+    patches: [
+        {
+            find: "inlineCode:{react",
+            replacement: {
+                match: /inlineCode:\{react:\((\i,\i,\i)\)=>/,
+                replace: "$&$self.render($1)??"
+            },
+        },
+    ],
+
+    render({ content }) {
+        const displayMatch = /^\$\$(.*)\$\$$/.exec(content);
+        const inlineMatch = /^\$(.*)\$$/.exec(content);
+        if(displayMatch)
+            return <LazyLatex displayMode formula={displayMatch[1]} delim="$$" />;
+        if(inlineMatch)
+            return <LazyLatex formula={inlineMatch[1]} delim="$" />;
+    }
+});
+
+function LazyLatex(props) {
+    const { formula, delim } = props;
+    const katex = useKatex();
+    return katex
+        ? <Latex {...props} katex={katex} />
+        : <LatexPlaceholder className="tex-loading" delim={delim}>{formula}</LatexPlaceholder>;
+}
+
+function Latex({ katex, formula, displayMode, delim }) {
+    const result = useMemo(() => {
+        try {
+            const html = katex.renderToString(formula, { displayMode });
+            return { html };
+        } catch(error) {
+            return { error };
+        }
+    }, [formula, displayMode]);
+
+    return result.html
+        ? <span className="tex" dangerouslySetInnerHTML={{ __html: result.html }} />
+        : <LatexError formula={formula} delim={delim} error={result.error} />;
+}
+
+function LatexError({ formula, delim, error }) {
+    const { rawMessage, position, length } = error;
+    const pre = formula.slice(0, position);
+    const mid = formula.slice(position, position+length);
+    const suf = formula.slice(position+length);
+    return (
+        <Tooltip text={rawMessage}>
+            {({ onMouseLeave, onMouseEnter }) => (
+                <LatexPlaceholder
+                    onMouseLeave={onMouseLeave}
+                    onMouseEnter={onMouseEnter}
+                    delim={delim}
+                    className="tex-error"
+                >
+                    {pre}<strong>{mid}</strong>{suf}
+                </LatexPlaceholder>
+            )}
+        </Tooltip>
+    );
+}
+
+function LatexPlaceholder({ className, delim, children, ...props }) {
+    return (
+        <code className={classes(className, "tex-placeholder inline")} {...props}>
+            {delim}
+            {children}
+            {delim}
+        </code>
+    );
+}

--- a/src/plugins/tex/index.tsx
+++ b/src/plugins/tex/index.tsx
@@ -63,7 +63,7 @@ function LazyLatex(props) {
     const katex = useKatex();
     return katex
         ? <Latex {...props} katex={katex} />
-        : <LatexPlaceholder className="tex-loading" delim={delim}>{formula}</LatexPlaceholder>;
+        : <LatexPlaceholder className="vc-tex-loading" delim={delim}>{formula}</LatexPlaceholder>;
 }
 
 function Latex({ katex, formula, displayMode, delim }) {
@@ -93,7 +93,7 @@ function LatexError({ formula, delim, error }) {
                     onMouseLeave={onMouseLeave}
                     onMouseEnter={onMouseEnter}
                     delim={delim}
-                    className="tex-error"
+                    className="vc-tex-error"
                 >
                     {pre}<strong>{mid}</strong>{suf}
                 </LatexPlaceholder>
@@ -104,7 +104,7 @@ function LatexError({ formula, delim, error }) {
 
 function LatexPlaceholder({ className, delim, children, ...props }) {
     return (
-        <code className={classes(className, "tex-placeholder inline")} {...props}>
+        <code className={classes(className, "vc-tex-placeholder inline")} {...props}>
             {delim}
             {children}
             {delim}

--- a/src/plugins/tex/index.tsx
+++ b/src/plugins/tex/index.tsx
@@ -1,11 +1,16 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import "./style.css";
 
 import { Devs } from "@utils/constants";
 import { makeLazy } from "@utils/lazy";
 import { classes } from "@utils/misc";
 import definePlugin from "@utils/types";
-import { React, Tooltip, useMemo } from "@webpack/common";
-import { useEffect, useState } from "@webpack/common";
+import { React, Tooltip, useEffect, useMemo, useState } from "@webpack/common";
 
 const SCRIPT_URL = "https://unpkg.com/katex@0.16.9/dist/katex.mjs";
 const STYLE_URL = "https://unpkg.com/katex@0.16.9/dist/katex.min.css";

--- a/src/plugins/tex/index.tsx
+++ b/src/plugins/tex/index.tsx
@@ -7,28 +7,16 @@
 import "./style.css";
 
 import { Devs } from "@utils/constants";
-import { makeLazy } from "@utils/lazy";
+import { getKatex } from "@utils/dependencies";
 import { classes } from "@utils/misc";
 import definePlugin from "@utils/types";
 import { React, Tooltip, useEffect, useMemo, useState } from "@webpack/common";
 
-const SCRIPT_URL = "https://unpkg.com/katex@0.16.9/dist/katex.mjs";
-const STYLE_URL = "https://unpkg.com/katex@0.16.9/dist/katex.min.css";
-
-let theKatex: undefined | any = undefined;
-export const loadKatex = makeLazy(async () => {
-    const style = document.createElement("link");
-    style.setAttribute("rel", "stylesheet");
-    style.setAttribute("href", STYLE_URL);
-    document.head.appendChild(style);
-    return theKatex = (await import(SCRIPT_URL)).default;
-});
-
 export function useKatex() {
-    const [katex, setKatex] = useState(theKatex);
+    const [katex, setKatex] = useState();
     useEffect(() => {
         if(katex === undefined)
-            loadKatex().then(setKatex);
+            getKatex().then(setKatex);
     });
     return katex;
 }

--- a/src/plugins/tex/style.css
+++ b/src/plugins/tex/style.css
@@ -1,0 +1,8 @@
+.katex-display {
+    margin: 0;
+    display: inline-block;
+}
+
+.tex-error {
+    color: var(--status-danger);
+}

--- a/src/plugins/tex/style.css
+++ b/src/plugins/tex/style.css
@@ -1,3 +1,5 @@
+@import url("https://unpkg.com/katex@0.16.9/dist/katex.min.css");
+
 .katex-display {
     margin: 0;
     display: inline-block;

--- a/src/plugins/tex/style.css
+++ b/src/plugins/tex/style.css
@@ -3,6 +3,6 @@
     display: inline-block;
 }
 
-.tex-error {
+.vc-tex-error {
     color: var(--status-danger);
 }

--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -84,3 +84,6 @@ export const shikiOnigasmSrc = "https://unpkg.com/@vap/shiki@0.10.3/dist/onig.wa
 
 // @ts-expect-error
 export const getStegCloak = /* #__PURE__*/ makeLazy(() => import("https://unpkg.com/stegcloak-dist@1.0.0/index.js"));
+
+// @ts-expect-error
+export const getKatex = /* #__PURE__*/ makeLazy(async () => (await import("https://unpkg.com/katex@0.16.9/dist/katex.mjs")).default);


### PR DESCRIPTION
Renders $\LaTeX$ formulas. `` `$\sin x$` `` renders as $\sin x$, `` `$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$` `` renders as $\displaystyle x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$. The latter is intentionally set to an inline-block instead of a block, to save space.

This plugin requires external libraries, which will not work in the userscript version without additional workarounds.