### PR TITLE
chore: allow external code to be properly licenced

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,10 @@
             "error",
             {
                 "files": ["scripts/header-new.txt", "scripts/header-old.txt"],
-                "templates": { "author": [".*", "Vendicated and contributors"] }
+                "templates": {
+                    "author": [".*", "Vendicated and contributors"],
+                    "licence": [".*", "GPL-3.0-or-later"]
+                }
             }
         ],
         "quotes": ["error", "double", { "avoidEscape": true }],

--- a/scripts/header-new.txt
+++ b/scripts/header-new.txt
@@ -1,3 +1,3 @@
 Vencord, a Discord client mod
 Copyright (c) {year} {author}
-SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: {licence}


### PR DESCRIPTION
I am working on a plugin that would require an external library, but that library is too small to guarantee a dependency.
Also, dynamically loading that library from npm/unpkg is not possible, since it loads a pollyfil it assumes is also a dependency.

So, I decided to simply copy the 4 typescript files I needed, to the folder of my plugin.
The eslint configuration forces all files to have `GPL-3.0-or-later` as the licence, meaning `MIT` code will be improperly licenced.

So I added the licence info as a template pattern to allow other licences on non-vencord files.