### PR TITLE
feat(Plugin): removeSupport

### DIFF
--- a/src/plugins/removeSupport/index.ts
+++ b/src/plugins/removeSupport/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "removeSupport",
+    description: "Removing support button from the header",
+    authors: [Devs.Syirezz],
+
+    start() {
+        const observer = new MutationObserver(() => {
+            const support_button = document.querySelector(".anchor_af404b.anchorUnderlineOnHover_af404b");
+            if (support_button) {
+                support_button.remove();
+            }
+        });
+
+        observer.observe(document.documentElement, { childList: true, subtree: true });
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -533,6 +533,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Antti: {
         name: "Antti",
         id: 312974985876471810n
+    },
+    Syirezz: {
+        name: "Syirezz",
+        id: 992006036544290837n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
# removeSupport
This plugin remove a support button from header of discord. I think no one use this button

## Screenshots
![image](https://github.com/Vendicated/Vencord/assets/111554400/5278fe40-6c03-432f-88c4-3f3e180a6aed)
![image](https://github.com/Vendicated/Vencord/assets/111554400/1bca7387-6511-43ca-8da9-98d500c9025f)
