### PR TITLE
Plugin: DisableDiscordRestart

### DIFF
--- a/src/plugins/disableDiscordRestart/index.tsx
+++ b/src/plugins/disableDiscordRestart/index.tsx
@@ -1,0 +1,87 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import definePlugin, { OptionType } from "@utils/types";
+import { Devs } from "@utils/constants";
+
+import './styles.css';
+
+const settings = definePluginSettings({
+    showAlert: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Show alert when Ctrl + R is disabled",
+        restartNeeded: true,
+    },
+});
+
+const disableRestartShortcut = (event) => {
+    if (event.ctrlKey && event.key === 'r') {
+        event.preventDefault();
+        event.stopPropagation();
+        console.log("Ctrl + R shortcut disabled");
+        if (settings.store.showAlert) {
+            showAlertPopup("Ctrl + R shortcut disabled", "DisableDiscordRestart - Made by Burlone");
+        }
+    }
+};
+
+const showAlertPopup = (message, title) => {
+    const modal = document.createElement('div');
+    modal.classList.add('discord-popup');
+
+    const closeButton = document.createElement('button');
+    closeButton.textContent = 'Close';
+    closeButton.classList.add('discord-popup-close');
+    closeButton.addEventListener('click', () => {
+        document.body.removeChild(modal);
+    });
+
+    const messageElement = document.createElement('p');
+    messageElement.textContent = message;
+    messageElement.classList.add('discord-popup-message');
+
+    const titleElement = document.createElement('h2');
+    titleElement.textContent = title;
+    titleElement.classList.add('discord-popup-title');
+
+    modal.appendChild(closeButton);
+    modal.appendChild(titleElement);
+    modal.appendChild(messageElement);
+
+    document.body.appendChild(modal);
+};
+
+const startPlugin = () => {
+    document.addEventListener('keydown', disableRestartShortcut);
+};
+
+const stopPlugin = () => {
+    document.removeEventListener('keydown', disableRestartShortcut);
+};
+
+export default definePlugin({
+    name: "DisableDiscordRestart",
+    authors: [Devs.Burlone],
+    description: "Disables the Ctrl + R shortcut to prevent Discord from restarting.",
+    dependencies: [],
+    start: startPlugin,
+    stop: stopPlugin,
+    settings
+});

--- a/src/plugins/disableDiscordRestart/styles.css
+++ b/src/plugins/disableDiscordRestart/styles.css
@@ -1,0 +1,35 @@
+.discord-popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 20px;
+    background: #36393f;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    z-index: 9999;
+}
+
+.discord-popup-close {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    padding: 5px 10px;
+    background: #202225;
+    color: #ffffff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.discord-popup-title {
+    margin: 0;
+    font-size: 18px;
+    color: #ffffff;
+}
+
+.discord-popup-message {
+    margin-top: 10px;
+    font-size: 16px;
+    color: #ffffff;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -514,6 +514,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "verticalsync",
         id: 328165170536775680n
     },
+    Burlone: {
+        name: "Burlone",
+        id: 1065395762298630214n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Disables the Ctrl + R shortcut to prevent Discord from restarting.