### PR TITLE
feat(plugin): copyContents

### DIFF
--- a/src/plugins/copyContents/index.tsx
+++ b/src/plugins/copyContents/index.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-// lots of this code was stolen from the viewRaw plugin (the message hover menu stuff) :3
 import { addButton, removeButton } from "@api/MessagePopover";
 import { copyWithToast } from "@utils/misc";
 import definePlugin from "@utils/types";

--- a/src/plugins/copyContents/index.tsx
+++ b/src/plugins/copyContents/index.tsx
@@ -1,0 +1,62 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// lots of this code was stolen from the viewRaw plugin (the message hover menu stuff) :3
+import { addButton, removeButton } from "@api/MessagePopover";
+import { copyWithToast } from "@utils/misc";
+import definePlugin from "@utils/types";
+import { ChannelStore } from "@webpack/common";
+
+const Clipboard = () => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="currentColor"
+            aria-hidden="true"
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+        >
+            <path
+                fill="currentColor"
+                d="M17 4h-1.18A3 3 0 0 0 13 2h-2a3 3 0 0 0-2.82 2H7a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3m-7 1a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1h-4Zm8 14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h1v1a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V6h1a1 1 0 0 1 1 1Z"
+            />
+        </svg>
+    );
+};
+
+export default definePlugin({
+    name: "CopyContents",
+    description:
+        "Replicates the mobile client feature to copy message contents, including formatting.",
+    authors: [
+        {
+            id: 785248634458996767n,
+            name: "br4x.",
+        },
+    ],
+    dependencies: ["MessagePopoverAPI"],
+
+    start() {
+        addButton("CopyContents", msg => {
+            const copyMessageContents = () => {
+                copyWithToast(msg.content);
+            };
+
+            return {
+                message: msg,
+                channel: ChannelStore.getChannel(msg.channel_id),
+                onClick: copyMessageContents,
+                label: "Copy Contents",
+                icon: Clipboard,
+            };
+        });
+    },
+
+    stop() {
+        removeButton("CopyContents");
+    },
+});


### PR DESCRIPTION
Adds the nifty mobile feature to copy the message contents (including formatting such as **boldness**, headers, and mentions).

Message button:  
![Discord_kRl1RBkl78](https://github.com/Vendicated/Vencord/assets/63559800/6d53a0c7-80e6-473e-94bf-ec8ff7d9cc38)

Results: plugin (top) vs selecting and copying (bottom)  
![Discord_hb27hLBkez](https://github.com/Vendicated/Vencord/assets/63559800/110e7170-f15f-4220-bc09-705148a00280)
![Discord_qnZjpiPaZq](https://github.com/Vendicated/Vencord/assets/63559800/8b7b9ae5-44ae-4bc3-ab56-34403a7c88aa)
