### PR TITLE
Dearrow: fix ">" handling

### DIFF
--- a/src/plugins/dearrow/index.tsx
+++ b/src/plugins/dearrow/index.tsx
@@ -69,7 +69,7 @@ async function embedDidMount(this: Component<Props>) {
 
         if (hasTitle && replaceElements !== ReplaceElements.ReplaceThumbnailsOnly) {
             embed.dearrow.oldTitle = embed.rawTitle;
-            embed.rawTitle = titles[0].title.replace(/ >(\S)/g, " $1");
+            embed.rawTitle = titles[0].title.replace(/(^|\s)>(\S)/g, "$1$2");
         }
 
         if (hasThumb && replaceElements !== ReplaceElements.ReplaceTitlesOnly) {


### PR DESCRIPTION
Fixed ">" handling at the start of DeArrow titles. Regex taken straight from https://github.com/ajayyy/DeArrow/blob/669a392c39593984aea19bfdac91b19da467def9/src/titles/titleFormatter.ts#L474

Before:
![image](https://github.com/Vendicated/Vencord/assets/41648788/c5ba3043-0164-4bec-aeb3-c8ef9a77de37)

After:
![image](https://github.com/Vendicated/Vencord/assets/41648788/fbaca5f5-2914-4459-84ba-ca57253f4891)

[test video](https://www.youtube.com/watch?v=egxSBhfjcTU)