### PR TITLE
ThemeAttributes: add data-author-username to messages

### DIFF
--- a/src/plugins/themeAttributes/README.md
+++ b/src/plugins/themeAttributes/README.md
@@ -15,6 +15,7 @@ This allows themes to more easily theme those elements or even do things that ot
 ### Chat Messages
 
 - `data-author-id` contains the id of the author
+- `data-author-username` contains the username of the author
 - `data-is-self` is a boolean indicating whether this is the current user's message
 
 ![image](https://github.com/Vendicated/Vencord/assets/45497981/34bd5053-3381-402f-82b2-9c812cc7e122)

--- a/src/plugins/themeAttributes/index.ts
+++ b/src/plugins/themeAttributes/index.ts
@@ -36,10 +36,12 @@ export default definePlugin({
     ],
 
     getMessageProps(props: { message: Message; }) {
-        const authorId = props.message?.author?.id;
+        const author = props.message?.author;
+        const authorId = author?.id;
         return {
             "data-author-id": authorId,
-            "data-is-self": authorId && authorId === UserStore.getCurrentUser()?.id
+            "data-author-username": author?.username,
+            "data-is-self": authorId && authorId === UserStore.getCurrentUser()?.id,
         };
     }
 });


### PR DESCRIPTION
Very minor change, so we didn't add ourselves to the author field.
We use a modified version of the plugin locally because using IDs is unreliable for our use case (theming PluralKit messages) and having the username exposed makes it possible.
Thought we might as well open up a PR for it rather than let it sit alone in a gist somewhere.