### PR TITLE
fix(MessageLogger): correctly mark markdown headers red

### DIFF
--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,5 +1,5 @@
 /* Message content highlighting */
-.messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p, span) {
+.messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p) {
     color: var(--status-danger, #f04747) !important;
 }
 

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -4,7 +4,7 @@
 }
 
 /* Markdown title highlighting */
-.messagelogger-deleted [class*="contents"] div[id*="message-content"] > :is(h1, h2, h3) {
+.messagelogger-deleted [class*="contents"] :is(h1, h2, h3) {
     color: var(--status-danger, #f04747) !important;
 }
 

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,5 +1,10 @@
 /* Message content highlighting */
-.messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p) {
+.messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p, span) {
+    color: var(--status-danger, #f04747) !important;
+}
+
+/* Markdown title highlighting */
+.messagelogger-deleted [class*="contents"] div[id*="message-content"] > :is(h1, h2, h3) {
     color: var(--status-danger, #f04747) !important;
 }
 


### PR DESCRIPTION
This fixes bug where Markdown headers from deleted logged messages don't show as red text (if option is enabled)

without fix:
![image](https://github.com/Vendicated/Vencord/assets/75569739/2af52de7-76c7-4c17-840e-393571d620ce)

with fix:
![image](https://github.com/Vendicated/Vencord/assets/75569739/768dacd0-f4ef-4f88-afab-f8befcdadd80)
