### PR TITLE
Fix: Resurrect Home Plugin's Cached Messages Bug

### DIFF
--- a/src/plugins/resurrectHome/index.tsx
+++ b/src/plugins/resurrectHome/index.tsx
@@ -134,8 +134,8 @@ export default definePlugin({
         {
             find: '"MessageActionCreators"',
             replacement: {
-                match: /(?<=focusMessage\(\i\){.+?)(?=focus:{messageId:(\i)})/,
-                replace: "before:$1,"
+                match: /(\i\.focusMessage\(\i\))\{.+?focus:{messageId:(\i)}/,
+                replace: "$1,cache:true,force:true,focus:{messageId:$2"
             }
         },
         // Force Server Home instead of Server Guide


### PR DESCRIPTION
This fixes a bug in the Resurrect Home plugin where recent messages would disappear, leaving only older and real-time messages visible when returning to a channel after viewing an old thread within it.

(I specifically discovered the bug when clicking on the [oldest thread](https://discord.com/channels/1015060230222131221/1059989000204583002) created in `#core-development` in the Vencord server, and then going back to the regular `#core-development` channel)