### PR TITLE
PinDMs: Fix unexpected behaviours when using last message sort

### DIFF
--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -106,12 +106,12 @@ export function categoryLen() {
 }
 
 export function getAllUncollapsedChannels() {
-    return categories.filter(c => !c.collapsed).map(c => {
-        if (settings.store.pinOrder === PinOrder.LastMessage)
-            return PrivateChannelSortStore.getPrivateChannelIds().filter(channel => c.channels.includes(channel));
+    if (settings.store.pinOrder === PinOrder.LastMessage) {
+        const sortedChannels = PrivateChannelSortStore.getPrivateChannelIds();
+        return categories.filter(c => !c.collapsed).flatMap(c => sortedChannels.filter(channel => c.channels.includes(channel)));
+    }
 
-        return c.channels;
-    }).flat();
+    return categories.filter(c => !c.collapsed).flatMap(c => c.channels);
 }
 
 export function getSections() {

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -9,7 +9,7 @@ import { Settings } from "@api/Settings";
 import { UserStore } from "@webpack/common";
 
 import { DEFAULT_COLOR } from "./constants";
-import { forceUpdate } from "./index";
+import { forceUpdate, PinOrder, PrivateChannelSortStore, settings } from "./index";
 
 export interface Category {
     id: string;
@@ -106,7 +106,12 @@ export function categoryLen() {
 }
 
 export function getAllUncollapsedChannels() {
-    return categories.filter(c => !c.collapsed).map(c => c.channels).flat();
+    return categories.filter(c => !c.collapsed).map(c => {
+        if (settings.store.pinOrder === PinOrder.LastMessage)
+            return PrivateChannelSortStore.getPrivateChannelIds().filter(channel => c.channels.includes(channel));
+
+        return c.channels;
+    }).flat();
 }
 
 export function getSections() {

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -236,7 +236,7 @@ export default definePlugin({
         const category = categories[categoryIndex - 1];
         if (!category) return false;
 
-        return category.collapsed && this.instance.props.selectedChannelId !== category.channels[channelIndex];
+        return category.collapsed && this.instance.props.selectedChannelId !== this.getCategoryChannels(category)[channelIndex];
     },
 
     getScrollOffset(channelId: string, rowHeight: number, padding: number, preRenderedChildren: number, originalOffset: number) {

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -29,7 +29,7 @@ interface ChannelComponentProps {
 
 const headerClasses = findByPropsLazy("privateChannelsHeaderContainer");
 
-const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as { getPrivateChannelIds: () => string[]; };
+export const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as { getPrivateChannelIds: () => string[]; };
 
 export let instance: any;
 export const forceUpdate = () => instance?.props?._forceUpdate?.();


### PR DESCRIPTION
Fixed alt + up/down not working as expected and fixed the channel preview when collapsing a category being incorrect when using the most recent message sort option

Resolves #2322 