### PR TITLE
Fix: PetPet Plugin's Upload Image Option

### DIFF
--- a/src/plugins/crashHandler/index.ts
+++ b/src/plugins/crashHandler/index.ts
@@ -135,8 +135,11 @@ export default definePlugin({
         try {
             const channelId = SelectedChannelStore.getChannelId();
 
-            DraftManager.clearDraft(channelId, DraftType.ChannelMessage);
-            DraftManager.clearDraft(channelId, DraftType.FirstThreadMessage);
+            for (const key in DraftType) {
+                if (!Number.isNaN(Number(key))) continue;
+
+                DraftManager.clearDraft(channelId, DraftType[key]);
+            }
         } catch (err) {
             CrashHandlerLogger.debug("Failed to clear drafts.", err);
         }

--- a/src/plugins/crashHandler/index.ts
+++ b/src/plugins/crashHandler/index.ts
@@ -24,22 +24,20 @@ import { closeAllModals } from "@utils/modal";
 import definePlugin, { OptionType } from "@utils/types";
 import { maybePromptToUpdate } from "@utils/updater";
 import { filters, findBulk, proxyLazyWebpack } from "@webpack";
-import { FluxDispatcher, NavigationRouter, SelectedChannelStore } from "@webpack/common";
+import { DraftType, FluxDispatcher, NavigationRouter, SelectedChannelStore } from "@webpack/common";
 
 const CrashHandlerLogger = new Logger("CrashHandler");
-const { ModalStack, DraftManager, DraftType, closeExpressionPicker } = proxyLazyWebpack(() => {
-    const modules = findBulk(
+
+const { ModalStack, DraftManager, closeExpressionPicker } = proxyLazyWebpack(() => {
+    const [ModalStack, DraftManager, ExpressionManager] = findBulk(
         filters.byProps("pushLazy", "popAll"),
         filters.byProps("clearDraft", "saveDraft"),
-        filters.byProps("DraftType"),
-        filters.byProps("closeExpressionPicker", "openExpressionPicker"),
-    );
+        filters.byProps("closeExpressionPicker", "openExpressionPicker"),);
 
     return {
-        ModalStack: modules[0],
-        DraftManager: modules[1],
-        DraftType: modules[2]?.DraftType,
-        closeExpressionPicker: modules[3]?.closeExpressionPicker,
+        ModalStack,
+        DraftManager,
+        closeExpressionPicker: ExpressionManager?.closeExpressionPicker,
     };
 });
 

--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -24,13 +24,12 @@ import { getCurrentGuild } from "@utils/discord";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy, findStoreLazy, proxyLazyWebpack } from "@webpack";
-import { Alerts, ChannelStore, EmojiStore, FluxDispatcher, Forms, IconUtils, lodash, Parser, PermissionsBits, PermissionStore, UploadHandler, UserSettingsActionCreators, UserStore } from "@webpack/common";
+import { Alerts, ChannelStore, DraftType, EmojiStore, FluxDispatcher, Forms, IconUtils, lodash, Parser, PermissionsBits, PermissionStore, UploadHandler, UserSettingsActionCreators, UserStore } from "@webpack/common";
 import type { CustomEmoji } from "@webpack/types";
 import type { Message } from "discord-types/general";
 import { applyPalette, GIFEncoder, quantize } from "gifenc";
 import type { ReactElement, ReactNode } from "react";
 
-const DRAFT_TYPE = 0;
 const StickerStore = findStoreLazy("StickersStore") as {
     getPremiumPacks(): StickerPack[];
     getAllGuildStickers(): Map<string, Sticker[]>;
@@ -807,7 +806,7 @@ export default definePlugin({
         gif.finish();
 
         const file = new File([gif.bytesView()], `${stickerId}.gif`, { type: "image/gif" });
-        UploadHandler.promptToUpload([file], ChannelStore.getChannel(channelId), DRAFT_TYPE);
+        UploadHandler.promptToUpload([file], ChannelStore.getChannel(channelId), DraftType.ChannelMessage);
     },
 
     canUseEmote(e: CustomEmoji, channelId: string) {

--- a/src/plugins/petpet/index.ts
+++ b/src/plugins/petpet/index.ts
@@ -21,7 +21,7 @@ import { Devs } from "@utils/constants";
 import { makeLazy } from "@utils/lazy";
 import definePlugin from "@utils/types";
 import { findByPropsLazy } from "@webpack";
-import { DraftType, UploadHandler, UploadModule, UserUtils } from "@webpack/common";
+import { DraftType, UploadHandler, UploadManager, UserUtils } from "@webpack/common";
 import { applyPalette, GIFEncoder, quantize } from "gifenc";
 
 const DEFAULT_DELAY = 20;
@@ -61,7 +61,7 @@ async function resolveImage(options: Argument[], ctx: CommandContext, noServerPf
                 const upload = UploadStore.getUpload(ctx.channel.id, opt.name, DraftType.SlashCommand);
                 if (upload) {
                     if (!upload.isImage) {
-                        UploadModule.clearAll(ctx.channel.id, DraftType.SlashCommand);
+                        UploadManager.clearAll(ctx.channel.id, DraftType.SlashCommand);
                         throw "Upload is not an image";
                     }
                     return upload.item.file;
@@ -75,12 +75,12 @@ async function resolveImage(options: Argument[], ctx: CommandContext, noServerPf
                     return user.getAvatarURL(noServerPfp ? void 0 : ctx.guild?.id, 2048).replace(/\?size=\d+$/, "?size=2048");
                 } catch (err) {
                     console.error("[petpet] Failed to fetch user\n", err);
-                    UploadModule.clearAll(ctx.channel.id, DraftType.SlashCommand);
+                    UploadManager.clearAll(ctx.channel.id, DraftType.SlashCommand);
                     throw "Failed to fetch user. Check the console for more info.";
                 }
         }
     }
-    UploadModule.clearAll(ctx.channel.id, DraftType.SlashCommand);
+    UploadManager.clearAll(ctx.channel.id, DraftType.SlashCommand);
     return null;
 }
 
@@ -134,7 +134,7 @@ export default definePlugin({
                     var url = await resolveImage(opts, cmdCtx, noServerPfp);
                     if (!url) throw "No Image specified!";
                 } catch (err) {
-                    UploadModule.clearAll(cmdCtx.channel.id, DraftType.SlashCommand);
+                    UploadManager.clearAll(cmdCtx.channel.id, DraftType.SlashCommand);
                     sendBotMessage(cmdCtx.channel.id, {
                         content: String(err),
                     });
@@ -152,7 +152,7 @@ export default definePlugin({
                 canvas.width = canvas.height = resolution;
                 const ctx = canvas.getContext("2d")!;
 
-                UploadModule.clearAll(cmdCtx.channel.id, DraftType.SlashCommand);
+                UploadManager.clearAll(cmdCtx.channel.id, DraftType.SlashCommand);
 
                 for (let i = 0; i < FRAMES; i++) {
                     ctx.clearRect(0, 0, canvas.width, canvas.height);

--- a/src/plugins/petpet/index.ts
+++ b/src/plugins/petpet/index.ts
@@ -21,10 +21,9 @@ import { Devs } from "@utils/constants";
 import { makeLazy } from "@utils/lazy";
 import definePlugin from "@utils/types";
 import { findByPropsLazy } from "@webpack";
-import { UploadHandler, UserUtils } from "@webpack/common";
+import { DraftType, UploadHandler, UploadModule, UserUtils } from "@webpack/common";
 import { applyPalette, GIFEncoder, quantize } from "gifenc";
 
-const DRAFT_TYPE = 0;
 const DEFAULT_DELAY = 20;
 const DEFAULT_RESOLUTION = 128;
 const FRAMES = 10;
@@ -59,9 +58,12 @@ async function resolveImage(options: Argument[], ctx: CommandContext, noServerPf
     for (const opt of options) {
         switch (opt.name) {
             case "image":
-                const upload = UploadStore.getUploads(ctx.channel.id, DRAFT_TYPE)[0];
+                const upload = UploadStore.getUpload(ctx.channel.id, opt.name, DraftType.SlashCommand);
                 if (upload) {
-                    if (!upload.isImage) throw "Upload is not an image";
+                    if (!upload.isImage) {
+                        UploadModule.clearAll(ctx.channel.id, DraftType.SlashCommand);
+                        throw "Upload is not an image";
+                    }
                     return upload.item.file;
                 }
                 break;
@@ -73,10 +75,12 @@ async function resolveImage(options: Argument[], ctx: CommandContext, noServerPf
                     return user.getAvatarURL(noServerPfp ? void 0 : ctx.guild?.id, 2048).replace(/\?size=\d+$/, "?size=2048");
                 } catch (err) {
                     console.error("[petpet] Failed to fetch user\n", err);
+                    UploadModule.clearAll(ctx.channel.id, DraftType.SlashCommand);
                     throw "Failed to fetch user. Check the console for more info.";
                 }
         }
     }
+    UploadModule.clearAll(ctx.channel.id, DraftType.SlashCommand);
     return null;
 }
 
@@ -130,6 +134,7 @@ export default definePlugin({
                     var url = await resolveImage(opts, cmdCtx, noServerPfp);
                     if (!url) throw "No Image specified!";
                 } catch (err) {
+                    UploadModule.clearAll(cmdCtx.channel.id, DraftType.SlashCommand);
                     sendBotMessage(cmdCtx.channel.id, {
                         content: String(err),
                     });
@@ -146,6 +151,8 @@ export default definePlugin({
                 const canvas = document.createElement("canvas");
                 canvas.width = canvas.height = resolution;
                 const ctx = canvas.getContext("2d")!;
+
+                UploadModule.clearAll(cmdCtx.channel.id, DraftType.SlashCommand);
 
                 for (let i = 0; i < FRAMES; i++) {
                     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -174,7 +181,7 @@ export default definePlugin({
                 const file = new File([gif.bytesView()], "petpet.gif", { type: "image/gif" });
                 // Immediately after the command finishes, Discord clears all input, including pending attachments.
                 // Thus, setTimeout is needed to make this execute after Discord cleared the input
-                setTimeout(() => UploadHandler.promptToUpload([file], cmdCtx.channel, DRAFT_TYPE), 10);
+                setTimeout(() => UploadHandler.promptToUpload([file], cmdCtx.channel, DraftType.ChannelMessage), 10);
             },
         },
     ]

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -477,7 +477,11 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     xocherry: {
         name: "xocherry",
         id: 221288171013406720n
-    }
+    },
+    ScattrdBlade: {
+        name: "ScattrdBlade",
+        id: 678007540608532491n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/webpack/common/stores.ts
+++ b/src/webpack/common/stores.ts
@@ -29,8 +29,6 @@ export type GenericStore = t.FluxStore & Record<string, any>;
 
 export const { DraftType }: { DraftType: typeof t.DraftType; } = findByPropsLazy("DraftType");
 
-export const UploadModule = findByPropsLazy("clearAll");
-
 export let MessageStore: Omit<Stores.MessageStore, "getMessages"> & {
     getMessages(chanId: string): any;
 };

--- a/src/webpack/common/stores.ts
+++ b/src/webpack/common/stores.ts
@@ -27,12 +27,9 @@ export const Flux: t.Flux = findByPropsLazy("connectStores");
 
 export type GenericStore = t.FluxStore & Record<string, any>;
 
-export enum DraftType {
-    ChannelMessage = 0,
-    ThreadSettings = 1,
-    FirstThreadMessage = 2,
-    ApplicationLauncherCommand = 3
-}
+export const { DraftType }: { DraftType: typeof t.DraftType; } = findByPropsLazy("DraftType");
+
+export const UploadModule = findByPropsLazy("clearAll");
 
 export let MessageStore: Omit<Stores.MessageStore, "getMessages"> & {
     getMessages(chanId: string): any;

--- a/src/webpack/common/types/stores.d.ts
+++ b/src/webpack/common/types/stores.d.ts
@@ -173,6 +173,15 @@ export class DraftStore extends FluxStore {
     getThreadSettings(channelId: string): any | null;
 }
 
+export declare enum DraftType {
+    ChannelMessage,
+    ThreadSettings,
+    FirstThreadMessage,
+    ApplicationLauncherCommand,
+    Poll,
+    SlashCommand,
+}
+
 export class GuildStore extends FluxStore {
     getGuild(guildId: string): Guild;
     getGuildCount(): number;

--- a/src/webpack/common/types/stores.d.ts
+++ b/src/webpack/common/types/stores.d.ts
@@ -173,7 +173,7 @@ export class DraftStore extends FluxStore {
     getThreadSettings(channelId: string): any | null;
 }
 
-export declare enum DraftType {
+export enum DraftType {
     ChannelMessage,
     ThreadSettings,
     FirstThreadMessage,

--- a/src/webpack/common/utils.ts
+++ b/src/webpack/common/utils.ts
@@ -119,6 +119,8 @@ export function showToast(message: string, type = ToastType.MESSAGE) {
 }
 
 export const UserUtils = findByPropsLazy("getUser", "fetchCurrentUser") as { getUser: (id: string) => Promise<User>; };
+
+export const UploadManager = findByPropsLazy("clearAll", "addFile");
 export const UploadHandler = findByPropsLazy("showUploadFileSizeExceededError", "promptToUpload") as {
     promptToUpload: (files: File[], channel: Channel, draftType: Number) => void;
 };

--- a/src/webpack/webpack.ts
+++ b/src/webpack/webpack.ts
@@ -432,7 +432,7 @@ export async function extractAndLoadChunks(code: string[], matcher: RegExp = Def
     }
 
     const [, rawChunkIds, entryPointId] = match;
-    if (Number.isNaN(entryPointId)) {
+    if (Number.isNaN(Number(entryPointId))) {
         const err = new Error("extractAndLoadChunks: Matcher didn't return a capturing group with the chunk ids array, or the entry point id returned as the second group wasn't a number");
         logger.warn(err, "Code:", code, "Matcher:", matcher);
 


### PR DESCRIPTION
The image option for the PetPet command has not been working for about 5 months now, as noted in the closed #2070 pull request. This finally fixes it so it actually works again. This also includes clearing the slash command draft after you run it, so if you run the slash command again, the previously uploaded file from the previous slash command run will not be there in the upload area. The code to clear draft is placed in more than one area within PetPet's code to make sure the slash command draft is cleared even if the command fails and such. Also made DraftType use webpack common and implemented it into the `fakeNitro` and `crashHandler` plugins. Along with DraftType, I also added UploadModule (which is the thing that allows draft clear to happen) to webpack common to make it easier for future use.