### PR TITLE
fix: Plugins without start/stop function failing to stop/start

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -170,7 +170,9 @@ export const startPlugin = traceFunction("startPlugin", function startPlugin(p: 
             return false;
         }
     }
+
     p.started = true;
+
     if (commands?.length) {
         logger.debug("Registering commands of plugin", name);
         for (const cmd of commands) {
@@ -200,6 +202,7 @@ export const startPlugin = traceFunction("startPlugin", function startPlugin(p: 
 
 export const stopPlugin = traceFunction("stopPlugin", function stopPlugin(p: Plugin) {
     const { name, commands, flux, contextMenus } = p;
+
     if (p.stop) {
         logger.info("Stopping plugin", name);
         if (!p.started) {
@@ -213,6 +216,7 @@ export const stopPlugin = traceFunction("stopPlugin", function stopPlugin(p: Plu
             return false;
         }
     }
+
     p.started = false;
 
     if (commands?.length) {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -165,13 +165,12 @@ export const startPlugin = traceFunction("startPlugin", function startPlugin(p: 
         }
         try {
             p.start();
-            p.started = true;
         } catch (e) {
             logger.error(`Failed to start ${name}\n`, e);
             return false;
         }
     }
-
+    p.started = true;
     if (commands?.length) {
         logger.debug("Registering commands of plugin", name);
         for (const cmd of commands) {
@@ -209,12 +208,12 @@ export const stopPlugin = traceFunction("stopPlugin", function stopPlugin(p: Plu
         }
         try {
             p.stop();
-            p.started = false;
         } catch (e) {
             logger.error(`Failed to stop ${name}\n`, e);
             return false;
         }
     }
+    p.started = false;
 
     if (commands?.length) {
         logger.debug("Unregistering commands of plugin", name);


### PR DESCRIPTION
Fixes #2462 

the issue mentioned above applies to all plugins without a start/stop function defined (like MoreKaomoji)

this occurs because the `stopPlugin` and `startPlugin` functions in plugins/index.ts rely on a stop/start function being defined respectively

so when I disable VcNarrator, p.started will still be true bc VcNarrator doesn't have a stop() function defined

then when i try to enable it again, it'll error bc it thinks it's already started

fix is to move the `p.started = true/false` to after that if statement

this way if start() errored then it'll return early and won't set p.started (so everything else should still work as intended)