### PR TITLE
Rename "Relaunch Discord" to "Restart Discord"

### DIFF
--- a/src/components/VencordSettings/VencordTab.tsx
+++ b/src/components/VencordSettings/VencordTab.tsx
@@ -49,7 +49,7 @@ const iconWithTooltip = (Icon: ComponentType<{ className?: string; }>, tooltip: 
 
 const NotificationLogIcon = iconWithTooltip(LogIcon, "Open Notification Log");
 const QuickCssIcon = iconWithTooltip(PaintbrushIcon, "Edit QuickCSS");
-const RelaunchIcon = iconWithTooltip(RestartIcon, "Relaunch Discord");
+const RelaunchIcon = iconWithTooltip(RestartIcon, "Restart Discord");
 const OpenSettingsDirIcon = iconWithTooltip(FolderIcon, "Open Settings Directory");
 const OpenGithubIcon = iconWithTooltip(GithubIcon, "View Vencord's GitHub Repository");
 


### PR DESCRIPTION
I think "Restart" is more natural.

Also see https://github.com/Vencord/Vesktop/pull/701.