### PR TITLE
feat(ViewIcons): Group & User DMs icons support

### DIFF
--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -172,7 +172,7 @@ const GroupDMContext: NavContextMenuPatchCallback = (children, { channel }: Grou
 export default definePlugin({
     name: "ViewIcons",
     authors: [Devs.Ven, Devs.TheKodeToad, Devs.Nuckyz, Devs.nyx],
-    description: "Makes avatars and banners in user profiles clickable, adds View Icon/Banner entries in the user and server context menu, and adds View Icon entry in the group channel context menu.",
+    description: "Makes avatars and banners in user profiles clickable, adds View Icon/Banner entries in the user, server and group channel context menu.",
     tags: ["ImageUtilities"],
 
     settings,

--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -152,9 +152,6 @@ const GuildContext: NavContextMenuPatchCallback = (children, { guild }: GuildCon
 const GroupDMContext: NavContextMenuPatchCallback = (children, { channel }: GroupDMContextProps) => {
     if (!channel) return;
 
-    const { icon } = channel;
-    if (!icon) return;
-
     children.splice(-1, 0, (
         <Menu.MenuGroup>
             <Menu.MenuItem
@@ -186,7 +183,7 @@ export default definePlugin({
     },
 
     patches: [
-        // Make pfps clickable
+        // Profiles Modal pfp
         {
             find: "User Profile Modal - Context Menu",
             replacement: {
@@ -194,7 +191,7 @@ export default definePlugin({
                 replace: "{src:$1,onClick:()=>$self.openImage($1)"
             }
         },
-        // Make banners clickable
+        // Banners
         {
             find: ".NITRO_BANNER,",
             replacement: {
@@ -205,11 +202,37 @@ export default definePlugin({
                     'onClick:ev=>$1&&ev.target.style.backgroundImage&&$self.openImage($2),style:{cursor:$1?"pointer":void 0,'
             }
         },
+        // User DMs "User Profile" popup in the right
         {
             find: ".avatarPositionPanel",
             replacement: {
                 match: /(?<=avatarWrapperNonUserBot.{0,50})onClick:(\i\|\|\i)\?void 0(?<=,avatarSrc:(\i).+?)/,
                 replace: "style:($1)?{cursor:\"pointer\"}:{},onClick:$1?()=>{$self.openImage($2)}"
+            }
+        },
+        // Group DMs top small & large icon
+        {
+            find: ".recipients.length>=2",
+            all: true,
+            replacement: {
+                match: /null==\i\.icon\?.+?src:(\(0,\i\.getChannelIconURL\).+?\))(?=[,}])/,
+                replace: (m, iconUrl) => `${m},onClick:()=>$self.openImage(${iconUrl})`
+            }
+        },
+        // User DMs top small icon
+        {
+            find: /HiddenVisually,{children:\i\.\i\.Messages\.DIRECT_MESSAGE/,
+            replacement: {
+                match: /.Avatar,.+?src:(.+?\))(?=[,}])/,
+                replace: (m, avatarUrl) => `${m},onClick:()=>$self.openImage(${avatarUrl})`
+            }
+        },
+        // User Dms top large icon
+        {
+            find: 'experimentLocation:"empty_messages"',
+            replacement: {
+                match: /.Avatar,.+?src:(.+?\))(?=[,}])/,
+                replace: (m, avatarUrl) => `${m},onClick:()=>$self.openImage(${avatarUrl})`
             }
         }
     ]

--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -36,6 +36,10 @@ interface GuildContextProps {
     guild?: Guild;
 }
 
+interface GroupDMContextProps {
+    channel: Channel;
+}
+
 const settings = definePluginSettings({
     format: {
         type: OptionType.SELECT,
@@ -145,10 +149,30 @@ const GuildContext: NavContextMenuPatchCallback = (children, { guild }: GuildCon
     ));
 };
 
+const GroupDMContext: NavContextMenuPatchCallback = (children, { channel }: GroupDMContextProps) => {
+    if (!channel) return;
+
+    const { icon } = channel;
+    if (!icon) return;
+
+    children.splice(-1, 0, (
+        <Menu.MenuGroup>
+            <Menu.MenuItem
+                id="view-icon"
+                label="View Icon"
+                action={() =>
+                    openImage(IconUtils.getChannelIconURL(channel)!)
+                }
+                icon={ImageIcon}
+            />
+        </Menu.MenuGroup>
+    ));
+};
+
 export default definePlugin({
     name: "ViewIcons",
-    authors: [Devs.Ven, Devs.TheKodeToad, Devs.Nuckyz],
-    description: "Makes avatars and banners in user profiles clickable, and adds View Icon/Banner entries in the user and server context menu",
+    authors: [Devs.Ven, Devs.TheKodeToad, Devs.Nuckyz, Devs.nyx],
+    description: "Makes avatars and banners in user profiles clickable, adds View Icon/Banner entries in the user and server context menu, and adds View Icon entry in the group channel context menu.",
     tags: ["ImageUtilities"],
 
     settings,
@@ -157,7 +181,8 @@ export default definePlugin({
 
     contextMenus: {
         "user-context": UserContext,
-        "guild-context": GuildContext
+        "guild-context": GuildContext,
+        "gdm-context": GroupDMContext
     },
 
     patches: [

--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -158,7 +158,7 @@ const GroupDMContext: NavContextMenuPatchCallback = (children, { channel }: Grou
     children.splice(-1, 0, (
         <Menu.MenuGroup>
             <Menu.MenuItem
-                id="view-icon"
+                id="view-group-channel-icon"
                 label="View Icon"
                 action={() =>
                     openImage(IconUtils.getChannelIconURL(channel)!)

--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -158,7 +158,7 @@ const GroupDMContext: NavContextMenuPatchCallback = (children, { channel }: Grou
                 id="view-group-channel-icon"
                 label="View Icon"
                 action={() =>
-                    openImage(IconUtils.getChannelIconURL(channel)!)
+                    openImage(IconUtils.getChannelIconURL(channel))
                 }
                 icon={ImageIcon}
             />

--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -158,7 +158,7 @@ const GroupDMContext: NavContextMenuPatchCallback = (children, { channel }: Grou
                 id="view-group-channel-icon"
                 label="View Icon"
                 action={() =>
-                    openImage(IconUtils.getChannelIconURL(channel))
+                    openImage(IconUtils.getChannelIconURL(channel)!)
                 }
                 icon={ImageIcon}
             />

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -490,6 +490,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "ScattrdBlade",
         id: 678007540608532491n
     },
+    nyx: {
+        name: "verticalsync",
+        id: 328165170536775680n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/webpack/common/utils.ts
+++ b/src/webpack/common/utils.ts
@@ -147,4 +147,4 @@ export const MessageActions = findByPropsLazy("editMessage", "sendMessage");
 export const UserProfileActions = findByPropsLazy("openUserProfileModal", "closeUserProfileModal");
 export const InviteActions = findByPropsLazy("resolveInvite");
 
-export const IconUtils: t.IconUtils = findByPropsLazy("getGuildBannerURL", "getUserAvatarURL", "getChannelIconURL");
+export const IconUtils: t.IconUtils = findByPropsLazy("getGuildBannerURL", "getUserAvatarURL");

--- a/src/webpack/common/utils.ts
+++ b/src/webpack/common/utils.ts
@@ -147,4 +147,4 @@ export const MessageActions = findByPropsLazy("editMessage", "sendMessage");
 export const UserProfileActions = findByPropsLazy("openUserProfileModal", "closeUserProfileModal");
 export const InviteActions = findByPropsLazy("resolveInvite");
 
-export const IconUtils: t.IconUtils = findByPropsLazy("getGuildBannerURL", "getUserAvatarURL");
+export const IconUtils: t.IconUtils = findByPropsLazy("getGuildBannerURL", "getUserAvatarURL", "getChannelIconURL");


### PR DESCRIPTION
Lets you view the icon of group channel icons by adding an entry in the context menu called "View Icon".

![image](https://github.com/Vendicated/Vencord/assets/60797172/2f4d136a-d9ae-4d94-afbf-f47d43a1facb)
![image](https://github.com/Vendicated/Vencord/assets/60797172/f6e33cec-2e44-465d-8c49-a93cdef47a01)
