### PR TITLE
feat(ShowTimeouts): Also show invites disabled tooltip

### DIFF
--- a/src/plugins/showHiddenThings/README.md
+++ b/src/plugins/showHiddenThings/README.md
@@ -5,7 +5,7 @@ Displays various moderator-only elements regardless of permissions.
 ## Features
 
 - Show member timeout icons in chat
-![](https://camo.githubusercontent.com/65fc9ee6175e63daaf9acc0ba2c01cff1cf419847569b49197537a85646a49d7/68747470733a2f2f692e646f6c66692e65732f3543506a446b576772742e706e673f6b65793d31754e786368385a3359364c4955)
+![](https://github.com/Vendicated/Vencord/assets/47677887/75e1f6ba-8921-4188-9c2d-c9c3f9d07101)
 
 - Show the invites paused tooltip in the server list
-![](https://camo.githubusercontent.com/7d8983d531c63df54095cd24c19dfb99e00088922fd2ec703f9cf7781204258d/68747470733a2f2f692e646f6c66692e65732f36685472756e4d4867512e706e673f6b65793d344274534d524f46726b77476357)
+![](https://github.com/Vendicated/Vencord/assets/47677887/b6a923d2-ac55-40d9-b4f8-fa6fc117148b)

--- a/src/plugins/showHiddenThings/README.md
+++ b/src/plugins/showHiddenThings/README.md
@@ -1,0 +1,11 @@
+# ShowHiddenThings
+
+Displays various moderator-only elements regardless of permissions.
+
+## Features
+
+- Show member timeout icons in chat
+![](https://camo.githubusercontent.com/65fc9ee6175e63daaf9acc0ba2c01cff1cf419847569b49197537a85646a49d7/68747470733a2f2f692e646f6c66692e65732f3543506a446b576772742e706e673f6b65793d31754e786368385a3359364c4955)
+
+- Show the invites paused tooltip in the server list
+![](https://i.dolfi.es/6hTrunMHgQ.png?key=4BtSMROFrkwGcW)

--- a/src/plugins/showHiddenThings/README.md
+++ b/src/plugins/showHiddenThings/README.md
@@ -8,4 +8,4 @@ Displays various moderator-only elements regardless of permissions.
 ![](https://camo.githubusercontent.com/65fc9ee6175e63daaf9acc0ba2c01cff1cf419847569b49197537a85646a49d7/68747470733a2f2f692e646f6c66692e65732f3543506a446b576772742e706e673f6b65793d31754e786368385a3359364c4955)
 
 - Show the invites paused tooltip in the server list
-![](https://i.dolfi.es/6hTrunMHgQ.png?key=4BtSMROFrkwGcW)
+![](https://camo.githubusercontent.com/7d8983d531c63df54095cd24c19dfb99e00088922fd2ec703f9cf7781204258d/68747470733a2f2f692e646f6c66692e65732f36685472756e4d4867512e706e673f6b65793d344274534d524f46726b77476357)

--- a/src/plugins/showHiddenThings/index.ts
+++ b/src/plugins/showHiddenThings/index.ts
@@ -16,20 +16,45 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
-import definePlugin from "@utils/types";
+import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    showTimeouts: {
+        type: OptionType.BOOLEAN,
+        description: "Show member timeout icons in chat.",
+        default: true,
+    },
+    showInvitesPaused: {
+        type: OptionType.BOOLEAN,
+        description: "Show the invites paused tooltip in the server list.",
+        default: true,
+    },
+});
 
 export default definePlugin({
-    name: "ShowTimeouts",
-    description: "Display member timeout icons in chat regardless of permissions.",
+    name: "ShowHiddenThings",
+    tags: ["ShowTimeouts", "ShowInvitesPaused"],
+    description: "Displays various moderator-only elements regardless of permissions.",
     authors: [Devs.Dolfies],
     patches: [
         {
             find: "showCommunicationDisabledStyles",
+            predicate: () => settings.store.showTimeouts,
             replacement: {
                 match: /&&\i\.\i\.canManageUser\(\i\.\i\.MODERATE_MEMBERS,\i\.author,\i\)/,
                 replace: "",
             },
         },
+        {
+            find: "useShouldShowInvitesDisabledNotif:",
+            predicate: () => settings.store.showInvitesPaused,
+            replacement: {
+                match: /\i\.\i\.can\(\i\.Permissions.MANAGE_GUILD,\i\)/,
+                replace: "true",
+            },
+        }
     ],
+    settings,
 });

--- a/src/plugins/showHiddenThings/index.ts
+++ b/src/plugins/showHiddenThings/index.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { definePluginSettings } from "@api/Settings";
+import { definePluginSettings, migratePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
@@ -33,6 +33,7 @@ const settings = definePluginSettings({
     },
 });
 
+migratePluginSettings("ShowHiddenThings", "ShowTimeouts");
 export default definePlugin({
     name: "ShowHiddenThings",
     tags: ["ShowTimeouts", "ShowInvitesPaused"],


### PR DESCRIPTION
## Summary

- Renames the plugin to be more generic
- Also shows invites disabled tooltip now
- Adds settings for everything

![](https://i.dolfi.es/6hTrunMHgQ.png?key=4BtSMROFrkwGcW)