### PR TITLE
Fix Alt + F4 on QuickCSS window closing all windows

### DIFF
--- a/src/main/ipcMain.ts
+++ b/src/main/ipcMain.ts
@@ -138,6 +138,12 @@ ipcMain.handle(IpcEvents.OPEN_MONACO_EDITOR, async () => {
             sandbox: false
         }
     });
+    win.webContents.on("before-input-event", (event, input) => {
+        if (input.alt && input.key === "F4") {
+            event.preventDefault();
+            win.close();
+        }
+    });
 
     makeLinksOpenExternally(win);
 


### PR DESCRIPTION
I think the expected behaviour should be that only the QuickCSS window gets closed when you press Alt + F4 while it is focused.

**Old behaviour:**
 Alt + F4 while the Quick CSS window is focused closes both the Quick CSS window and the main Discord window.
 **New behaviour:**
 Alt + F4 while the Quick CSS window is focused will only close the Quick CSS window.