### PR TITLE
messageLogger: fix niche bug ignoring edits when content is same

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -255,7 +255,7 @@ export default definePlugin({
                     replace: "$1" +
                         ".update($3,m =>" +
                         "   (($2.message.flags & 64) === 64 || $self.shouldIgnore($2.message, true)) ? m :" +
-                        "   $2.message.content !== m.editHistory?.[0]?.content && $2.message.content !== m.content ?" +
+                        "   $2.message.content !== m.content ?" +
                         "       m.set('editHistory',[...(m.editHistory || []), $self.makeEdit($2.message, m)]) :" +
                         "       m" +
                         ")" +


### PR DESCRIPTION
This removes the redundant check `$2.message.content !== m.editHistory?.[0]?.content` which checks if the new message content is different from the first item in the editHistory. This is not needed (there is another check `$2.message.content !== m.content`), and results in a bug; the other check should be sufficient.

Fixes #2395.