### PR TITLE
[Plugin] DeviceSpoof

### DIFF
--- a/src/plugins/deviceSpoof/index.ts
+++ b/src/plugins/deviceSpoof/index.ts
@@ -1,0 +1,41 @@
+import definePlugin, { StartAt, OptionType } from "@utils/types";
+import { Settings } from "@api/Settings";
+
+export default definePlugin({
+    name: "DeviceSpoof",
+    description: "This plugin spoofs the device you are on while connecting to the discord gateway",
+    authors: [
+        {
+            id: 1162674474496307210n,
+            name: "EinTim",
+        },
+    ],
+    startAt: StartAt.Init, //we need this so we have our patches applied before the fast connect
+    patches: [
+        {
+            find: "this.handleIdentify()",
+            replacement: {
+                match: /let (.)=this\.handleIdentify\(\);/g, //there are two occurences of this, one on fast connect and one on the normal connect
+                replace: "$&;$1.properties.browser=$self.getBrowserType();",
+            }
+           
+        }
+    ],
+    getBrowserType(){
+        return Settings.plugins.DeviceSpoof.Device;
+    },
+    options: {
+        Device: {
+            type: OptionType.SELECT,
+            description: "The device this session will identify as",
+            restartNeeded: true,
+            default: "Discord Client",
+            options: [
+                { label: "Desktop", value: "Discord Client", default: true },
+                { label: "Browser", value: "Chrome" },
+                { label: "Mobile", value: "Discord Android" },
+                { label: "Console", value: "Discord Embedded" }
+            ],
+        },
+    },
+});


### PR DESCRIPTION
This plugin allows you to change the device your discord client uses to authenticate with the discord gateway. This allows your desktop client to be displayed as the mobile app, for example.

Supported types:
- Mobile
- Desktop
- Browser
- Embedded/Game console

![image](https://github.com/Vendicated/Vencord/assets/57799248/0178c083-ddb3-4b52-9c8c-080623a45dcb)
![image](https://github.com/Vendicated/Vencord/assets/57799248/188e2c33-9041-4ce4-a24f-1f8f5a6fd584)
![image](https://github.com/Vendicated/Vencord/assets/57799248/67493bad-ae7e-46f1-94c1-bdfbbd7a2750)
![image](https://github.com/Vendicated/Vencord/assets/57799248/77a19728-a77f-479c-aebe-a65af33d3a4e)
