### PR TITLE
Add NoAccountLimit plugin

### DIFF
--- a/src/plugins/noAccountLimit/index.ts
+++ b/src/plugins/noAccountLimit/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2024 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NoAccountLimit",
+    description: "Allows you to add as many accounts as you want", 
+    authors: [Devs.HAHALOSAH],
+    patches: [
+        {
+            find: '"switch-accounts-modal"',
+            replacement: {
+                match: "=5",
+                replace: "=1/0"
+            },
+        },
+    ],
+});


### PR DESCRIPTION
This plugin removes the 5 account limit for the account switcher