### PR TITLE
ctrlEnterSend: fix for new Discord update

### DIFF
--- a/src/plugins/ctrlEnterSend/index.ts
+++ b/src/plugins/ctrlEnterSend/index.ts
@@ -40,9 +40,9 @@ export default definePlugin({
     }),
     patches: [
         {
-            find: ".ENTER&&(!",
+            find: "!this.hasOpenCodeBlock()",
             replacement: {
-                match: /(?<=(\i)\.which===\i\.\i.ENTER&&).{0,100}(\(0,\i\.\i\)\(\i\)).{0,100}(?=&&\(\i\.preventDefault)/,
+                match: /!(\i).shiftKey&&!(this.hasOpenCodeBlock\(\))&&\(.{0,100}?\)/,
                 replace: "$self.shouldSubmit($1, $2)"
             }
         }


### PR DESCRIPTION
This plugin is broken recently because Discord sneakily changed something. Here is a fix.

It seems that Discord changed the logic for message submission back to what it was before last major update.