### PR TITLE
feat(plugin): WakaTime submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/plugins/wakaTime"]
+	path = src/plugins/wakaTime
+	url = https://github.com/wakatime/vencord-wakatime.git


### PR DESCRIPTION
I have added a submodule to the user plugin officially supported by WakaTime, which was created by NeonGamerBot-QK.

I don't think this should require a DevBuild to install and will be much more accessible when added to the main repository. (I'm not affiliated in any way with this plugin or WakaTime. I'm only submitting a submodule pull request.)

Related: Plugin Request https://github.com/Vencord/plugin-requests/issues/369