### PR TITLE
feat(plugin): Character count

### DIFF
--- a/src/plugins/characterCount/index.css
+++ b/src/plugins/characterCount/index.css
@@ -1,3 +1,10 @@
 .vc-char-count-text {
-    margin-bottom: -30px;
+    /* Though these are odd measures I think it's the best you can get without it looking either too close to the buttons or too close to the border */
+    margin-right: -4px;
+    margin-bottom: -8px;
+    font-size: 14px;
+}
+
+.vc-char-count-chat-input {
+    min-height: 48px;
 }

--- a/src/plugins/characterCount/index.css
+++ b/src/plugins/characterCount/index.css
@@ -1,0 +1,3 @@
+.vc-char-count-text {
+    margin-bottom: -30px;
+}

--- a/src/plugins/characterCount/index.tsx
+++ b/src/plugins/characterCount/index.tsx
@@ -1,0 +1,74 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./index.css";
+
+import { classNameFactory } from "@api/Styles";
+import { Devs } from "@utils/constants";
+import { classes } from "@utils/misc";
+import definePlugin from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+import { useMemo, UserStore } from "@webpack/common";
+import { User } from "discord-types/general";
+
+interface CharacterCountProps {
+    type: any;
+    textValue: string;
+    className: string;
+    maxCharacterCount?: any;
+    showRemainingCharsAfterCount?: boolean;
+}
+
+const PremiumCapabilities: {
+    canUseIncreasedMessageLength: (user: User) => boolean;
+} = findByPropsLazy("canUseIncreasedMessageLength");
+const DiscordConstants: {
+    MAX_MESSAGE_LENGTH_PREMIUM: number;
+    MAX_MESSAGE_LENGTH: number;
+} = findByPropsLazy("MAX_MESSAGE_LENGTH_PREMIUM");
+
+const charCountClasses: {
+    [key: string]: string;
+} = findByPropsLazy("characterCount", "flairContainer");
+
+const cl = classNameFactory("vc-char-count-");
+
+export default definePlugin({
+    name: "CharacterCount",
+    description: "Display the character count in the chat input",
+    authors: [
+        Devs.Fres
+    ],
+    patches: [
+        {
+            find: "indentCharacterCount]",
+            replacement: {
+                match: /(\?\(.{0,30}?jsx\)).{0,100}?,({.{0,100}?showRemainingCharsAfterCount.{0,100}?})/,
+                replace: "$1($self.CharacterCount,$2"
+            }
+        }
+    ],
+    CharacterCount: function ({ textValue, type }: CharacterCountProps) {
+        const msgLength = textValue.length;
+
+        const maxMessageLength = useMemo(() =>
+            PremiumCapabilities.canUseIncreasedMessageLength(UserStore.getCurrentUser()) ?
+                DiscordConstants.MAX_MESSAGE_LENGTH_PREMIUM :
+                DiscordConstants.MAX_MESSAGE_LENGTH,
+        []);
+
+        const className = useMemo(() => classes(
+            charCountClasses.characterCount,
+            cl("text"),
+            msgLength > maxMessageLength ? charCountClasses.error : null
+        ), [msgLength]);
+
+        return <div
+            className={className}>
+            {msgLength}/{maxMessageLength}
+        </div>;
+    }
+});

--- a/src/plugins/characterCount/index.tsx
+++ b/src/plugins/characterCount/index.tsx
@@ -49,8 +49,16 @@ export default definePlugin({
                 match: /(\?\(.{0,30}?jsx\)).{0,100}?,({.{0,100}?showRemainingCharsAfterCount.{0,100}?})/,
                 replace: "$1($self.CharacterCount,$2"
             }
+        },
+        {
+            find: "slateContainer)",
+            replacement: {
+                match: /className:.{0,50}?\(\).{0,50}?\.slateContainer/,
+                replace: "$&,$self.chatInputClass"
+            }
         }
     ],
+    chatInputClass: cl("chat-input"),
     CharacterCount: function ({ textValue, type }: CharacterCountProps) {
         const msgLength = textValue.length;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -449,7 +449,11 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     PolisanTheEasyNick: {
         name: "Oleh Polisan",
         id: 242305263313485825n
-    }
+    },
+    Fres: {
+        name: "fres",
+        id: 843448897737064448n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Add Character Count plugin
Always displays the character count on the bottom right of the chat input, followed by the user's max character count
![image](https://github.com/Vendicated/Vencord/assets/126067139/6dbe250d-30d4-425b-b9ca-f4b2161238c2)
