### PR TITLE
Google it

### DIFF
--- a/src/plugins/LetMeGoogleThat/index.ts
+++ b/src/plugins/LetMeGoogleThat/index.ts
@@ -9,7 +9,7 @@ import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
-function letMeGoogleThat(message) {
+function letMeGoogleThat(message: string) {
     return settings.store.defaultUrl + encodeURIComponent(message);
 }
 

--- a/src/plugins/LetMeGoogleThat/index.ts
+++ b/src/plugins/LetMeGoogleThat/index.ts
@@ -1,0 +1,48 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { ApplicationCommandOptionType, findOption } from "@api/Commands";
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+function letMeGoogleThat(message) {
+    return settings.store.defaultUrl + encodeURIComponent(message);
+}
+
+const settings = definePluginSettings({
+    defaultUrl: {
+        type: OptionType.STRING,
+        default: "https://letmegooglethat.vercel.app?q=",
+        description: "Default url - RECOMMEND NOT CHANGING UNLESS YOU KNOW WHAT YOU ARE DOING!",
+        restartNeeded: true,
+    },
+});
+
+export default definePlugin({
+    name: "LetMeGoogleThat",
+    description: "Makes a let me google that command!",
+    authors: [Devs.Abstractmelon, Devs.UnluckyCrafter],
+    dependencies: ["CommandsAPI"],
+    settings,
+    commands: [
+        {
+            name: "letmegooglethat",
+            description: "Creates a let me google that link and send it!",
+            options: [
+                {
+                    name: "query",
+                    description: "What you want to google!",
+                    required: false,
+                    type: ApplicationCommandOptionType.STRING,
+                },
+            ],
+            execute: opts => ({
+                content: letMeGoogleThat(findOption(opts, "query", ""))
+            }),
+        }
+    ]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -529,6 +529,14 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     nekohaxx: {
         name: "nekohaxx",
         id: 1176270221628153886n
+    },
+    Abstractmelon: {
+        name: "Abstractmelon",
+        id: 906283767734362144n
+    },
+    UnluckyCrafter: {
+        name: "UnluckyCrafter",
+        id: 1170452569848549429n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
# Let Me Google That For You Command

This command generates a "Let Me Google That For You" (LMGTFY) URL. By default, it uses `https://letmegooglethat.vercel.app/`, but you can customize it to use any other LMGTFY-like service.

### Features
- Generates a LMGTFY URL based on a command
- Customizable URL

## Example
When a user types the command with a query, the bot responds with a LMGTFY URL.

![example](https://github.com/Vendicated/Vencord/assets/129030233/f9c14355-e5a7-497d-a4a8-bba9b53e6d0a)
