### PR TITLE
Better error for primitives on proxyLazy + fix StartupTimings

### DIFF
--- a/src/plugins/startupTimings/index.tsx
+++ b/src/plugins/startupTimings/index.tsx
@@ -17,9 +17,9 @@
 */
 
 import { Devs } from "@utils/constants";
-import { LazyComponent } from "@utils/react";
 import definePlugin from "@utils/types";
 
+import StartupTimingPage from "./StartupTimingPage";
 export default definePlugin({
     name: "StartupTimings",
     description: "Adds Startup Timings to the Settings menu",
@@ -31,5 +31,5 @@ export default definePlugin({
             replace: '{section:"StartupTimings",label:"Startup Timings",element:$self.StartupTimingPage},$&'
         }
     }],
-    StartupTimingPage: LazyComponent(() => require("./StartupTimingPage").default)
+    StartupTimingPage
 });

--- a/src/plugins/startupTimings/index.tsx
+++ b/src/plugins/startupTimings/index.tsx
@@ -20,6 +20,7 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 
 import StartupTimingPage from "./StartupTimingPage";
+
 export default definePlugin({
     name: "StartupTimings",
     description: "Adds Startup Timings to the Settings menu",

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -116,12 +116,13 @@ export function proxyLazy<T>(factory: () => T, attempts = 5, isChild = false): T
                     attempts,
                     true
                 );
-            const obj = target[kGET]();
-            if (typeof obj === "object" || typeof obj === "function") {
-                return Reflect.get(obj, p, receiver);
-            } else {
-                return ()=>obj; // don't call Reflect.get if it's a primitive
+            const lazyTarget = target[kGET]();
+            if (typeof lazyTarget === "object" || typeof lazyTarget === "function") {
+                return Reflect.get(lazyTarget, p, receiver);
             }
+
+            const val = lazyTarget[p];
+            return typeof val === "function" ? val.bind(lazyTarget) : val;
         }
     }) as any;
 }

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -120,7 +120,7 @@ export function proxyLazy<T>(factory: () => T, attempts = 5, isChild = false): T
             if (typeof lazyTarget === "object" || typeof lazyTarget === "function") {
                 return Reflect.get(lazyTarget, p, receiver);
             }
-            throw new Error("proxyInner called on a primitive value");
+            throw new Error("proxyLazy called on a primitive value");
         }
     }) as any;
 }

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -116,8 +116,12 @@ export function proxyLazy<T>(factory: () => T, attempts = 5, isChild = false): T
                     attempts,
                     true
                 );
-
-            return Reflect.get(target[kGET](), p, receiver);
+            const obj = target[kGET]();
+            if (typeof obj === "object") {
+                return Reflect.get(obj, p, receiver);
+            } else {
+                return ()=>obj; // don't call Reflect.get if it's a primitive
+            }
         }
     }) as any;
 }

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -117,7 +117,7 @@ export function proxyLazy<T>(factory: () => T, attempts = 5, isChild = false): T
                     true
                 );
             const obj = target[kGET]();
-            if (typeof obj === "object") {
+            if (typeof obj === "object" || typeof obj === "function") {
                 return Reflect.get(obj, p, receiver);
             } else {
                 return ()=>obj; // don't call Reflect.get if it's a primitive

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -120,9 +120,7 @@ export function proxyLazy<T>(factory: () => T, attempts = 5, isChild = false): T
             if (typeof lazyTarget === "object" || typeof lazyTarget === "function") {
                 return Reflect.get(lazyTarget, p, receiver);
             }
-
-            const val = lazyTarget[p];
-            return typeof val === "function" ? val.bind(lazyTarget) : val;
+            throw new Error("proxyInner called on a primitive value");
         }
     }) as any;
 }


### PR DESCRIPTION
`findByPropsLazy` makes the properties of the lazy object also lazy, but that doesn't work for primitives bc `Reflect.get` can't be run on primitives

Before:

![image](https://github.com/Vendicated/Vencord/assets/45801973/269caf20-583d-4942-9a0a-4713bc702c19)


After:

![image](https://github.com/Vendicated/Vencord/assets/45801973/16bd72b1-37e1-4ab4-a672-f333865e4040)
