### PR TITLE
ReviewDB: Fix website url

### DIFF
--- a/src/plugins/reviewDB/settings.tsx
+++ b/src/plugins/reviewDB/settings.tsx
@@ -71,7 +71,7 @@ export const settings = definePluginSettings({
                 </Button>
 
                 <Button onClick={async () => {
-                    let url = "https://reviewdb.mantikafasi.dev/";
+                    let url = "https://reviewdb.mantikafasi.dev";
                     const token = await getToken();
                     if (token)
                         url += "/api/redirect?token=" + encodeURIComponent(token);


### PR DESCRIPTION
Since URL used to have an `/` it would redirect to https://reviewdb.mantikafasi.dev//api/redirect instead.

This fix will help with confusion for the average non-techy Vencord user