### PR TITLE
fix(VoiceMessages): Make Chrome record audio as ogg

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "gifenc": "github:mattdesl/gifenc#64842fca317b112a8590f8fef2bf3825da8f6fe3",
         "monaco-editor": "^0.43.0",
         "nanoid": "^4.0.2",
+        "opus-recorder": "^8.0.5",
         "virtual-merge": "^1.0.1"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   eslint-plugin-path-alias@1.0.0:
     hash: m6sma4g6bh67km3q6igf6uxaja
@@ -33,6 +37,9 @@ dependencies:
   nanoid:
     specifier: ^4.0.2
     version: 4.0.2
+  opus-recorder:
+    specifier: ^8.0.5
+    version: 8.0.5
   virtual-merge:
     specifier: ^1.0.1
     version: 1.0.1
@@ -2532,6 +2539,10 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /opus-recorder@8.0.5:
+    resolution: {integrity: sha512-tBRXc9Btds7i3bVfA7d5rekAlyOcfsivt5vSIXHxRV1Oa+s6iXFW8omZ0Lm3ABWotVcEyKt96iIIUcgbV07YOw==}
+    dev: false
+
   /p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -3464,7 +3475,3 @@ packages:
     name: gifenc
     version: 1.0.3
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -49,3 +49,49 @@ declare module "*.css?managed" {
     const name: string;
     export default name;
 }
+
+declare module "opus-recorder" { // no types :sob: https://github.com/chris-rudmin/opus-recorder/issues/276
+    export default class Recorder {
+        constructor(config?: {
+            bufferLength?: number;
+            encoderPath?: string;
+            mediaTrackConstraints?: MediaStreamConstraints | boolean;
+            monitorGain?: number;
+            numberOfChannels?: number;
+            recordingGain?: number;
+            sourceNode?: MediaStreamAudioSourceNode;
+
+            encoderApplication?: number;
+            encoderBitRate?: number;
+            encoderComplexity?: number;
+            encoderFrameSize?: number;
+            encoderSampleRate?: number;
+            maxFramesPerPage?: number;
+            originalSampleRateOverride?: number;
+            resampleQuality?: number;
+            streamPages?: boolean;
+
+            wavBitDepth?: number;
+        });
+
+        close(): void;
+
+        pause(flush?: boolean): void;
+
+        resume(): Promise<void> | void;
+
+        start(): Promise<void>;
+
+        stop(): void;
+
+        ondataavailable(audio: ArrayBuffer): void;
+
+        onpause(): void;
+
+        onresume(): void;
+
+        onstart(): void;
+
+        onstop(): void;
+    }
+}

--- a/src/plugins/voiceMessages/WebRecorder.tsx
+++ b/src/plugins/voiceMessages/WebRecorder.tsx
@@ -17,15 +17,17 @@
 */
 
 import { Button, useState } from "@webpack/common";
+import Recorder from "opus-recorder";
 
 import type { VoiceRecorder } from ".";
 import { settings } from "./settings";
-
+let url:string|null = null;
 export const VoiceRecorderWeb: VoiceRecorder = ({ setAudioBlob, onRecordingChange }) => {
     const [recording, setRecording] = useState(false);
     const [paused, setPaused] = useState(false);
-    const [recorder, setRecorder] = useState<MediaRecorder>();
+    const [recorder, setRecorder] = useState<Recorder>();
     const [chunks, setChunks] = useState<Blob[]>([]);
+    const [stream, setStream] = useState<MediaStream>();
 
     const changeRecording = (recording: boolean) => {
         setRecording(recording);
@@ -41,27 +43,30 @@ export const VoiceRecorderWeb: VoiceRecorder = ({ setAudioBlob, onRecordingChang
                     echoCancellation: settings.store.echoCancellation,
                     noiseSuppression: settings.store.noiseSuppression,
                 }
-            }).then(stream => {
+            }).then(async stream => {
                 const chunks = [] as Blob[];
                 setChunks(chunks);
-
-                const recorder = new MediaRecorder(stream);
+                setStream(stream);
+                const audioCtx = new AudioContext();
+                const source = audioCtx.createMediaStreamSource(stream);
+                const blob = await (await fetch("https://www.unpkg.com/opus-recorder@8.0.5/dist/encoderWorker.min.js")).blob();
+                if (!url) url = URL.createObjectURL(blob);
+                const recorder = new Recorder({ sourceNode: source, encoderPath: url, streamPages: true });
                 setRecorder(recorder);
-                recorder.addEventListener("dataavailable", e => {
-                    chunks.push(e.data);
-                });
+                recorder.ondataavailable=e => {
+                    chunks.push(new Blob([e], { type: "audio/ogg; codecs=opus" }));
+                };
                 recorder.start();
-
                 changeRecording(true);
             });
         } else {
             if (recorder) {
-                recorder.addEventListener("stop", () => {
+                recorder.onstop=() => {
                     setAudioBlob(new Blob(chunks, { type: "audio/ogg; codecs=opus" }));
-
                     changeRecording(false);
-                });
+                };
                 recorder.stop();
+                stream?.getAudioTracks().forEach(track => track.stop());
             }
         }
     }


### PR DESCRIPTION
Fixes #1512 

Works on Chrome extension + Chrome userscript

I ending up having to import the web worker file from unpkg because I was having trouble with bundling it into the userscript (Worker constructor needs a URL so I tried storing a blob of the entire file in the userscript, but that increased size by 70%)

Let me know if you prefer not fetching from unpkg (I tried bundling the `encoderworker.min.js` into the `third-party` folder and it worked for the extension but idk how to do it for userscript)