### PR TITLE
showHiddenThings: also show ModView & hidden discovery servers

### DIFF
--- a/src/plugins/showHiddenThings/README.md
+++ b/src/plugins/showHiddenThings/README.md
@@ -9,3 +9,9 @@ Displays various moderator-only elements regardless of permissions.
 
 - Show the invites paused tooltip in the server list
 ![](https://github.com/Vendicated/Vencord/assets/47677887/b6a923d2-ac55-40d9-b4f8-fa6fc117148b)
+
+- Show the member mod view context menu item in all servers
+
+![](https://github.com/Vendicated/Vencord/assets/47677887/3dac95dd-841c-4c15-ad87-2db7bd1e4dab)
+
+- Disable filters in Server Discovery search that hide servers that don't meet discovery criteria

--- a/src/plugins/showHiddenThings/index.ts
+++ b/src/plugins/showHiddenThings/index.ts
@@ -31,6 +31,11 @@ const settings = definePluginSettings({
         description: "Show the invites paused tooltip in the server list.",
         default: true,
     },
+    showModView: {
+        type: OptionType.BOOLEAN,
+        description: "Show the member mod view context menu item in all servers.",
+        default: true,
+    },
 });
 
 migratePluginSettings("ShowHiddenThings", "ShowTimeouts");
@@ -55,6 +60,14 @@ export default definePlugin({
                 match: /\i\.\i\.can\(\i\.Permissions.MANAGE_GUILD,\i\)/,
                 replace: "true",
             },
+        },
+        {
+            find: "canAccessGuildMemberModViewWithExperiment:",
+            predicate: () => settings.store.showModView,
+            replacement: {
+                match: /return \i\.hasAny\(\i\.computePermissions\(\{user:\i,context:\i,checkElevated:!1\}\),\i\.MemberSafetyPagePermissions\)/,
+                replace: "return true",
+            }
         }
     ],
     settings,

--- a/src/plugins/showHiddenThings/index.ts
+++ b/src/plugins/showHiddenThings/index.ts
@@ -36,12 +36,17 @@ const settings = definePluginSettings({
         description: "Show the member mod view context menu item in all servers.",
         default: true,
     },
+    disableDiscoveryFilters: {
+        type: OptionType.BOOLEAN,
+        description: "Disable filters in Server Discovery search that hide servers that don't meet discovery criteria.",
+        default: true,
+    },
 });
 
 migratePluginSettings("ShowHiddenThings", "ShowTimeouts");
 export default definePlugin({
     name: "ShowHiddenThings",
-    tags: ["ShowTimeouts", "ShowInvitesPaused"],
+    tags: ["ShowTimeouts", "ShowInvitesPaused", "ShowModView", "DisableDiscoveryFilters"],
     description: "Displays various moderator-only elements regardless of permissions.",
     authors: [Devs.Dolfies],
     patches: [
@@ -67,6 +72,14 @@ export default definePlugin({
             replacement: {
                 match: /return \i\.hasAny\(\i\.computePermissions\(\{user:\i,context:\i,checkElevated:!1\}\),\i\.MemberSafetyPagePermissions\)/,
                 replace: "return true",
+            }
+        },
+        {
+            find: "auto_removed:",
+            predicate: () => settings.store.disableDiscoveryFilters,
+            replacement: {
+                match: /filters:\i\.join\(" AND "\),facets:\[/,
+                replace: "facets:["
             }
         }
     ],


### PR DESCRIPTION
This kinda steps on the toes of the user functionality in PermissionsViewer
![jmjadwQPSn 1](https://github.com/Vendicated/Vencord/assets/47677887/3dac95dd-841c-4c15-ad87-2db7bd1e4dab)
