### PR TITLE
[Plugin] BetterBanReasons

### DIFF
--- a/src/plugins/betterBanReasons/README.md
+++ b/src/plugins/betterBanReasons/README.md
@@ -1,0 +1,6 @@
+### Create custom reasons to use in the Discord ban modal.
+
+![image](https://github.com/Vendicated/Vencord/assets/119569726/d0c1bd70-00b1-4786-a2f7-7db809f15ab0)
+![image](https://github.com/Vendicated/Vencord/assets/119569726/411411f6-f2b7-4747-b6e7-4615116dcf22)
+
+I do not think that we're **easily** and **non-jankily** able to add the click functionality

--- a/src/plugins/betterBanReasons/README.md
+++ b/src/plugins/betterBanReasons/README.md
@@ -3,4 +3,6 @@
 ![image](https://github.com/Vendicated/Vencord/assets/119569726/d0c1bd70-00b1-4786-a2f7-7db809f15ab0)
 ![image](https://github.com/Vendicated/Vencord/assets/119569726/411411f6-f2b7-4747-b6e7-4615116dcf22)
 
-I do not think that we're **easily** and **non-jankily** able to add the click functionality
+I do not think that we're **easily** and **non-jankily** able to add the click functionality, so I didn't implement that. If anybody gets it working, shoot me a message on Discord.
+
+[Original plugin request](https://github.com/Vencord/plugin-requests/issues/607)

--- a/src/plugins/betterBanReasons/index.tsx
+++ b/src/plugins/betterBanReasons/index.tsx
@@ -79,7 +79,7 @@ const settings = definePluginSettings({
 });
 
 export default definePlugin({
-    name: "CustomBanReasons",
+    name: "BetterBanReasons",
     description: "Create custom reasons to use in the Discord ban modal.",
     authors: [Devs.Inbestigator],
     patches: [

--- a/src/plugins/customBanReasons/index.tsx
+++ b/src/plugins/customBanReasons/index.tsx
@@ -1,0 +1,100 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { Button, Forms, TextInput, useEffect, useState } from "@webpack/common";
+
+function ReasonsComponent() {
+    const [reasons, setReasons] = useState(settings.store.reasons as string[]);
+
+    useEffect(() => {
+        settings.store.reasons = reasons;
+    }, [reasons]);
+
+    return (
+        <Forms.FormSection title="Reasons">
+            {reasons.map((reason, index) => (
+                <div
+                    style={{
+                        display: "grid",
+                        padding: 0,
+                        paddingBottom: "0.5rem",
+                        gap: "0.5rem",
+                        gridTemplateColumns: "auto",
+                    }}
+                >
+                    <TextInput
+                        style={{ flex: 1 }}
+                        type="text"
+                        key={index}
+                        value={reason}
+                        onChange={(value: string) => {
+                            reasons[index] = value;
+                            setReasons([...reasons]);
+                        }}
+                        placeholder="Reason"
+                    />
+                    <Button
+                        color={Button.Colors.RED}
+                        style={{ height: "100%" }}
+                        size={Button.Sizes.MIN}
+                        onClick={() => {
+                            reasons.splice(index, 1);
+                            setReasons([...reasons]);
+                        }}
+                    >
+                        Remove
+                    </Button>
+                </div>
+            ))}
+            <Button
+                size={Button.Sizes.SMALL}
+                onClick={() => {
+                    reasons.push("");
+                    setReasons([...reasons]);
+                }}
+            >
+                Add new
+            </Button>
+        </Forms.FormSection>
+    );
+}
+
+const settings = definePluginSettings({
+    reasons: {
+        description: "Your custom reasons",
+        type: OptionType.COMPONENT,
+        default: [
+            "Suspicious or spam account",
+            "Compromised or spam account",
+            "Breaking server rules",
+        ],
+        component: ReasonsComponent,
+    },
+});
+
+export default definePlugin({
+    name: "CustomBanReasons",
+    description: "Create custom reasons to use in the Discord ban modal.",
+    authors: [Devs.Inbestigator],
+    patches: [
+        {
+            find: 'username:"@".concat(_.default.getName',
+            replacement: {
+                match: /U=\[([\s\S]*?)\]/,
+                replace: "U=$self.getReasons()",
+            },
+        },
+    ],
+    getReasons: (): { name: string; value: string; }[] => {
+        return settings.store.reasons.map((reason: string) => {
+            return { name: reason, value: reason };
+        });
+    },
+    settings,
+});

--- a/src/plugins/customBanReasons/index.tsx
+++ b/src/plugins/customBanReasons/index.tsx
@@ -25,7 +25,7 @@ function ReasonsComponent() {
                         padding: 0,
                         paddingBottom: "0.5rem",
                         gap: "0.5rem",
-                        gridTemplateColumns: "auto",
+                        gridTemplateColumns: "6fr 1fr",
                     }}
                 >
                     <TextInput


### PR DESCRIPTION
### Create custom reasons to use in the Discord ban modal.

![image](https://github.com/Vendicated/Vencord/assets/119569726/d0c1bd70-00b1-4786-a2f7-7db809f15ab0)
![image](https://github.com/Vendicated/Vencord/assets/119569726/411411f6-f2b7-4747-b6e7-4615116dcf22)

I do not think that we're **easily** and **non-jankily** able to add the click functionality, so I didn't implement that. If anybody gets it working, shoot me a message on Discord.

[Original plugin request](https://github.com/Vencord/plugin-requests/issues/607)