### PR TITLE
EmoteCloner: fix low quality; don't count managed emojis

### DIFF
--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -132,10 +132,11 @@ function getGuildCandidates(data: Data) {
         for (const emoji of emojis) {
             if (emoji.animated === isAnimated) {
                 count++;
+                if (emoji.managed === true) {
+                    count--;
+                }
             }
-            if (emoji.managed === true) {
-                count--; // twitch emojis do not count towards the limit
-            }
+
         }
         return count < emojiSlots;
     }).sort((a, b) => a.name.localeCompare(b.name));

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -56,7 +56,7 @@ function getUrl(data: Data) {
     if (data.t === "Emoji")
         return `${location.protocol}//${window.GLOBAL_ENV.CDN_HOST}/emojis/${data.id}.${data.isAnimated ? "gif" : "png"}`;
 
-    return `${window.GLOBAL_ENV.MEDIA_PROXY_ENDPOINT}/stickers/${data.id}.${StickerExt[data.format_type]}?size=2048`;
+    return `${window.GLOBAL_ENV.MEDIA_PROXY_ENDPOINT}/stickers/${data.id}.${StickerExt[data.format_type]}?size=4096`;
 }
 
 async function fetchSticker(id: string) {

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -363,7 +363,7 @@ export default definePlugin({
     name: "EmoteCloner",
     description: "Allows you to clone Emotes & Stickers to your own server (right click them)",
     tags: ["StickerCloner"],
-    authors: [Devs.Ven, Devs.Nuckyz, Devs.Byron],
+    authors: [Devs.Ven, Devs.Nuckyz],
     contextMenus: {
         "message": messageContextMenuPatch,
         "expression-picker": expressionPickerPatch

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -129,15 +129,9 @@ function getGuildCandidates(data: Data) {
         const { emojis } = EmojiStore.getGuilds()[g.id];
 
         let count = 0;
-        for (const emoji of emojis) {
-            if (emoji.animated === isAnimated) {
+        for (const emoji of emojis)
+            if (emoji.animated === isAnimated && !emoji.managed)
                 count++;
-                if (emoji.managed === true) {
-                    count--;
-                }
-            }
-
-        }
         return count < emojiSlots;
     }).sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -129,8 +129,14 @@ function getGuildCandidates(data: Data) {
         const { emojis } = EmojiStore.getGuilds()[g.id];
 
         let count = 0;
-        for (const emoji of emojis)
-            if (emoji.animated === isAnimated) count++;
+        for (const emoji of emojis) {
+            if (emoji.animated === isAnimated) {
+                count++;
+            }
+            if (emoji.managed === true) {
+                count--; // twitch emojis do not count towards the limit
+            }
+        }
         return count < emojiSlots;
     }).sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -54,9 +54,9 @@ const StickerExt = [, "png", "png", "json", "gif"] as const;
 
 function getUrl(data: Data) {
     if (data.t === "Emoji")
-        return `${location.protocol}//${window.GLOBAL_ENV.CDN_HOST}/emojis/${data.id}.${data.isAnimated ? "gif" : "png"}`;
+        return `${location.protocol}//${window.GLOBAL_ENV.CDN_HOST}/emojis/${data.id}.${data.isAnimated ? "gif" : "png"}?size=4096&lossless=true`;
 
-    return `${window.GLOBAL_ENV.MEDIA_PROXY_ENDPOINT}/stickers/${data.id}.${StickerExt[data.format_type]}?size=4096`;
+    return `${window.GLOBAL_ENV.MEDIA_PROXY_ENDPOINT}/stickers/${data.id}.${StickerExt[data.format_type]}?size=4096&lossless=true`;
 }
 
 async function fetchSticker(id: string) {

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -56,7 +56,7 @@ function getUrl(data: Data) {
     if (data.t === "Emoji")
         return `${location.protocol}//${window.GLOBAL_ENV.CDN_HOST}/emojis/${data.id}.${data.isAnimated ? "gif" : "png"}`;
 
-    return `${window.GLOBAL_ENV.MEDIA_PROXY_ENDPOINT}/stickers/${data.id}.${StickerExt[data.format_type]}`;
+    return `${window.GLOBAL_ENV.MEDIA_PROXY_ENDPOINT}/stickers/${data.id}.${StickerExt[data.format_type]}?size=2048`;
 }
 
 async function fetchSticker(id: string) {
@@ -362,7 +362,7 @@ export default definePlugin({
     name: "EmoteCloner",
     description: "Allows you to clone Emotes & Stickers to your own server (right click them)",
     tags: ["StickerCloner"],
-    authors: [Devs.Ven, Devs.Nuckyz],
+    authors: [Devs.Ven, Devs.Nuckyz, Devs.Byron],
     contextMenus: {
         "message": messageContextMenuPatch,
         "expression-picker": expressionPickerPatch

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -425,6 +425,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     newwares: {
         name: "newwares",
         id: 421405303951851520n
+    },
+    Byron: {
+        name: "byeoon",
+        id: 1167275288036655133n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
This pull request simply improves the quality of stickers so that they get cloned to 2048. 

**Before**:
![image](https://github.com/Vendicated/Vencord/assets/47872200/b6ac0327-771c-4124-a4fc-70f7860819a4)

**After**:
![image](https://github.com/Vendicated/Vencord/assets/47872200/888a21c1-cd14-40c7-9aec-237d777f7aae)
