### PR TITLE
[Plugin] ReplaceGoogleSearch

### DIFF
--- a/src/plugins/ReplaceGoogleSearch/index.tsx
+++ b/src/plugins/ReplaceGoogleSearch/index.tsx
@@ -68,7 +68,7 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "ReplaceGoogleSearch",
-    description: "Replaces the Google search with difrent Engines",
+    description: "Replaces the Google search with different Engines",
     authors: [
         Devs.Moxxie,
         Devs.Ethan
@@ -76,7 +76,7 @@ export default definePlugin({
 
     getUrl: (): Engine => {
         if (settings.store.engine) {
-            if(settings.store.useCustomEngine) {
+            if (settings.store.useCustomEngine) {
                 return { name: settings.store.engineName, url: settings.store.engineUrl };
             }
 

--- a/src/plugins/ReplaceGoogleSearch/index.tsx
+++ b/src/plugins/ReplaceGoogleSearch/index.tsx
@@ -1,0 +1,108 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+interface Engine {
+    name: string;
+    url: string;
+}
+
+const Engines = {
+    Google: "https://www.google.com/search?q=",
+    DuckDuckGo: "https://duckduckgo.com/",
+    Bing: "https://www.bing.com/search?q=",
+    Yahoo: "https://search.yahoo.com/search?p=",
+    Github: "https://github.com/search?q=",
+    Kagi: "https://kagi.com/search?q=",
+    Yandex: "https://yandex.com/search/?text=",
+    AOL: "https://search.aol.com/aol/search?q=",
+    Baidu: "https://www.baidu.com/s?wd=",
+    Wikipedia: "https://wikipedia.org/w/index.php?search=",
+} as const;
+
+const settings = definePluginSettings({
+    engine: {
+        description: "Choose one of the default search engines to replace Google with",
+        type: OptionType.SELECT,
+        options: Object.keys(Engines).map((engine => ({
+            label: engine,
+            value: engine
+        })))
+    },
+    useCustomEngine: {
+        description: "Use a custom search engine",
+        type: OptionType.BOOLEAN,
+        default: false
+    },
+    engineName: {
+        description: "",
+        type: OptionType.STRING,
+        default: "",
+        placeholder: "Enter the name of the custom search engine",
+    },
+    engineUrl: {
+        description: "",
+        type: OptionType.STRING,
+        default: "https://",
+        placeholder: "Enter the URL of the custom search engine",
+    }
+});
+
+export default definePlugin({
+    name: "ReplaceGoogleSearch",
+    description: "Replaces the Google search with difrent Engines",
+    authors: [
+        Devs.Moxxie,
+        Devs.Ethan
+    ],
+
+    getUrl: (): Engine => {
+        if (settings.store.engine) {
+            if(settings.store.useCustomEngine) {
+                return { name: settings.store.engineName, url: settings.store.engineUrl };
+            }
+
+            const engine = settings.store.engine as keyof typeof Engines;
+            return { name: engine, url: Engines[engine] };
+        }
+
+        return { name: "Google", url: Engines.Google };
+    },
+
+    settings,
+
+    patches: [
+        {
+            find: "\"text cannot be null\"",
+            replacement: {
+                match: /label:\i.default.Messages.SEARCH_WITH_GOOGLE,/,
+                replace: "label:\"Search with \"+$self.getUrl().name,"
+            }
+        },
+        {
+            find: "\"text cannot be null\"",
+            replacement: {
+                match: /window.open\("https:\/\/www.google.com\/search\?q="/,
+                replace: "window.open($self.getUrl().url"
+            }
+        }
+    ],
+});

--- a/src/plugins/ReplaceGoogleSearch/index.tsx
+++ b/src/plugins/ReplaceGoogleSearch/index.tsx
@@ -10,11 +10,6 @@ import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { Flex, Menu } from "@webpack/common";
 
-interface Engine {
-    name: string;
-    url: string;
-}
-
 const DefaultEngines = {
     Google: "https://www.google.com/search?q=",
     DuckDuckGo: "https://duckduckgo.com/",
@@ -88,15 +83,16 @@ function makeSearchItem(src: string) {
     );
 }
 
-
 const messageContextMenuPatch: NavContextMenuPatchCallback = (children, _props) => {
     const selection = document.getSelection()?.toString();
     if (!selection) return;
 
-    const group = findGroupChildrenByChildId("copy", children);
-    group?.push(makeSearchItem(selection));
+    const group = findGroupChildrenByChildId("search-google", children);
+    if (group) {
+        const idx = group.findIndex(c => c?.props?.id === "search-google");
+        if (idx !== -1) group[idx] = makeSearchItem(selection);
+    }
 };
-
 
 export default definePlugin({
     name: "ReplaceGoogleSearch",
@@ -104,17 +100,6 @@ export default definePlugin({
     authors: [Devs.Moxxie, Devs.Ethan],
 
     settings,
-
-
-    patches: [
-        {
-            find: "\"text cannot be null\"",
-            replacement: {
-                match: /\[\(0,\i.jsx\)\(\i.MenuItem,\{id:"search-google",label:\i.default.Messages.SEARCH_WITH_GOOGLE,action:t},"search-google"\)\]/,
-                replace: "null"
-            }
-        }
-    ],
 
     contextMenus: {
         "message": messageContextMenuPatch

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -473,7 +473,15 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     ImBanana: {
         name: "Im_Banana",
         id: 635250116688871425n
-    }
+    },
+    Moxxie: {
+        name: "Moxxie",
+        id: 712653921692155965n,
+    },
+    Ethan: {
+        name: "Ethan",
+        id: 721717126523781240n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -474,6 +474,14 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Im_Banana",
         id: 635250116688871425n
     },
+    xocherry: {
+        name: "xocherry",
+        id: 221288171013406720n
+    },
+    ScattrdBlade: {
+        name: "ScattrdBlade",
+        id: 678007540608532491n
+    },
     Moxxie: {
         name: "Moxxie",
         id: 712653921692155965n,


### PR DESCRIPTION
## ReplaceGoogleSearch
This plugin implements a patch to replace the "Search with Google" in the context menu when right clicking on a highlighted word. You can this engine with the dropdown menu in the settings which gives you the options Google, Bing, Yahoo, Github, Kagi, Yandex, AOL, Baidu and Wikipedia. Alternatively, you can enable the "Use Custom Search Engine" option in the settings to use an alternate engine.

<details>
    <summary><strong>Screenshots</strong></summary>
    <img src="https://i.imgur.com/g3ptYvS.png" />
    <img src="https://i.imgur.com/Y56p7VY.png" />
</details>