### PR TITLE
feat(USRBG): update to new API

### DIFF
--- a/src/plugins/usrbg/index.tsx
+++ b/src/plugins/usrbg/index.tsx
@@ -30,7 +30,7 @@ interface UsrbgApiReturn {
     endpoint: string
     bucket: string
     prefix: string
-    users: { [id: string]: string }
+    users: Record<string, string>
 }
 
 const settings = definePluginSettings({
@@ -53,7 +53,7 @@ const settings = definePluginSettings({
 export default definePlugin({
     name: "USRBG",
     description: "Displays user banners from USRBG, allowing anyone to get a banner without Nitro",
-    authors: [Devs.AutumnVN, Devs.pylix, Devs.TheKodeToad, Devs.katlyn],
+    authors: [Devs.AutumnVN, Devs.katlyn, Devs.pylix, Devs.TheKodeToad],
     settings,
     patches: [
         {

--- a/src/plugins/usrbg/index.tsx
+++ b/src/plugins/usrbg/index.tsx
@@ -120,21 +120,14 @@ export default definePlugin({
     },
 
     userHasBackground(userId: string) {
-        if (this.data === null) return false;
-        return this.data.users[userId] !== undefined;
+        return !!this.data?.users[userId];
     },
 
     getImageUrl(userId: string): string|null {
-        if (this.data == null) {
-            return null;
-        }
+        if (!this.userHasBackground(userId)) return null;
 
-        const etag = this.data.users[userId];
-        if (etag === undefined) {
-            return null;
-        }
-
-        const { endpoint, bucket, prefix } = this.data;
+        // We can assert that data exists because userHasBackground returned true
+        const { endpoint, bucket, prefix, users: { [userId]: etag } } = this.data!;
         return `${endpoint}/${bucket}/${prefix}${userId}?${etag}`;
     },
 

--- a/src/plugins/usrbg/index.tsx
+++ b/src/plugins/usrbg/index.tsx
@@ -25,13 +25,12 @@ import definePlugin, { OptionType } from "@utils/types";
 import style from "./index.css?managed";
 
 const API_URL = "https://usrbg.is-hardly.online/users";
-const cachebust = Date.now();
 
 interface UsrbgApiReturn {
     endpoint: string
     bucket: string
     prefix: string
-    users: string[]
+    users: { [id: string]: string }
 }
 
 const settings = definePluginSettings({
@@ -122,7 +121,7 @@ export default definePlugin({
 
     userHasBackground(userId: string) {
         if (this.data === null) return false;
-        return this.data.users.includes(userId);
+        return this.data.users[userId] !== undefined;
     },
 
     getImageUrl(userId: string): string|null {
@@ -130,8 +129,13 @@ export default definePlugin({
             return null;
         }
 
+        const etag = this.data.users[userId];
+        if (etag === undefined) {
+            return null;
+        }
+
         const { endpoint, bucket, prefix } = this.data;
-        return `${endpoint}/${bucket}/${prefix}${userId}?${cachebust}`;
+        return `${endpoint}/${bucket}/${prefix}${userId}?${etag}`;
     },
 
     async start() {


### PR DESCRIPTION
USRBG has moved storage to a new dedicated platform, allowing better integration and more control over the data that can be made available for plugins to use. This has allowed creation of a new API that has several benefits:
- The API's data is updated immediately upon a user's background being approved
- Data sent over-the-pipe can be reduced, only sending a list of user ids and a small bit of metadata (~800kB instead of the current 1.7MB)
- Dead links are no longer a possibility and do not need to be filtered out of the dataset
