### PR TITLE
Plugin: Media downloader

### DIFF
--- a/src/api/Commands/commandHelpers.ts
+++ b/src/api/Commands/commandHelpers.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { mergeDefaults } from "@utils/misc";
+import { mergeDefaults } from "@utils/mergeDefaults";
 import { findByPropsLazy } from "@webpack";
 import { MessageActions, SnowflakeUtils } from "@webpack/common";
 import { Message } from "discord-types/general";

--- a/src/api/Settings.ts
+++ b/src/api/Settings.ts
@@ -20,7 +20,7 @@ import { debounce } from "@shared/debounce";
 import { SettingsStore as SettingsStoreClass } from "@shared/SettingsStore";
 import { localStorage } from "@utils/localStorage";
 import { Logger } from "@utils/Logger";
-import { mergeDefaults } from "@utils/misc";
+import { mergeDefaults } from "@utils/mergeDefaults";
 import { putCloudSettings } from "@utils/settingsSync";
 import { DefinedSettings, OptionType, SettingsChecks, SettingsDefinition } from "@utils/types";
 import { React } from "@webpack/common";

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -7,6 +7,7 @@
 import type { Settings } from "@api/Settings";
 import { IpcEvents } from "@shared/IpcEvents";
 import { SettingsStore } from "@shared/SettingsStore";
+import { mergeDefaults } from "@utils/mergeDefaults";
 import { ipcMain } from "electron";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 
@@ -54,28 +55,8 @@ const DefaultNativeSettings: NativeSettings = {
     plugins: {}
 };
 
-/**
- * Recursively merges defaults into an object and returns the same object
- * Can't use the version in misc.tsx because navigator is not defined at this point
- * @param obj Object
- * @param defaults Defaults
- * @returns obj
- */
-function mergeDefaultsNative<T>(obj: T, defaults: T): T {
-    for (const key in defaults) {
-        const v = defaults[key];
-        if (typeof v === "object" && !Array.isArray(v)) {
-            obj[key] ??= {} as any;
-            mergeDefaultsNative(obj[key], v);
-        } else {
-            obj[key] ??= v;
-        }
-    }
-    return obj;
-}
-
 const nativeSettings = readSettings<NativeSettings>("native", NATIVE_SETTINGS_FILE);
-mergeDefaultsNative(nativeSettings, DefaultNativeSettings);
+mergeDefaults(nativeSettings, DefaultNativeSettings);
 
 export const NativeSettings = new SettingsStore(nativeSettings);
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -7,6 +7,7 @@
 import type { Settings } from "@api/Settings";
 import { IpcEvents } from "@shared/IpcEvents";
 import { SettingsStore } from "@shared/SettingsStore";
+import { mergeDefaults } from "@utils/misc";
 import { ipcMain } from "electron";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 
@@ -42,7 +43,22 @@ ipcMain.handle(IpcEvents.SET_SETTINGS, (_, data: Settings, pathToNotify?: string
     RendererSettings.setData(data, pathToNotify);
 });
 
-export const NativeSettings = new SettingsStore(readSettings("native", NATIVE_SETTINGS_FILE));
+export interface NativeSettings {
+    plugins: {
+        [plugin: string]: {
+            [setting: string]: any;
+        };
+    };
+}
+
+const DefaultNativeSettings: NativeSettings = {
+    plugins: {}
+};
+
+const nativeSettings = readSettings<NativeSettings>("native", NATIVE_SETTINGS_FILE);
+mergeDefaults(nativeSettings, DefaultNativeSettings);
+
+export const NativeSettings = new SettingsStore(nativeSettings);
 
 NativeSettings.addGlobalChangeListener(() => {
     try {

--- a/src/plugins/mediaDownloader.desktop/DownloadImagesIcon.tsx
+++ b/src/plugins/mediaDownloader.desktop/DownloadImagesIcon.tsx
@@ -20,6 +20,7 @@ export function DownloadImagesIcon({ height = 24, width = 24, className }: { hei
             height={height}
             width={width}
             className={classes(cl("icon"), className)}
+            fillOpacity="0.0"
         >
             <path stroke="currentColor" d="M13 4H8.8C7.11984 4 6.27976 4 5.63803 4.32698C5.07354 4.6146 4.6146 5.07354 4.32698 5.63803C4 6.27976 4 7.11984 4 8.8V15.2C4 16.8802 4 17.7202 4.32698 18.362C4.6146 18.9265 5.07354 19.3854 5.63803 19.673C6.27976 20 7.11984 20 8.8 20H15.2C16.8802 20 17.7202 20 18.362 19.673C18.9265 19.3854 19.3854 18.9265 19.673 18.362C20 17.7202 20 16.8802 20 15.2V11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
             <path stroke="currentColor" d="M4 16L8.29289 11.7071C8.68342 11.3166 9.31658 11.3166 9.70711 11.7071L13 15M13 15L15.7929 12.2071C16.1834 11.8166 16.8166 11.8166 17.2071 12.2071L20 15M13 15L15.25 17.25" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />

--- a/src/plugins/mediaDownloader.desktop/DownloadImagesIcon.tsx
+++ b/src/plugins/mediaDownloader.desktop/DownloadImagesIcon.tsx
@@ -1,0 +1,29 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@api/Styles";
+import { classes } from "@utils/misc";
+
+const cl = classNameFactory("vc-dlimage-");
+
+export function DownloadImagesIcon({ height = 24, width = 24, className }: { height?: number; width?: number; className?: string; }) {
+    return (
+        // AUTHOR: Ananthanath A X Kalaiism
+        // LICENSE: Public Domain
+        // COLLECTION: Kalai Oval Interface Icons
+        // Downloaded from https://www.svgrepo.com/svg/502638/download-photo
+        <svg
+            viewBox="0 0 24 24"
+            height={height}
+            width={width}
+            className={classes(cl("icon"), className)}
+        >
+            <path stroke="currentColor" d="M13 4H8.8C7.11984 4 6.27976 4 5.63803 4.32698C5.07354 4.6146 4.6146 5.07354 4.32698 5.63803C4 6.27976 4 7.11984 4 8.8V15.2C4 16.8802 4 17.7202 4.32698 18.362C4.6146 18.9265 5.07354 19.3854 5.63803 19.673C6.27976 20 7.11984 20 8.8 20H15.2C16.8802 20 17.7202 20 18.362 19.673C18.9265 19.3854 19.3854 18.9265 19.673 18.362C20 17.7202 20 16.8802 20 15.2V11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            <path stroke="currentColor" d="M4 16L8.29289 11.7071C8.68342 11.3166 9.31658 11.3166 9.70711 11.7071L13 15M13 15L15.7929 12.2071C16.1834 11.8166 16.8166 11.8166 17.2071 12.2071L20 15M13 15L15.25 17.25" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            <path stroke="currentColor" d="M18 3V8M18 8L16 6M18 8L20 6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+    );
+}

--- a/src/plugins/mediaDownloader.desktop/contextMenu.tsx
+++ b/src/plugins/mediaDownloader.desktop/contextMenu.tsx
@@ -1,0 +1,60 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { Flex } from "@components/Flex";
+import { PluginNative } from "@utils/types";
+import { Menu } from "@webpack/common";
+
+import mediaDownloaderDesktop from ".";
+import { DownloadImagesIcon } from "./DownloadImagesIcon";
+
+const Native = VencordNative.pluginHelpers.MediaDownloader as PluginNative<typeof import("./native")>;
+
+
+function makeDownloadItem(src: string, proxy: string) {
+    return (
+        <Menu.MenuItem
+            label={
+                <Flex style={{ alignItems: "center", gap: "0.5em" }}>
+                    Quick Save
+                    <DownloadImagesIcon height={16} width={16} />
+                </Flex>
+            }
+            key="download-image"
+            id="download-image"
+            action={() => Native.downloadFile(src, proxy)}
+        />
+    );
+}
+
+export const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
+    // console.log(props);
+    // if (props?.reverseImageSearchType !== "img") return;
+    if (!mediaDownloaderDesktop.settings.store.showInContextMenu) return;
+
+    const src = props.itemHref ?? props.itemSrc;
+    // TODO: find a way to extract the full proxied video URI if it's a video
+    const proxy = props.itemSafeSrc; // will just be a preview jpg if it's an animation.
+    if (!src && !proxy) return;
+
+    const group = findGroupChildrenByChildId("save-image", children) ?? children;
+    group?.push(makeDownloadItem(src, proxy));
+};
+
+export const imageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
+    // console.log(props);
+    if (!mediaDownloaderDesktop.settings.store.showInContextMenu) return;
+
+    const proxy = props.src;
+    // TODO: find a way to extract the original URI
+    const src = proxy;
+    if (!src && !proxy) return;
+
+    const group = findGroupChildrenByChildId("save-image", children) ?? children;
+
+    group.push(makeDownloadItem(src, proxy));
+};

--- a/src/plugins/mediaDownloader.desktop/index.tsx
+++ b/src/plugins/mediaDownloader.desktop/index.tsx
@@ -1,0 +1,59 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { addButton, removeButton } from "@api/MessagePopover";
+import { Devs } from "@utils/constants";
+import definePlugin, { PluginNative } from "@utils/types";
+import { ChannelStore } from "@webpack/common";
+
+import { DownloadImagesIcon } from "./DownloadImagesIcon";
+import { settings } from "./settings";
+
+const Native = VencordNative.pluginHelpers.MediaDownloader as PluginNative<typeof import("./native")>;
+
+
+export default definePlugin({
+    name: "MediaDownloader",
+    description: "Tool(s) to quickly save images and videos",
+    authors: [Devs.Eloelle],
+    settings: settings,
+
+    // TODO: Add other interactions such as floating download button on individual media
+    start() {
+        addButton("vc-imagedownload", message => {
+            if (message.attachments.length === 0 && message.embeds.length === 0) return null;
+            return {
+                label: "Download All Images & Videos",
+                icon: DownloadImagesIcon,
+                message,
+                channel: ChannelStore.getChannel(message.channel_id),
+                onClick: async () => {
+                    // console.log("Attachments:");
+                    message.attachments.forEach(attachment => {
+                        // console.log(attachment);
+                        Native
+                            .downloadFile(attachment.url, attachment.proxy_url)
+                            .then(success => console.log(success))
+                            .catch(error => console.log(error));
+                    });
+                    // console.log("Embeds:");
+                    message.embeds.forEach(embed => {
+                        // console.log(embed);
+                        const target = embed.image || embed.video || null;
+                        if (!target) return false;
+                        Native
+                            .downloadFile(target.url, target.proxyURL || "")
+                            .then(success => console.log(success))
+                            .catch(error => console.log(error));
+                    });
+                }
+            };
+        });
+    },
+    stop() {
+        removeButton("vc-imagedownload");
+    }
+});

--- a/src/plugins/mediaDownloader.desktop/index.tsx
+++ b/src/plugins/mediaDownloader.desktop/index.tsx
@@ -60,6 +60,38 @@ export default definePlugin({
     contextMenus: {
         "message": messageContextMenuPatch,
         "image-context": imageContextMenuPatch
-    }
-    // TODO: Add floating download button on individual media
+    },
+    patches: [
+        // Add floating download button on image attachments (it will open them in the browser)
+        {
+            find: "&&\"AUDIO\"",
+            replacement: {
+                match: /!(\w{1,3}&&)"AUDIO"===(\w{1,3}\|\|)/,
+                replace: (m, z, v) => `${m}!${z}"IMAGE"===${v}`
+            },
+            predicate: () => settings.store.addHoverButtonToImageAttachments
+        },
+        // Hijack download hoverbutton to use media downloader
+        {
+            find: "AnalyticEvents.MEDIA_DOWNLOAD_BUTTON_TAPPED",
+            replacement: {
+                match: /href:(\w{1,3}),onClick:(\w{1,3}),target:(\w{1,3}),rel:(\w{1,3}),className:(\w{1,3}),"aria-label":(\w{1,3}).default.Messages.DOWNLOAD,/g,
+                replace: (m, href, onClick, target, rel, classname, label) => `onClick:(e)=>$self.downloadFileSafe(${href}).then(${onClick}(e)),className:${classname},"aria-label":${label}.default.Messages.DOWNLOAD,`
+            },
+            predicate: () => settings.store.hijackHoverButtonForQuickDownload
+        }
+    ],
+    downloadFileProxy(sourceURI: string, proxyURI: string) {
+        return Native
+            .downloadFile(sourceURI, proxyURI)
+            .then(success => console.log(success))
+            .catch(error => console.log(error));
+    },
+    downloadFileSafe(uri: string) {
+        return Native
+            .downloadFile(uri, uri)
+            .then(success => console.log(success))
+            .catch(error => console.log(error));
+    },
+    // TODO: Add patch for floating download button on embedded media
 });

--- a/src/plugins/mediaDownloader.desktop/index.tsx
+++ b/src/plugins/mediaDownloader.desktop/index.tsx
@@ -9,6 +9,7 @@ import { Devs } from "@utils/constants";
 import definePlugin, { PluginNative } from "@utils/types";
 import { ChannelStore } from "@webpack/common";
 
+import { imageContextMenuPatch, messageContextMenuPatch } from "./contextMenu";
 import { DownloadImagesIcon } from "./DownloadImagesIcon";
 import { settings } from "./settings";
 
@@ -21,10 +22,10 @@ export default definePlugin({
     authors: [Devs.Eloelle],
     settings: settings,
 
-    // TODO: Add other interactions such as floating download button on individual media
     start() {
         addButton("vc-imagedownload", message => {
             if (message.attachments.length === 0 && message.embeds.length === 0) return null;
+            if (!settings.store.showInMessageHoverMenu) return null;
             return {
                 label: "Download All Images & Videos",
                 icon: DownloadImagesIcon,
@@ -55,5 +56,10 @@ export default definePlugin({
     },
     stop() {
         removeButton("vc-imagedownload");
+    },
+    contextMenus: {
+        "message": messageContextMenuPatch,
+        "image-context": imageContextMenuPatch
     }
+    // TODO: Add floating download button on individual media
 });

--- a/src/plugins/mediaDownloader.desktop/native.ts
+++ b/src/plugins/mediaDownloader.desktop/native.ts
@@ -1,0 +1,115 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { BrowserWindow, dialog, IpcMainInvokeEvent } from "electron";
+import { createWriteStream, existsSync, PathLike } from "fs";
+import http from "http";
+import https from "https";
+import { getSettings } from "main/ipcMain";
+import path from "path";
+import { LiteralUnion } from "type-fest";
+
+function isValidDownloadFolder(dir: string) {
+    if (!dir) return false;
+    if (dir === "C:\\") return false;
+    if (dir.startsWith("/dev")) return false;
+    if (dir.startsWith("/bin")) return false;
+    // TODO more reasonable safety checks
+    return true;
+}
+
+export async function selectMediaFolder(event: IpcMainInvokeEvent): Promise<LiteralUnion<"cancelled" | "invalid", string>> {
+    const res = await dialog.showOpenDialog(BrowserWindow.getFocusedWindow()!, {
+        properties: ["openDirectory"]
+    });
+    if (!res.filePaths.length) return "cancelled";
+
+    const dir = res.filePaths[0];
+    if (!isValidDownloadFolder(dir)) return "invalid";
+
+    return dir;
+}
+
+function decorateFileName(baseName: string) {
+    return baseName + "_" + Math.random().toString(36).slice(2);
+}
+
+function generateFilePath(url: URL, directory: PathLike, backupExtension: string) {
+
+    const sanitizedFilename = path.basename(url.pathname).replace(/([^a-z0-9_\-.() ]+)/, "_");
+    const sourceExtension = path.extname(sanitizedFilename);
+    const sourceName = path.basename(sanitizedFilename, sourceExtension) || "image";
+    const extension = sourceExtension || "." + backupExtension;
+
+    // TODO: expose more filename decoration options
+    let fullpath = path.resolve(directory.toLocaleString(), sourceName + extension);
+
+    let maxloops = 99;
+    while (existsSync(fullpath) && maxloops--) {
+        const tryName = decorateFileName(sourceName);
+        fullpath = path.resolve(directory.toLocaleString(), tryName + extension);
+    }
+    if (maxloops === -1) {
+        console.error("No free filename found in 99 attempts");
+        return null;
+    }
+
+    return fullpath;
+}
+
+function chooseProtocol(protocol: string) {
+    switch (protocol) {
+        case "https:": return https;
+        case "http:": return http;
+        default: return null;
+    }
+}
+
+function parseContentType(header: string | undefined) {
+    if (!header) return ["unknown", "unknown"];
+    const parsed = /^(\w*)\/(\w*)/.exec(header);
+    return parsed ?? ["unknown", "unknown"];
+}
+
+export function downloadFile(event: IpcMainInvokeEvent, sourceURL: string, proxyURL: string) {
+    const settings = getSettings().plugins?.MediaDownloader;
+    if (!settings || !settings.enabled) return Promise.reject("Media downloader plugin is not enabled :?");
+    if (!isValidDownloadFolder(settings.directory)) return Promise.reject("A valid downloads folder is not selected!");
+
+    // TODO: more intelligently choose between them
+    const url = new URL(settings.useProxy ? proxyURL : sourceURL);
+    if (!url) return Promise.reject("URL could not be validated!");
+
+    const protocol = chooseProtocol(url.protocol);
+    if (!protocol) return Promise.reject("Protocol could not be validated. HTTP or HTTPS only.");
+
+    return new Promise((resolve, reject) => {
+        protocol.get(url, function (response) {
+            // TODO: handle unusual response codes? redirects? etc.
+
+            const [fileCategory, fileSubtype] = parseContentType(response.headers["content-type"]);
+            // TODO: decide if filtering out non-media this way is reliable and/or important
+            // if (fileCategory && fileCategory !== "image" && fileCategory !== "video") return false;
+
+            const outputPath = generateFilePath(url, settings.directory, fileSubtype);
+            if (!outputPath) {
+                reject("Unable to find an available filename to save under. :(");
+                return;
+            }
+
+            const file = createWriteStream(outputPath).on("error", err => {
+                reject("File writing error: " + err);
+            }).on("finish", () => {
+                resolve("File downloaded to " + outputPath);
+            });
+
+            response.pipe(file);
+
+        }).on("error", e => {
+            reject(`Error in download: ${e.message}`);
+        });
+    });
+}

--- a/src/plugins/mediaDownloader.desktop/settings.tsx
+++ b/src/plugins/mediaDownloader.desktop/settings.tsx
@@ -54,5 +54,15 @@ export const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         description: "Download Discord's cached version (more secure, but may be compressed)",
         default: true
+    },
+    showInMessageHoverMenu: {
+        type: OptionType.BOOLEAN,
+        description: "Show 'download all' button in message hover menu",
+        default: false
+    },
+    showInContextMenu: {
+        type: OptionType.BOOLEAN,
+        description: "Show 'Quick Download' button in context menu",
+        default: true
     }
 });

--- a/src/plugins/mediaDownloader.desktop/settings.tsx
+++ b/src/plugins/mediaDownloader.desktop/settings.tsx
@@ -64,5 +64,17 @@ export const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         description: "Show 'Quick Download' button in context menu",
         default: true
+    },
+    addHoverButtonToImageAttachments: {
+        type: OptionType.BOOLEAN,
+        description: "Add 'quick download' button to images, not just video and audio",
+        default: true,
+        restartNeeded: true
+    },
+    hijackHoverButtonForQuickDownload: {
+        type: OptionType.BOOLEAN,
+        description: "Use the configured quick-download settings instead of opening in browser",
+        default: true,
+        restartNeeded: true
     }
 });

--- a/src/plugins/mediaDownloader.desktop/settings.tsx
+++ b/src/plugins/mediaDownloader.desktop/settings.tsx
@@ -6,12 +6,13 @@
 
 import { definePluginSettings } from "@api/Settings";
 import { OptionType, PluginNative } from "@utils/types";
-import { Button, Flex, Forms, TextInput, Toasts, useState } from "@webpack/common";
+import { Button, Flex, Forms, TextInput, Toasts, useEffect, useState } from "@webpack/common";
 
 const Native = VencordNative.pluginHelpers.MediaDownloader as PluginNative<typeof import("./native")>;
 
 function DirectoryPickerComponent(props: { setValue(v: any): void; }) {
-    const [value, setValue] = useState(settings.store.directory);
+    const [value, setValue] = useState("");
+    useEffect(() => { Native.getMediaFolder().then(setValue).catch(console.log); });
     return (
         <>
             <Forms.FormTitle tag="h4">Download Directory</Forms.FormTitle>
@@ -32,7 +33,6 @@ function DirectoryPickerComponent(props: { setValue(v: any): void; }) {
                                 });
                                 return;
                         }
-                        props.setValue(choice);
                         setValue(choice);
                     }}
                 >

--- a/src/plugins/mediaDownloader.desktop/settings.tsx
+++ b/src/plugins/mediaDownloader.desktop/settings.tsx
@@ -1,0 +1,58 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { OptionType, PluginNative } from "@utils/types";
+import { Button, Flex, Forms, TextInput, Toasts, useState } from "@webpack/common";
+
+const Native = VencordNative.pluginHelpers.MediaDownloader as PluginNative<typeof import("./native")>;
+
+function DirectoryPickerComponent(props: { setValue(v: any): void; }) {
+    const [value, setValue] = useState(settings.store.directory);
+    return (
+        <>
+            <Forms.FormTitle tag="h4">Download Directory</Forms.FormTitle>
+            <Flex flexDirection="row" style={{ gap: "0.5em" }}>
+                <Button
+                    size={Button.Sizes.SMALL}
+                    onClick={async () => {
+                        const choice = await Native.selectMediaFolder();
+                        switch (choice) {
+                            case "cancelled":
+                                return;
+                            case "invalid":
+                                Toasts.show({
+                                    message:
+                                        "Invalid save location.",
+                                    id: Toasts.genId(),
+                                    type: Toasts.Type.FAILURE
+                                });
+                                return;
+                        }
+                        props.setValue(choice);
+                        setValue(choice);
+                    }}
+                >
+                    Choose
+                </Button>
+                <TextInput placeholder="Media Save Directory" editable={false} value={value} style={{ flexGrow: 1, gap: "0.5em" }} />
+            </Flex>
+        </>
+    );
+}
+
+export const settings = definePluginSettings({
+    directory: {
+        type: OptionType.COMPONENT,
+        description: "Directory to save media files in",
+        component: DirectoryPickerComponent
+    },
+    useProxy: {
+        type: OptionType.BOOLEAN,
+        description: "Download Discord's cached version (more secure, but may be compressed)",
+        default: true
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -437,6 +437,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Byron: {
         name: "byeoon",
         id: 1167275288036655133n
+    },
+    Eloelle: {
+        name: "Eloelle",
+        id: 90987261205696512n,
     }
 } satisfies Record<string, Dev>);
 

--- a/src/utils/mergeDefaults.ts
+++ b/src/utils/mergeDefaults.ts
@@ -1,0 +1,24 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Recursively merges defaults into an object and returns the same object
+ * @param obj Object
+ * @param defaults Defaults
+ * @returns obj
+ */
+export function mergeDefaults<T>(obj: T, defaults: T): T {
+    for (const key in defaults) {
+        const v = defaults[key];
+        if (typeof v === "object" && !Array.isArray(v)) {
+            obj[key] ??= {} as any;
+            mergeDefaults(obj[key], v);
+        } else {
+            obj[key] ??= v;
+        }
+    }
+    return obj;
+}

--- a/src/utils/misc.tsx
+++ b/src/utils/misc.tsx
@@ -21,25 +21,6 @@ import { Clipboard, Toasts } from "@webpack/common";
 import { DevsById } from "./constants";
 
 /**
- * Recursively merges defaults into an object and returns the same object
- * @param obj Object
- * @param defaults Defaults
- * @returns obj
- */
-export function mergeDefaults<T>(obj: T, defaults: T): T {
-    for (const key in defaults) {
-        const v = defaults[key];
-        if (typeof v === "object" && !Array.isArray(v)) {
-            obj[key] ??= {} as any;
-            mergeDefaults(obj[key], v);
-        } else {
-            obj[key] ??= v;
-        }
-    }
-    return obj;
-}
-
-/**
  * Calls .join(" ") on the arguments
  * classes("one", "two") => "one two"
  */


### PR DESCRIPTION
Depends on #2346

Addresses plugin request https://github.com/Vencord/plugin-requests/issues/188

Many TODOs still but it's working pretty well for what it is so I figured I could put it in the review queue and if I get more time to work on it I'll just keep adding on.

Features (each can be enabled/disabled individually):
- (background) A 'safe' native interface that allows the user to select their media download folder without exposing direct file writing capabilities to the renderer
- A button in the message hover toolbar ('accessories') which downloads all embedded and attached media to the configured folder in a single click
- A menu item in the context menu when clicking on an image (in a message or when enlarged) which downloads the image to the preselected folder in one click
  - This currently can only download proxied media and still previews of videos, just like the 'save as' menu option. It might be possible to improve this behaviour but it'll be more invasive.
- A download hover button over image attachments, in the top-right, like the one over video attachments
  - Only attached images, not embedded ones. Embedded ones will need a separate, more invasive patch.
- An option to hijack aforementioned hover button to one-click download to the configured media folder (for videos, images, and audio) instead of opening it in the browser

