### PR TITLE
MessageLogger: use discord variables instead of hardcoded colors

### DIFF
--- a/src/plugins/messageLogger/deleteStyleOverlay.css
+++ b/src/plugins/messageLogger/deleteStyleOverlay.css
@@ -1,3 +1,3 @@
 .messagelogger-deleted {
-    background-color: rgba(240 71 71 / 15%) !important;
+    background-color: hsla(var(--red-430-hsl, 0 85% 61%) / 15%) !important;
 }

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,16 +1,16 @@
 /* Message content highlighting */
 .messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p) {
-    color: var(--red-430, #f04747) !important;
+    color: var(--status-danger, #f04747) !important;
 }
 
 /* Bot "thinking" text highlighting */
 .messagelogger-deleted [class*="colorStandard"] {
-    color: var(--red-430, #f04747) !important;
+    color: var(--status-danger, #f04747) !important;
 }
 
 /* Embed highlighting */
 .messagelogger-deleted article :is(div, span, h1, h2, h3, p) {
-    color: var(--red-430, #f04747) !important;
+    color: var(--status-danger, #f04747) !important;
 }
 
 .messagelogger-deleted a {

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,19 +1,19 @@
 /* Message content highlighting */
 .messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p) {
-    color: #f04747 !important;
+    color: var(--red-430, #f04747) !important;
 }
 
 /* Bot "thinking" text highlighting */
 .messagelogger-deleted [class*="colorStandard"] {
-    color: #f04747 !important;
+    color: var(--red-430, #f04747) !important;
 }
 
 /* Embed highlighting */
 .messagelogger-deleted article :is(div, span, h1, h2, h3, p) {
-    color: #f04747 !important;
+    color: var(--red-430, #f04747) !important;
 }
 
 .messagelogger-deleted a {
-    color: #be3535 !important;
+    color: var(--red-460, #be3535) !important;
     text-decoration: underline;
 }


### PR DESCRIPTION
Colors now use discord variables for better theme compatibility