### PR TITLE
new plugin: MaskedLinkPaste

### DIFF
--- a/src/plugins/maskedLinkPaste/README.md
+++ b/src/plugins/maskedLinkPaste/README.md
@@ -1,0 +1,5 @@
+# MaskedLinkPaste
+
+Pasting a link while you have text selected will paste your link as a masked link at that location
+
+![](https://github.com/Vendicated/Vencord/assets/78964224/1d3be2c6-7957-44c9-92ec-551069d46c02)

--- a/src/plugins/maskedLinkPaste/index.ts
+++ b/src/plugins/maskedLinkPaste/index.ts
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants.js";
+import definePlugin from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+
+const linkRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+
+const { SlateTransforms } = findByPropsLazy("SlateTransforms");
+
+export default definePlugin({
+    name: "MaskedLinkPaste",
+    authors: [Devs.TheSun],
+    description: "Pasting a link while having text selected will paste a hyperlink",
+    patches: [{
+        find: ".selection,preventEmojiSurrogates:",
+        replacement: {
+            match: /(?<=SlateTransforms.delete.{0,50})(\i)\.insertText\((\i)\)/,
+            replace: "$self.handlePaste($1, $2, () => $&)"
+        }
+    }],
+
+    handlePaste(editor, content: string, originalBehavior: () => void) {
+        if (content?.match(linkRegex) && editor.operations?.[0]?.type === "remove_text") {
+            SlateTransforms.insertText(
+                editor,
+                `[${editor.operations[0].text}](${content})`
+            );
+        }
+        else originalBehavior();
+    }
+});

--- a/src/plugins/maskedLinkPaste/index.ts
+++ b/src/plugins/maskedLinkPaste/index.ts
@@ -25,7 +25,7 @@ export default definePlugin({
     }],
 
     handlePaste(editor, content: string, originalBehavior: () => void) {
-        if (content?.match(linkRegex) && editor.operations?.[0]?.type === "remove_text") {
+        if (content && linkRegex.test(content) && editor.operations?.[0]?.type === "remove_text") {
             SlateTransforms.insertText(
                 editor,
                 `[${editor.operations[0].text}](${content})`

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -186,7 +186,7 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         id: 296776625432035328n,
     },
     TheSun: {
-        name: "ActuallyTheSun",
+        name: "sunnie",
         id: 406028027768733696n
     },
     axyie: {


### PR DESCRIPTION
Pasting a link while you have text selected will paste your link as a masked link at that location

![](https://github.com/Vendicated/Vencord/assets/78964224/1d3be2c6-7957-44c9-92ec-551069d46c02)