### PR TITLE
fix: canonicalize find in PatchHelper

### DIFF
--- a/src/components/VencordSettings/PatchHelperTab.tsx
+++ b/src/components/VencordSettings/PatchHelperTab.tsx
@@ -311,12 +311,13 @@ function PatchHelper() {
         try {
             let parsedFind = v as string | RegExp;
             if (/^\/.+?\/$/.test(v)) parsedFind = new RegExp(v.slice(1, -1));
+            const canonicalFind = canonicalizeMatch(parsedFind);
 
             setFindError(void 0);
             setParsedFind(parsedFind);
 
             if (v.length) {
-                findCandidates({ find: parsedFind, setModule, setError: setFindError });
+                findCandidates({ find: canonicalFind, setModule, setError: setFindError });
             }
         } catch (e: any) {
             setFindError((e as Error).message);


### PR DESCRIPTION
Before:
![image](https://github.com/Vendicated/Vencord/assets/55899582/5fd4bd44-1c7d-4d41-8bfb-c6d9c4404728)

After the fix `\i` works properly:
![image](https://github.com/Vendicated/Vencord/assets/55899582/5d287210-c521-4edc-9bb2-77238bdfc420)
