### PR TITLE
feat(plugin): DefaultStatusForever

### DIFF
--- a/src/plugins/defaultStatusForever/README.md
+++ b/src/plugins/defaultStatusForever/README.md
@@ -1,0 +1,5 @@
+# DefaultStatusForever
+
+Makes the custom status screen default to "Don't Clear" as the duration
+
+![The custom status screen, with "Don't Clear" selected and as the first option](https://github.com/Vendicated/Vencord/assets/44179559/e8cf0ca1-589c-43ef-9a6d-4fa3ed03a1f9)

--- a/src/plugins/defaultStatusForever/index.tsx
+++ b/src/plugins/defaultStatusForever/index.tsx
@@ -1,0 +1,48 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+interface Choice {
+    key: number;
+    value: any;
+    label: string;
+}
+
+export default definePlugin({
+    name: "DefaultStatusForever",
+    description: "Make statuses default to last forever",
+    authors: [Devs.ImLvna],
+
+    patches: [
+        {
+            // hardcode default status duration to null
+            find: "this.clearAfterOptions",
+            replacement: {
+                match: /(?<=value:)\i(?=,options:this.clearAfterOptions)/,
+                replace: "null"
+            }
+        },
+        {
+            // reorder the list to put "Dont't Clear" at the top
+            find: "get clearAfterOptions",
+            replacement: {
+                match: /(?<=get clearAfterOptions\(\){return).*?}]/,
+                replace: " $self.patchChoices($&)"
+            }
+        }
+    ],
+
+    patchChoices(choices: Choice[]) {
+        const nullChoice = choices.find(choice => choice.value === null);
+        if (nullChoice) {
+            choices.splice(choices.indexOf(nullChoice), 1);
+            choices.unshift(nullChoice);
+        }
+        return choices;
+    }
+});


### PR DESCRIPTION
# DefaultStatusForever

Makes the custom status screen default to "Don't Clear" as the duration

![The custom status screen, with "Don't Clear" selected and as the first option](https://github.com/Vendicated/Vencord/assets/44179559/e8cf0ca1-589c-43ef-9a6d-4fa3ed03a1f9)
