### PR TITLE
Add FavoriteDMs

### DIFF
--- a/src/plugins/favoriteDMs/README.md
+++ b/src/plugins/favoriteDMs/README.md
@@ -1,3 +1,6 @@
 # FavoriteDMs
 
 Allows Favoriting DMs and Threads when using the "Favorites Server" Experiment
+
+Comparison of with/without plugin:
+![context menu open for a dm, at the top the option "Favorite DM" is missing" there is a red arrow pointing to a different screenshot[with the plugin enabled] where the option "Favorite DM" is present in the DM context menu](https://github.com/Vendicated/Vencord/assets/37855219/48460a66-7f99-40b3-8128-3d7fee62cd2e)

--- a/src/plugins/favoriteDMs/README.md
+++ b/src/plugins/favoriteDMs/README.md
@@ -1,0 +1,3 @@
+# FavoriteDMs
+
+Allows Favoriting DMs and Threads when using the "Favorites Server" Experiment

--- a/src/plugins/favoriteDMs/index.ts
+++ b/src/plugins/favoriteDMs/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "FavoriteDMs",
+    description: "Allows favoriting DMs and Threads when using the \"Favorites Server\" Experiment",
+    authors: [Devs.F53],
+    patches: [{
+        find: "useCanFavoriteChannel",
+        replacement: {
+            match: /!\(\i\.isDM\(\)\|\|\i\.isThread\(\)\)/,
+            replace: "true",
+        }
+    }],
+});


### PR DESCRIPTION
Discord decided to ruin the "Favorites Server" experiment by removing your ability to favorite DMs & threads.

This is a very simple plugin that removes that check so you can favorite DMs and threads again.
