### PR TITLE
feat(plugin): SmallEmojis

### DIFF
--- a/src/plugins/smallEmojis/index.ts
+++ b/src/plugins/smallEmojis/index.ts
@@ -1,0 +1,47 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { SendListener } from "@api/MessageEvents";
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+
+let listener: SendListener;
+const DEFAULT_END_CHAR: string = "⠀";
+
+const settings = definePluginSettings({
+    endChar: {
+        name: "End Character",
+        description: `The character that will be added to the end of messages. (DEFAULT: "${DEFAULT_END_CHAR}")`,
+        type: OptionType.STRING,
+        default: DEFAULT_END_CHAR,
+    },
+});
+
+export default definePlugin({
+    name: "Small Emojis",
+    description: "Append a character to the end, so that messages that only contain emojis have a smaller height.",
+    authors: [Devs.GOLD],
+
+    settings,
+
+    start() {
+        listener = Vencord.Api.MessageEvents.addPreSendListener((_, data) => {
+            // Check if the message is empty
+            if (!data.content || data.content.trim().length === 0) return;
+
+            // Check if the message contains an url
+            if (data.content.match(/https?:\/\/[^\s]+/)) return;
+
+            data.content += settings.store.endChar;
+        });
+    },
+
+    stop() {
+        Vencord.Api.MessageEvents.removePreSendListener(listener);
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -437,6 +437,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Byron: {
         name: "byeoon",
         id: 1167275288036655133n
+    },
+    GOLD: {
+        name: "25GOLD25",
+        id: 287201627688140801n,
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
It adds a blank space to the end of the messages sent by the user, so that the height of the emojis (if the message only contains emojis) is reduced as if there was text in the message.

- The character can be changed in the settings.
- The character isn't added if the message doesn't contain any content (e.g. only an attachment) or if it has any links.

Enabled:
![Screenshot_2](https://github.com/Vendicated/Vencord/assets/92998482/014314b8-3c08-4b65-bf19-cee6b09b959b)

Disabled:
![Screenshot_1](https://github.com/Vendicated/Vencord/assets/92998482/556a7c55-f6cc-46a4-967e-ddd664f8cfca)

