### PR TITLE
fixes the readallnotifications button's css

### DIFF
--- a/src/plugins/readAllNotificationsButton/style.css
+++ b/src/plugins/readAllNotificationsButton/style.css
@@ -1,11 +1,8 @@
 .vc-ranb-button {
-    color: var(--interactive-normal);
-    padding: 0 0.5em;
+    background-color: rgb(30, 46, 226);
+    padding: 0.3em;
     margin-bottom: 0.5em;
-    width: 100%;
     box-sizing: border-box;
-}
-
-.vc-ranb-button:hover {
-    color: var(--interactive-active);
+    position: relative; 
+    margin-left: 5.5px;
 }


### PR DESCRIPTION
Hi, i fixed the css for the readallnotifications button, making it not transparent and making it towards the center and left and right margin not touch other elements of discord.
here is a image,
<img width="75" alt="Screenshot 2024-04-13 at 21 14 26" src="https://github.com/Vendicated/Vencord/assets/165617563/a6fcda12-7725-4f6b-981a-e5eff12518a8">

Thank you -@golonchy