### PR TITLE
new plugin: NoMouseNavigation

### DIFF
--- a/src/plugins/noMouseNavigation/index.ts
+++ b/src/plugins/noMouseNavigation/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NoMouseNavigation",
+    description: "Disables forward/back navigation with mouse side buttons",
+    tags: ["FFMSB", "sidebuttons"],
+    authors: [Devs.Vaker],
+
+    start() {
+        window.addEventListener("mouseup", this.event);
+    },
+
+    stop() {
+        window.removeEventListener("mouseup", this.event);
+    },
+
+    event(e: MouseEvent) {
+        if ([3, 4].includes(e.button)) {
+            e.preventDefault();
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -490,6 +490,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "ScattrdBlade",
         id: 678007540608532491n
     },
+    Vaker: {
+        name: "Vaker",
+        id: 92999669617000448n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
NoMouseNavigation allows users to disable the default handling of mouse side buttons (3 and 4).

Many people use side buttons for PTT. By default, Discord will handle those by navigating forward/backward through visited pages while the app is in focus, causing severe butthurt for PTT users. This plugin simply prevents the default behavior, PTT continues working normally.

P.S. I'm not sure if adding myself into the dev list in `constants.ts` is appropriate, but looking through other plugins, I couldn't find any files where authors are added in the way described by `2_PLUGINS.md`, so I assumed this is the new undocumented standard? Anyways, I can always revert that, just lmk.