### PR TITLE
ctrlEnterSend: use cmd+enter on macOS

### DIFF
--- a/src/plugins/ctrlEnterSend/index.ts
+++ b/src/plugins/ctrlEnterSend/index.ts
@@ -18,7 +18,7 @@ export default definePlugin({
             type: OptionType.SELECT,
             options: [
                 {
-                    label: "Ctrl+Enter (Enter or Shift+Enter for new line)",
+                    label: "Ctrl+Enter (Enter or Shift+Enter for new line) (cmd+enter on macOS)",
                     value: "ctrl+enter"
                 },
                 {
@@ -54,7 +54,7 @@ export default definePlugin({
                 result = event.shiftKey;
                 break;
             case "ctrl+enter":
-                result = event.ctrlKey;
+                result = process.platform === "darwin" ? event.metaKey : event.ctrlKey;
                 break;
             case "enter":
                 result = !event.shiftKey && !event.ctrlKey;


### PR DESCRIPTION
On macOS, the ctrl key is generally used as a secondary alt key for shortcuts. The cmd (⌘) key is the "main" modifier key, the equivalent of ctrl on windows/linux.