### PR TITLE
fix(plugins/vcDoubleClick): conflict with MessageClickActions

### DIFF
--- a/src/plugins/vcDoubleClick/index.ts
+++ b/src/plugins/vcDoubleClick/index.ts
@@ -52,7 +52,7 @@ export default definePlugin({
             replacement: {
                 match: /onClick:(\i)(?=,.{0,30}className:"channelMention".+?(\i)\.inContent)/,
                 replace: (_, onClick, props) => ""
-                    + `onClick:(vcDoubleClickEvt)=>$self.shouldRunOnClick(vcDoubleClickEvt,${props})&&${onClick}()`,
+                    + `onClick:(vcDoubleClickEvt)=>$self.shouldRunOnClick(vcDoubleClickEvt,${props})(vcDoubleClickEvt.stopPropagation(),${onClick}())`,
             }
         }
     ],


### PR DESCRIPTION
After enabling both `VoiceChatDoucleClick` and `MessageClickActions`, double clicking a voice channel mention in a message would both edit/reply to the message as well as join the voice channel, adding a `evt.stopPropagation()` fixes this behavior