### PR TITLE
ThemeAttributes: add larger avatar url variables to avatars

### DIFF
--- a/src/plugins/themeAttributes/README.md
+++ b/src/plugins/themeAttributes/README.md
@@ -24,6 +24,6 @@ This allows themes to more easily theme those elements or even do things that ot
 
 ### Avatars
 
-`--large-avatar-url` contains a URL for the users avatar with the size attribute adjusted.
+`--avatar-url-<resolution>` contains a URL for the users avatar with the size attribute adjusted for the resolutions `128, 256, 512, 1024, 2048, 4096`.
 
-![image](https://github.com/Vendicated/Vencord/assets/26598490/b86d05ea-3a49-4cfa-8d2f-6c4ed390cf4c)
+![image](https://github.com/Vendicated/Vencord/assets/26598490/192ddac0-c827-472f-9933-fa99ff36f723)

--- a/src/plugins/themeAttributes/README.md
+++ b/src/plugins/themeAttributes/README.md
@@ -1,6 +1,6 @@
 # ThemeAttributes
 
-This plugin adds data attributes to various elements inside Discord
+This plugin adds data attributes and CSS variables to various elements inside Discord
 
 This allows themes to more easily theme those elements or even do things that otherwise wouldn't be possible
 
@@ -19,3 +19,11 @@ This allows themes to more easily theme those elements or even do things that ot
 - `data-is-self` is a boolean indicating whether this is the current user's message
 
 ![image](https://github.com/Vendicated/Vencord/assets/45497981/34bd5053-3381-402f-82b2-9c812cc7e122)
+
+## CSS Variables
+
+### Avatars
+
+`--large-avatar-url` contains a URL for the users avatar with the size attribute adjusted.
+
+![image](https://github.com/Vendicated/Vencord/assets/26598490/b86d05ea-3a49-4cfa-8d2f-6c4ed390cf4c)

--- a/src/plugins/themeAttributes/index.ts
+++ b/src/plugins/themeAttributes/index.ts
@@ -13,7 +13,7 @@ import { Message } from "discord-types/general";
 const settings = definePluginSettings({
     imgSize: {
         type: OptionType.SELECT,
-        description: "The resolution of the avatar image",
+        description: "The resolution of the image in the --large-avatar-url CSS variable",
         options: ["300", "512", "1024", "2048", "4096"].map(n => ({ label: n, value: n, default: n === "300" })),
 
     }
@@ -46,12 +46,21 @@ export default definePlugin({
             }
         },
 
-        // add large-avatar-url to the img element in the avatarstack component
+        // add --large-avatar-url css variable to avatar img elements
+        // popout profiles
         {
             find: ".LABEL_WITH_ONLINE_STATUS",
             replacement: {
                 match: /(src:null!=\i\?(\i).{1,50}"aria-hidden":!0)/,
-                replace: "$1,\"style\":{\"--large-avatar-url\":\"url(\"+$2.replace(/\\d+$/,$self.settings.store.imgSize)+\")\"}"
+                replace: "$1,style:{\"--large-avatar-url\":\"url(\"+$2.replace(/\\d+$/,$self.settings.store.imgSize)+\")\"}"
+            }
+        },
+        // chat avatars
+        {
+            find: "showCommunicationDisabledStyles",
+            replacement: {
+                match: /(src:(\i),"aria-hidden":!0)/,
+                replace: "$1,style:{\"--large-avatar-url\":\"url(\"+$2.replace(/\\d+$/,$self.settings.store.imgSize)+\")\"}"
             }
         }
     ],

--- a/src/plugins/themeAttributes/index.ts
+++ b/src/plugins/themeAttributes/index.ts
@@ -51,16 +51,16 @@ export default definePlugin({
         {
             find: ".LABEL_WITH_ONLINE_STATUS",
             replacement: {
-                match: /(src:null!=\i\?(\i).{1,50}"aria-hidden":!0)/,
-                replace: "$1,style:{\"--large-avatar-url\":\"url(\"+$2.replace(/\\d+$/,$self.settings.store.imgSize)+\")\"}"
+                match: /src:null!=\i\?(\i).{1,50}"aria-hidden":!0/,
+                replace: "$&,style:{\"--large-avatar-url\":\"url(\"+$1.replace(/\\d+$/,$self.settings.store.imgSize)+\")\"}"
             }
         },
         // chat avatars
         {
             find: "showCommunicationDisabledStyles",
             replacement: {
-                match: /(src:(\i),"aria-hidden":!0)/,
-                replace: "$1,style:{\"--large-avatar-url\":\"url(\"+$2.replace(/\\d+$/,$self.settings.store.imgSize)+\")\"}"
+                match: /src:(\i),"aria-hidden":!0/,
+                replace: "$&,style:{\"--large-avatar-url\":\"url(\"+$1.replace(/\\d+$/,$self.settings.store.imgSize)+\")\"}"
             }
         }
     ],

--- a/src/plugins/themeAttributes/index.ts
+++ b/src/plugins/themeAttributes/index.ts
@@ -35,7 +35,7 @@ export default definePlugin({
             }
         },
 
-        // add --large-avatar-url css variable to avatar img elements
+        // add --avatar-url-<resolution> css variable to avatar img elements
         // popout profiles
         {
             find: ".LABEL_WITH_ONLINE_STATUS",

--- a/src/plugins/themeAttributes/index.ts
+++ b/src/plugins/themeAttributes/index.ts
@@ -55,8 +55,11 @@ export default definePlugin({
     ],
 
     getAvatarStyles(src: string) {
-        return Object.fromEntries([128, 256, 512, 1024, 2048, 4096]
-            .map(size => [`--avatar-url-${size}`, `url(${src.replace(/\d+$/, size.toString())})`])
+        return Object.fromEntries(
+            [128, 256, 512, 1024, 2048, 4096].map(size => [
+                `--avatar-url-${size}`,
+                `url(${src.replace(/\d+$/, String(size))})`
+            ])
         );
     },
 

--- a/src/plugins/themeAttributes/index.ts
+++ b/src/plugins/themeAttributes/index.ts
@@ -4,15 +4,27 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
-import definePlugin from "@utils/types";
+import definePlugin, { OptionType } from "@utils/types";
 import { UserStore } from "@webpack/common";
 import { Message } from "discord-types/general";
+
+const settings = definePluginSettings({
+    imgSize: {
+        type: OptionType.SELECT,
+        description: "The resolution of the avatar image",
+        options: ["300", "512", "1024", "2048", "4096"].map(n => ({ label: n, value: n, default: n === "300" })),
+
+    }
+});
 
 export default definePlugin({
     name: "ThemeAttributes",
     description: "Adds data attributes to various elements for theming purposes",
-    authors: [Devs.Ven],
+    authors: [Devs.Ven, Devs.Board],
+
+    settings,
 
     patches: [
         // Add data-tab-id to all tab bar items
@@ -31,6 +43,15 @@ export default definePlugin({
             replacement: {
                 match: /\.messageListItem(?=,"aria)/,
                 replace: "$&,...$self.getMessageProps(arguments[0])"
+            }
+        },
+
+        // add large-avatar-url to the img element in the avatarstack component
+        {
+            find: ".LABEL_WITH_ONLINE_STATUS",
+            replacement: {
+                match: /(src:null!=\i\?(\i).{1,50}"aria-hidden":!0)/,
+                replace: "$1,\"large-avatar-url\":$2.replace(/\\d+$/,$self.settings.store.imgSize)"
             }
         }
     ],

--- a/src/plugins/themeAttributes/index.ts
+++ b/src/plugins/themeAttributes/index.ts
@@ -51,7 +51,7 @@ export default definePlugin({
             find: ".LABEL_WITH_ONLINE_STATUS",
             replacement: {
                 match: /(src:null!=\i\?(\i).{1,50}"aria-hidden":!0)/,
-                replace: "$1,\"large-avatar-url\":$2.replace(/\\d+$/,$self.settings.store.imgSize)"
+                replace: "$1,\"style\":{\"--large-avatar-url\":\"url(\"+$2.replace(/\\d+$/,$self.settings.store.imgSize)+\")\"}"
             }
         }
     ],

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -382,6 +382,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "ant0n",
         id: 145224646868860928n
     },
+    Board: {
+        name: "Board",
+        id: 285475344817848320n,
+    },
     philipbry: {
         name: "philipbry",
         id: 554994003318276106n

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -383,7 +383,7 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         id: 145224646868860928n
     },
     Board: {
-        name: "Board",
+        name: "BoardTM",
         id: 285475344817848320n,
     },
     philipbry: {


### PR DESCRIPTION
As was advised in https://github.com/Vendicated/Vencord/pull/1976 I have now made an addition to the ThemeAttributes plugin.
![image](https://github.com/Vendicated/Vencord/assets/26598490/1dad594e-37b0-4224-928b-110492aa0ea2)
![image](https://github.com/Vendicated/Vencord/assets/26598490/7ceec140-97a8-437c-ae26-fe1b317856e7)
The plugin now adds a CSS variable called --large-avatar-url to the img element in the AvatarStack discord uses for the profile pop-outs. This can be used in themes that want to make the profile picture larger without losing image quality as a consequence.