### PR TITLE
LastfmRichPresence: Add option to use album name as status name

### DIFF
--- a/src/plugins/lastfm/index.tsx
+++ b/src/plugins/lastfm/index.tsx
@@ -150,7 +150,7 @@ const settings = definePluginSettings({
                 value: NameFormat.SongOnly
             },
             {
-                label: "Use album name",
+                label: "Use album name (falls back to custom status text if song has no album)",
                 value: NameFormat.AlbumName
             }
         ],

--- a/src/plugins/lastfm/index.tsx
+++ b/src/plugins/lastfm/index.tsx
@@ -77,7 +77,8 @@ const enum NameFormat {
     ArtistFirst = "artist-first",
     SongFirst = "song-first",
     ArtistOnly = "artist",
-    SongOnly = "song"
+    SongOnly = "song",
+    AlbumName = "album"
 }
 
 const applicationId = "1108588077900898414";
@@ -147,6 +148,10 @@ const settings = definePluginSettings({
             {
                 label: "Use song name only",
                 value: NameFormat.SongOnly
+            },
+            {
+                label: "Use album name",
+                value: NameFormat.AlbumName
             }
         ],
     },
@@ -313,6 +318,8 @@ export default definePlugin({
                     return trackData.artist;
                 case NameFormat.SongOnly:
                     return trackData.name;
+                case NameFormat.AlbumName:
+                    return trackData.album || settings.store.statusName;
                 default:
                     return settings.store.statusName;
             }


### PR DESCRIPTION
Defaults to custom status when album name is not set.

![image](https://github.com/Vendicated/Vencord/assets/120592920/8d060c70-128e-4931-ad1c-967d055de3c0)
