### PR TITLE
Cleanup: Add UploadStore to Webpack Common

### DIFF
--- a/src/plugins/petpet/index.ts
+++ b/src/plugins/petpet/index.ts
@@ -20,8 +20,7 @@ import { ApplicationCommandInputType, ApplicationCommandOptionType, Argument, Co
 import { Devs } from "@utils/constants";
 import { makeLazy } from "@utils/lazy";
 import definePlugin from "@utils/types";
-import { findByPropsLazy } from "@webpack";
-import { DraftType, UploadHandler, UploadManager, UserUtils } from "@webpack/common";
+import { DraftType, UploadHandler, UploadManager, UploadStore, UserUtils } from "@webpack/common";
 import { applyPalette, GIFEncoder, quantize } from "gifenc";
 
 const DEFAULT_DELAY = 20;
@@ -34,8 +33,6 @@ const getFrames = makeLazy(() => Promise.all(
         (_, i) => loadImage(`https://raw.githubusercontent.com/VenPlugs/petpet/main/frames/pet${i}.gif`)
     ))
 );
-
-const UploadStore = findByPropsLazy("getUploads");
 
 function loadImage(source: File | string) {
     const isFile = source instanceof File;

--- a/src/plugins/previewMessage/index.tsx
+++ b/src/plugins/previewMessage/index.tsx
@@ -20,11 +20,8 @@ import { addChatBarButton, ChatBarButton, removeChatBarButton } from "@api/ChatB
 import { generateId, sendBotMessage } from "@api/Commands";
 import { Devs } from "@utils/constants";
 import definePlugin, { StartAt } from "@utils/types";
-import { findByPropsLazy } from "@webpack";
-import { DraftStore, DraftType, SelectedChannelStore, UserStore, useStateFromStores } from "@webpack/common";
+import { DraftStore, DraftType, SelectedChannelStore, UploadStore, UserStore, useStateFromStores } from "@webpack/common";
 import { MessageAttachment } from "discord-types/general";
-
-const UploadStore = findByPropsLazy("getUploads");
 
 const getDraft = (channelId: string) => DraftStore.getDraft(channelId, DraftType.ChannelMessage);
 

--- a/src/webpack/common/utils.ts
+++ b/src/webpack/common/utils.ts
@@ -120,6 +120,7 @@ export function showToast(message: string, type = ToastType.MESSAGE) {
 
 export const UserUtils = findByPropsLazy("getUser", "fetchCurrentUser") as { getUser: (id: string) => Promise<User>; };
 
+export const UploadStore = findByPropsLazy("getUploads");
 export const UploadManager = findByPropsLazy("clearAll", "addFile");
 export const UploadHandler = findByPropsLazy("showUploadFileSizeExceededError", "promptToUpload") as {
     promptToUpload: (files: File[], channel: Channel, draftType: Number) => void;


### PR DESCRIPTION
Just thought a minor cleanup might be useful here since UploadManager and UploadHandler were already moved to Webpack Common. Ease of use for the future.