### PR TITLE
ShowHiddenThings: more effectively explode Algolia filters

### DIFF
--- a/src/plugins/showHiddenThings/index.ts
+++ b/src/plugins/showHiddenThings/index.ts
@@ -88,11 +88,11 @@ export default definePlugin({
             }
         },
         {
-            find: "\">200\"",
+            find: "MINIMUM_MEMBER_COUNT:",
             predicate: () => settings.store.disableDiscoveryFilters,
             replacement: {
-                match: /">200"/,
-                replace: "\">0\""
+                match: /MINIMUM_MEMBER_COUNT:function\(\)\{return \i}/,
+                replace: "MINIMUM_MEMBER_COUNT:() => \">0\""
             }
         },
         {

--- a/src/plugins/showHiddenThings/index.ts
+++ b/src/plugins/showHiddenThings/index.ts
@@ -80,11 +80,19 @@ export default definePlugin({
             }
         },
         {
-            find: "auto_removed:",
+            find: "prod_discoverable_guilds",
             predicate: () => settings.store.disableDiscoveryFilters,
             replacement: {
-                match: /filters:\i\.join\(" AND "\),facets:\[/,
-                replace: "facets:["
+                match: /\{"auto_removed:.*?\}/,
+                replace: "{}"
+            }
+        },
+        {
+            find: "\">200\"",
+            predicate: () => settings.store.disableDiscoveryFilters,
+            replacement: {
+                match: /">200"/,
+                replace: "\">0\""
             }
         },
         {


### PR DESCRIPTION
Current patch doesn't always work as there's multiple functions for fetching Algolia results, might be related to an experiment