### PR TITLE
Replace keyword "assert" with "with" for NodeJS v22+ support

### DIFF
--- a/scripts/build/common.mjs
+++ b/scripts/build/common.mjs
@@ -26,7 +26,7 @@ import { join, relative } from "path";
 import { promisify } from "util";
 
 // wtf is this assert syntax
-import PackageJSON from "../../package.json" assert { type: "json" };
+import PackageJSON from "../../package.json" with { type: "json" };
 import { getPluginTarget } from "../utils.mjs";
 
 export const VERSION = PackageJSON.version;


### PR DESCRIPTION
Replace keyword "assert" with "with" to work with NodeJS v22+
The "with" keyword for imports does require NodeJS v18.20.x+ (LTS) or v20.10+

NodeJS PR that removed the keyword for v22: https://github.com/nodejs/node/pull/52104