### PR TITLE
Add NoAutoMute plugin

### DIFF
--- a/src/plugins/noAutoUnmute/index.ts
+++ b/src/plugins/noAutoUnmute/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2024 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NoAutoUnmute",
+    description: "Prevents you from being automatically unmuted by Discord (such as by joining a VC call)",
+    authors: [Devs.HAHALOSAH],
+    patches: [
+        {
+            find: "isSelfMute(){",
+            replacement: {
+                match: /video:\i}=\i;/,
+                replace: "$&return;"
+            },
+        },
+    ],
+});


### PR DESCRIPTION
This plugin stops Discord from automatically unmuting you when you join a VC