### PR TITLE
customRPC: fix typos in settings descriptions

### DIFF
--- a/src/plugins/customRPC/index.tsx
+++ b/src/plugins/customRPC/index.tsx
@@ -178,7 +178,7 @@ const settings = definePluginSettings({
     },
     startTime: {
         type: OptionType.NUMBER,
-        description: "Start timestamp in milisecond (only for custom timestamp mode)",
+        description: "Start timestamp in milliseconds (only for custom timestamp mode)",
         onChange: onChange,
         disabled: isTimestampDisabled,
         isValid: (value: number) => {
@@ -188,7 +188,7 @@ const settings = definePluginSettings({
     },
     endTime: {
         type: OptionType.NUMBER,
-        description: "End timestamp in milisecond (only for custom timestamp mode)",
+        description: "End timestamp in milliseconds (only for custom timestamp mode)",
         onChange: onChange,
         disabled: isTimestampDisabled,
         isValid: (value: number) => {


### PR DESCRIPTION
Fixed up the spelling from "milisecond" to "milliseconds" :3