### PR TITLE
Add HideServers

### DIFF
--- a/src/api/ServerList.ts
+++ b/src/api/ServerList.ts
@@ -23,13 +23,17 @@ const logger = new Logger("ServerListAPI");
 export const enum ServerListRenderPosition {
     Above,
     In,
+    Below,
 }
 
-const renderFunctionsAbove = new Set<Function>();
-const renderFunctionsIn = new Set<Function>();
+const renderFunctions = {
+    [ServerListRenderPosition.Above]: new Set<Function>(),
+    [ServerListRenderPosition.In]: new Set<Function>(),
+    [ServerListRenderPosition.Below]: new Set<Function>(),
+};
 
 function getRenderFunctions(position: ServerListRenderPosition) {
-    return position === ServerListRenderPosition.Above ? renderFunctionsAbove : renderFunctionsIn;
+    return renderFunctions[position];
 }
 
 export function addServerListElement(position: ServerListRenderPosition, renderFunction: Function) {

--- a/src/plugins/_api/serverList.ts
+++ b/src/plugins/_api/serverList.ts
@@ -33,10 +33,15 @@ export default definePlugin({
         },
         {
             find: "Messages.SERVERS,children",
-            replacement: {
+            replacement: [{
                 match: /(?<=Messages\.SERVERS,children:)\i\.map\(\i\)/,
                 replace: "Vencord.Api.ServerList.renderAll(Vencord.Api.ServerList.ServerListRenderPosition.In).concat($&)"
+            },
+            {
+                match: /guildDiscoveryRef.{0,300}\{\}\)\]\}\)\]/,
+                replace: "$&.concat(Vencord.Api.ServerList.renderAll(Vencord.Api.ServerList.ServerListRenderPosition.Below))"
             }
+            ]
         }
     ]
 });

--- a/src/plugins/hideServers/components/HiddenServersButton.tsx
+++ b/src/plugins/hideServers/components/HiddenServersButton.tsx
@@ -1,0 +1,28 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { classNameFactory } from "@api/Styles";
+import { Button, ButtonLooks } from "@webpack/common";
+
+const cl = classNameFactory("vc-hideservers-");
+
+export default function ({ count, onClick, }: { count: number; onClick: () => void; }) {
+    return (
+        <div className={cl("button-wrapper")}>
+            {count > 0 ? (
+                <Button
+                    className={cl("button")}
+                    look={ButtonLooks.BLANK}
+                    size={Button.Sizes.MIN}
+                    onClick={onClick} >
+                    {count} Hidden
+                </Button>
+            ) : null}
+        </div>
+    );
+}

--- a/src/plugins/hideServers/components/modal.tsx
+++ b/src/plugins/hideServers/components/modal.tsx
@@ -1,0 +1,112 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@api/Styles";
+import { classes } from "@utils/misc";
+import {
+    closeModal,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalProps,
+    ModalRoot,
+    ModalSize,
+    openModal,
+} from "@utils/modal";
+import { findByPropsLazy } from "@webpack";
+import { Button, Forms, IconUtils, Text, useState } from "@webpack/common";
+import { Guild } from "discord-types/general";
+
+import { removeHidden } from "../settings";
+
+const cl = classNameFactory("vc-hideservers-");
+const IconClasses = findByPropsLazy("icon", "acronym", "childWrapper");
+
+function HiddenServersModal({
+    servers,
+    modalProps,
+    close,
+}: {
+    servers: Guild[];
+    modalProps: ModalProps;
+    close(): void;
+}) {
+    const [serverList, setServerList] = useState(servers);
+    function removeServer(id: string) {
+        removeHidden(id);
+        setServerList(serverList.filter(x => x.id !== id));
+    }
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE}>
+            <ModalHeader>
+                <Text variant="heading-lg/semibold" style={{ flexGrow: 1 }}>
+                    Hidden Servers
+                </Text>
+                <ModalCloseButton onClick={close} />
+            </ModalHeader>
+
+            <ModalContent>
+                <div className={cl("list")}>
+                    {serverList.length > 0 ? (
+                        serverList.map(server => (
+                            <div key={server.id} className={cl("row")}>
+                                <div className={cl("guildicon")}>
+                                    {server.icon
+                                        ? <img height="48" width="48"
+                                            src={IconUtils.getGuildIconURL({
+                                                id: server.id,
+                                                icon: server.icon,
+                                                canAnimate: true,
+                                                size: 240,
+                                            })} />
+                                        : <div
+                                            aria-hidden
+                                            className={classes(
+                                                IconClasses.childWrapper,
+                                                IconClasses.acronym
+                                            )}>
+                                            {server.acronym}
+                                        </div>
+                                    }
+                                </div>
+                                <Forms.FormTitle className={cl("name")}>
+                                    {server.name}
+                                </Forms.FormTitle>
+                                <Button
+                                    className={"row-button"}
+                                    color={Button.Colors.PRIMARY}
+                                    onClick={() => removeServer(server.id)}
+                                >
+                                    Remove
+                                </Button>
+                            </div>
+                        ))
+                    ) : (
+                        <Text variant="heading-sm/medium">
+                            No hidden servers
+                        </Text>
+                    )}
+                </div>
+            </ModalContent>
+
+            <ModalFooter></ModalFooter>
+        </ModalRoot>
+    );
+}
+
+export default function openHiddenServersModal({ servers }) {
+    const key = openModal(modalProps => {
+        return (
+            <HiddenServersModal
+                modalProps={modalProps}
+                servers={servers}
+                close={() => closeModal(key)}
+            />
+        );
+    });
+}

--- a/src/plugins/hideServers/components/style.css
+++ b/src/plugins/hideServers/components/style.css
@@ -1,0 +1,47 @@
+.vc-hideservers-button-wrapper {
+    display: flex;
+    justify-content: center;
+    margin: 0 0 8px;
+}
+
+.vc-hideservers-button {
+    max-width: 48px;
+    font-size: 60%;
+    background-color: var(--background-primary);
+    color: var(--header-secondary);
+}
+
+.vc-hideservers-list {
+    flex: 1 1 auto;
+}
+
+/* copied from blocked row */
+.vc-hideservers-row {
+    height: 62px;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    margin-left: 20px;
+    margin-right: 20px;
+    border-top: 1px solid var(--background-modifier-accent);
+    border-bottom: 1px solid transparent;
+    justify-content: space-between;
+}
+
+.vc-hideservers-guildicon {
+    display: flex;
+    align-items: center;
+    margin-right: 1em;
+}
+
+.vc-hideservers-guildicon img {
+    border-radius: 50%;
+}
+
+.vc-hideservers-name {
+    flex-grow: 1;
+}
+
+.vc-hideservers-row-button {
+    margin-left: auto;
+}

--- a/src/plugins/hideServers/index.tsx
+++ b/src/plugins/hideServers/index.tsx
@@ -1,0 +1,125 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// additional thanks to mwittrien/DevilBro and nexpid for their server hiding plugins, which served as inspiration
+
+import {
+    findGroupChildrenByChildId,
+    NavContextMenuPatchCallback,
+} from "@api/ContextMenu";
+import definePlugin from "@utils/types";
+import { Menu, React } from "@webpack/common";
+import { Guild } from "discord-types/general";
+
+import { addHidden, hiddenGuilds, loadHidden, settings } from "./settings";
+
+type guildsNode = {
+    type: "guild" | "folder";
+    id: number | string;
+    children: guildsNode[];
+};
+
+type qsResult = {
+    type: "GUILD" | string;
+    record?: {
+        id?: string;
+        guild_id?: string;
+    };
+};
+
+export let rerenderRef: undefined | WeakRef<Function>;
+
+const Patch: NavContextMenuPatchCallback = (
+    children,
+    { guild }: { guild: Guild; }
+) => {
+    const group = findGroupChildrenByChildId("privacy", children);
+
+    group?.push(
+        <Menu.MenuItem
+            id="vc-hide-server"
+            label="Hide Server"
+            action={() => addHidden(guild)}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "HideServers",
+    description:
+        "Allows you to hide servers from the guild list and quick switcher by right clicking them",
+    authors: [
+        {
+            name: "bep",
+            id: 0n,
+        },
+    ],
+    tags: ["guild", "server", "hide"],
+    contextMenus: {
+        "guild-context": Patch,
+        "guild-header-popout": Patch,
+    },
+    patches: [
+        // i tried a few different things like filtering the getGuildsTree area but all of them end up resetting scroll position sometimes
+        {
+            find: '("guildsnav")',
+            replacement: {
+                match: /(?<=Messages\.SERVERS.+?)(\i)(\.map.{0,50}?case \i\.GuildsNodeType\.FOLDER)/,
+                replace: "$1.flatMap($self.filterGuilds)$2",
+            },
+        },
+        // force it to rerender
+        {
+            find: '("guildsnav")',
+            replacement: {
+                match: /let{disableAppDownload.{0,10}isPlatformEmbedded/,
+                replace:
+                    "$self.grabRerender(Vencord.Webpack.Common.React.useReducer(x => x+1,0));$&",
+            },
+        },
+        {
+            find: "QUICKSWITCHER_PROTIP.format",
+            replacement: {
+                match: /(?<=renderResults\(\)\{)let\{query/,
+                replace:
+                    "this.props.results = $self.filterResults(this.props.results);$&",
+            },
+        },
+    ],
+    settings,
+
+    async start() {
+        await loadHidden();
+    },
+
+    filterGuilds(guild: guildsNode): guildsNode[] {
+        if (hiddenGuilds.has(guild.id.toString())) {
+            return [];
+        }
+        const newGuild = Object.assign({}, guild);
+        newGuild.children = guild.children.filter(
+            child => !hiddenGuilds.has(child.id.toString())
+        );
+
+        return [newGuild];
+    },
+
+    grabRerender([, e]: [unknown, Function]) {
+        rerenderRef = new WeakRef(e);
+    },
+
+    filterResults(results: qsResult[]): qsResult[] {
+        return results.filter(result => {
+            if (result?.record?.guild_id && hiddenGuilds.has(result.record.guild_id)) {
+                return false;
+            }
+            if (result.type === "GUILD" && hiddenGuilds.has(result.record!.id!)) {
+                return false;
+            }
+            return true;
+        });
+    },
+});

--- a/src/plugins/hideServers/index.tsx
+++ b/src/plugins/hideServers/index.tsx
@@ -96,7 +96,7 @@ export default definePlugin({
             find: '("guildsnav")',
             replacement: [
                 {
-                    match: /(?<=Messages\.SERVERS.+?)(\i)(\.map.{0,50}?case \i\.\i\.FOLDER)/,
+                    match: /(?<=Messages\.SERVERS,children:)(.+?\i)(\.map\(\i\))/,
                     replace: "$1.flatMap($self.filterGuilds)$2",
                 },
                 {

--- a/src/plugins/hideServers/index.tsx
+++ b/src/plugins/hideServers/index.tsx
@@ -17,7 +17,7 @@ import {
 } from "@api/ServerList";
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
-import { Menu, React } from "@webpack/common";
+import { GuildStore, Menu, React } from "@webpack/common";
 import { Guild } from "discord-types/general";
 
 import HiddenServersButton from "./components/HiddenServersButton";
@@ -62,8 +62,10 @@ const Patch: NavContextMenuPatchCallback = (
 };
 
 function serverListFunction() {
+    // if youve left a server dont show it in the count
+    const actuallyHidden = Array.from(hiddenGuilds).filter(x => GuildStore.getGuild(x)).length;
     return <HiddenServersButton
-        count={hiddenGuilds.size}
+        count={actuallyHidden}
         onClick={() => openHiddenServersModal({ servers: hiddenGuildsDetail() })}
     ></HiddenServersButton>;
 }

--- a/src/plugins/hideServers/index.tsx
+++ b/src/plugins/hideServers/index.tsx
@@ -96,7 +96,7 @@ export default definePlugin({
             find: '("guildsnav")',
             replacement: [
                 {
-                    match: /(?<=Messages\.SERVERS.+?)(\i)(\.map.{0,50}?case \i\.GuildsNodeType\.FOLDER)/,
+                    match: /(?<=Messages\.SERVERS.+?)(\i)(\.map.{0,50}?case \i\.\i\.FOLDER)/,
                     replace: "$1.flatMap($self.filterGuilds)$2",
                 },
                 {

--- a/src/plugins/hideServers/settings.tsx
+++ b/src/plugins/hideServers/settings.tsx
@@ -1,0 +1,62 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import * as DataStore from "@api/DataStore";
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+import { Button } from "@webpack/common";
+import { Guild } from "discord-types/general";
+
+import { rerenderRef } from ".";
+
+const DB_KEY = "HideServers_servers";
+
+export let hiddenGuilds: Set<string> = new Set();
+
+function rerender() {
+    const ref = rerenderRef?.deref();
+    if (ref) {
+        ref();
+    }
+}
+
+export function addHidden(guild: Guild) {
+    hiddenGuilds.add(guild.id);
+    rerender();
+    DataStore.set(DB_KEY, hiddenGuilds);
+}
+
+export async function loadHidden() {
+    const data = await DataStore.get(DB_KEY);
+    if (data) {
+        hiddenGuilds = data;
+    }
+    // rerender();
+}
+
+export function clearHidden() {
+    hiddenGuilds.clear();
+    DataStore.del(DB_KEY);
+    rerender();
+}
+
+export const settings = definePluginSettings({
+    resetHidden: {
+        type: OptionType.COMPONENT,
+        description: "Remove all hidden guilds from the list",
+        component: () => (
+            <div>
+                <Button
+                    size={Button.Sizes.SMALL}
+                    color={Button.Colors.RED}
+                    onClick={() => clearHidden()}
+                >
+                    Reset Hidden Guilds
+                </Button>
+            </div>
+        ),
+    },
+});

--- a/src/plugins/hideServers/settings.tsx
+++ b/src/plugins/hideServers/settings.tsx
@@ -7,21 +7,17 @@
 import * as DataStore from "@api/DataStore";
 import { definePluginSettings } from "@api/Settings";
 import { OptionType } from "@utils/types";
-import { Button } from "@webpack/common";
+import { findStoreLazy } from "@webpack";
+import { Button, GuildStore } from "@webpack/common";
 import { Guild } from "discord-types/general";
 
-import { rerenderRef } from ".";
+import { addIndicator, removeIndicator, rerender } from ".";
+
+const SortedGuildStore = findStoreLazy("SortedGuildStore");
 
 const DB_KEY = "HideServers_servers";
 
 export let hiddenGuilds: Set<string> = new Set();
-
-function rerender() {
-    const ref = rerenderRef?.deref();
-    if (ref) {
-        ref();
-    }
-}
 
 export function addHidden(guild: Guild) {
     hiddenGuilds.add(guild.id);
@@ -37,13 +33,37 @@ export async function loadHidden() {
     // rerender();
 }
 
+export function removeHidden(id: string) {
+    hiddenGuilds.delete(id);
+    rerender();
+    DataStore.set(DB_KEY, hiddenGuilds);
+}
+
 export function clearHidden() {
     hiddenGuilds.clear();
     DataStore.del(DB_KEY);
     rerender();
 }
 
+export function hiddenGuildsDetail(): Guild[] {
+    const sortedGuildIds = SortedGuildStore.getFlattenedGuildIds() as string[];
+    // otherwise the list is in order of increasing id number which is confusing
+    return sortedGuildIds.filter(id => hiddenGuilds.has(id)).map(id => GuildStore.getGuild(id));
+}
+
 export const settings = definePluginSettings({
+    showManager: {
+        type: OptionType.BOOLEAN,
+        description: "Show menu to unhide servers at the bottom of the list",
+        default: true,
+        onChange: val => {
+            if (val) {
+                addIndicator();
+            } else {
+                removeIndicator();
+            }
+        }
+    },
     resetHidden: {
         type: OptionType.COMPONENT,
         description: "Remove all hidden guilds from the list",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -478,6 +478,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "byeoon",
         id: 1167275288036655133n
     },
+    bep: {
+        name: "bep",
+        id: 0n,
+    },
     Kaitlyn: {
         name: "kaitlyn",
         id: 306158896630988801n


### PR DESCRIPTION
Small plugin that adds a context menu option to hide specific servers from the guilds list and quick switcher