### PR TITLE
feat(plugin): HTTPSearcher

### DIFF
--- a/src/plugins/httpSearcher/index.ts
+++ b/src/plugins/httpSearcher/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { ApplicationCommandInputType, ApplicationCommandOptionType, findOption, sendBotMessage } from "@api/Commands";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "HTTPSearcher",
+    description: "Search HTTP error codes use http.cat",
+    authors: [Devs.Syirezz],
+    dependencies: ["CommandsAPI"],
+
+    commands: [
+        {
+            name: "httpsearcher",
+            description: "Search HTTP error codes",
+            inputType: ApplicationCommandInputType.BUILT_IN,
+            options: [
+                {
+                    name: "code",
+                    description: "HTTP Error code for cat image",
+                    type: ApplicationCommandOptionType.INTEGER,
+                    required: true
+                },
+            ],
+            execute: async (_, ctx) => {
+                const httpError = findOption(_, "code", "");
+                if (!httpError) {
+                    return sendBotMessage(ctx.channel.id, {
+                        content: "No http code was defined!"
+                    });
+                }
+
+                return sendBotMessage(ctx.channel.id, {
+                    content: `Image of http code ${httpError}:\nhttps://http.cat/${httpError}`,
+                });
+            }
+        }
+    ]
+
+});
+

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -533,6 +533,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Antti: {
         name: "Antti",
         id: 312974985876471810n
+    },
+    Syirezz: {
+        name: "Syirezz",
+        id: 992006036544290837n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
# HTTPSearcher

This plugin use slash commands to give user by command `/httpsearcher code: 404` (example) a image url from **https://http.cat/**
![image](https://github.com/Vendicated/Vencord/assets/111554400/c1603d1a-75c9-4257-9d7f-dbd02fb15db3)
![image](https://github.com/Vendicated/Vencord/assets/111554400/3f5427a2-d174-4e15-9c74-6b48a597e6c7)
