### PR TITLE
Dearrow: allow configuring which elements get dearrowd

### DIFF
--- a/src/plugins/dearrow/index.tsx
+++ b/src/plugins/dearrow/index.tsx
@@ -6,10 +6,11 @@
 
 import "./styles.css";
 
+import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
-import definePlugin from "@utils/types";
+import definePlugin, { OptionType } from "@utils/types";
 import { Tooltip } from "@webpack/common";
 import type { Component } from "react";
 
@@ -34,11 +35,19 @@ interface Props {
     };
 }
 
+const enum ReplaceElements {
+    ReplaceAllElements,
+    ReplaceTitles,
+    ReplaceThumbnails
+}
+
 const embedUrlRe = /https:\/\/www\.youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/;
 
 async function embedDidMount(this: Component<Props>) {
     try {
         const { embed } = this.props;
+        const { replaceElements } = settings.store;
+
         if (!embed || embed.dearrow || embed.provider?.name !== "YouTube" || !embed.video?.url) return;
 
         const videoId = embedUrlRe.exec(embed.video.url)?.[1];
@@ -58,12 +67,12 @@ async function embedDidMount(this: Component<Props>) {
             enabled: true
         };
 
-        if (hasTitle) {
+        if (hasTitle && replaceElements !== ReplaceElements.ReplaceThumbnails) {
             embed.dearrow.oldTitle = embed.rawTitle;
             embed.rawTitle = titles[0].title.replace(/ >(\S)/g, " $1");
         }
 
-        if (hasThumb) {
+        if (hasThumb && replaceElements !== ReplaceElements.ReplaceTitles) {
             embed.dearrow.oldThumb = embed.thumbnail.proxyURL;
             embed.thumbnail.proxyURL = `https://dearrow-thumb.ajay.app/api/v1/getThumbnail?videoID=${videoId}&time=${thumbnails[0].timestamp}`;
         }
@@ -128,10 +137,30 @@ function DearrowButton({ component }: { component: Component<Props>; }) {
     );
 }
 
+const settings = definePluginSettings({
+    hideButton: {
+        description: "Hides the Dearrow button from YouTube embeds",
+        type: OptionType.BOOLEAN,
+        default: false,
+        restartNeeded: true
+    },
+    replaceElements: {
+        description: "Choose which elements of the embed will be replaced",
+        type: OptionType.SELECT,
+        restartNeeded: true,
+        options: [
+            { label: "Everything (Titles & Thumbnails)", value: ReplaceElements.ReplaceAllElements, default: true },
+            { label: "Titles", value: ReplaceElements.ReplaceTitles },
+            { label: "Thumbnails", value: ReplaceElements.ReplaceThumbnails },
+        ],
+    }
+});
+
 export default definePlugin({
     name: "Dearrow",
     description: "Makes YouTube embed titles and thumbnails less sensationalist, powered by Dearrow",
     authors: [Devs.Ven],
+    settings,
 
     embedDidMount,
     renderButton(component: Component<Props>) {
@@ -154,7 +183,8 @@ export default definePlugin({
             // add dearrow button
             {
                 match: /children:\[(?=null!=\i\?\i\.renderSuppressButton)/,
-                replace: "children:[$self.renderButton(this),"
+                replace: "children:[$self.renderButton(this),",
+                predicate: () => !settings.store.hideButton
             }
         ]
     }],

--- a/src/plugins/dearrow/index.tsx
+++ b/src/plugins/dearrow/index.tsx
@@ -37,8 +37,8 @@ interface Props {
 
 const enum ReplaceElements {
     ReplaceAllElements,
-    ReplaceTitles,
-    ReplaceThumbnails
+    ReplaceTitlesOnly,
+    ReplaceThumbnailsOnly
 }
 
 const embedUrlRe = /https:\/\/www\.youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/;
@@ -67,12 +67,12 @@ async function embedDidMount(this: Component<Props>) {
             enabled: true
         };
 
-        if (hasTitle && replaceElements !== ReplaceElements.ReplaceThumbnails) {
+        if (hasTitle && replaceElements !== ReplaceElements.ReplaceThumbnailsOnly) {
             embed.dearrow.oldTitle = embed.rawTitle;
             embed.rawTitle = titles[0].title.replace(/ >(\S)/g, " $1");
         }
 
-        if (hasThumb && replaceElements !== ReplaceElements.ReplaceTitles) {
+        if (hasThumb && replaceElements !== ReplaceElements.ReplaceTitlesOnly) {
             embed.dearrow.oldThumb = embed.thumbnail.proxyURL;
             embed.thumbnail.proxyURL = `https://dearrow-thumb.ajay.app/api/v1/getThumbnail?videoID=${videoId}&time=${thumbnails[0].timestamp}`;
         }
@@ -150,8 +150,8 @@ const settings = definePluginSettings({
         restartNeeded: true,
         options: [
             { label: "Everything (Titles & Thumbnails)", value: ReplaceElements.ReplaceAllElements, default: true },
-            { label: "Titles", value: ReplaceElements.ReplaceTitles },
-            { label: "Thumbnails", value: ReplaceElements.ReplaceThumbnails },
+            { label: "Titles", value: ReplaceElements.ReplaceTitlesOnly },
+            { label: "Thumbnails", value: ReplaceElements.ReplaceThumbnailsOnly },
         ],
     }
 });


### PR DESCRIPTION
Adds two new options to the `Dearrow` plugin.

- Ability to hide the `Dearrow Toggle` Button
- Ability to only replace certain elements
  - `Titles`, only replaces titles
  - `Thumbnails`, only replaces thumbnails
  - `Everything`, replaces everything (default)
  
---

Preview with each option enabled / disabled:

<details>
<summary>Original</summary>
<img src="https://github.com/Vendicated/Vencord/assets/87046111/355e6f49-2020-4fe3-bf28-86305095420d" />
</details>

<details>
<summary><code>Everything</code></summary>
<img src="https://github.com/Vendicated/Vencord/assets/87046111/f9e9e53c-2699-41ec-bb93-88a8d4b60f31" />
</details>

<details>
<summary><code>Title</code></summary>
<img src="https://github.com/Vendicated/Vencord/assets/87046111/90deda8d-f3d2-40e6-94a4-1c46cce02991" />
</details>

<details>
<summary><code>Thumbnail</code></summary>
<img src="https://github.com/Vendicated/Vencord/assets/87046111/3598202b-18b6-4307-8585-2b5b975ece0e" />
</details>

<details>
<summary><code>Hidden Dearrow Button</code> & <code>Everything</code></summary>
<img src="https://github.com/Vendicated/Vencord/assets/87046111/06c55634-9dfa-453d-8c5f-501389bfa8a2" />
</details>

<details>
<summary>Plugin Settings</summary>
<img src="https://github.com/Vendicated/Vencord/assets/87046111/aca67593-c6a6-4568-bc84-2327bbef8971" />
</details>