### PR TITLE
Cloud Sync: Stop discarding unknown root level values

### DIFF
--- a/src/utils/settingsSync.ts
+++ b/src/utils/settingsSync.ts
@@ -113,16 +113,34 @@ export async function uploadSettingsBackup(showToast = true): Promise<void> {
 const cloudSettingsLogger = new Logger("Cloud:Settings", "#39b7e0");
 
 export async function putCloudSettings(manual?: boolean) {
-    const settings = await exportSettings({ minify: true });
+    const settings = JSON.parse(await exportSettings({ minify: true }));
 
     try {
+
+        let oldSettings = {};
+        try {
+            const existingDataRes = await fetch(new URL("/v1/settings", getCloudUrl()), {
+                method: "GET",
+                headers: {
+                    Authorization: await getCloudAuth(),
+                    Accept: "application/octet-stream"
+                },
+            });
+
+            if (existingDataRes.ok) {
+                const data = await existingDataRes.arrayBuffer();
+                const oldSettingsString = new TextDecoder().decode(inflateSync(new Uint8Array(data)));
+                oldSettings = JSON.parse(oldSettingsString);
+            }
+        } catch (e) { }
+
         const res = await fetch(new URL("/v1/settings", getCloudUrl()), {
             method: "PUT",
             headers: {
                 Authorization: await getCloudAuth(),
                 "Content-Type": "application/octet-stream"
             },
-            body: deflateSync(new TextEncoder().encode(settings))
+            body: deflateSync(new TextEncoder().encode(JSON.stringify({ ...oldSettings, ...settings })))
         });
 
         if (!res.ok) {


### PR DESCRIPTION
This will merge local root object values over existing remote values that may not exist in the client.

For example with a change I am making to the core right now where I have added a `cssSnippets` object to the root, this is so that clients with this patch will not remove that from the cloud data if they don't support it.
This is also useful for people running their own fork that adds more to cloud sync like I have, so they don't accidentally delete that data when using the upstream build (for example, when setting up a new device, using the browser extension, or even when testing if something is broken by their own dev build.)