### PR TITLE
Do not crop non-square donor badges

### DIFF
--- a/src/plugins/_api/badges/index.tsx
+++ b/src/plugins/_api/badges/index.tsx
@@ -163,7 +163,7 @@ export default definePlugin({
                 style: {
                     borderRadius: "50%",
                     transform: "scale(0.9)", // The image is a bit too big compared to default badges
-                    objectFit: "contain" // Do not crop non-square images
+                    ["objectFit" as any]: "contain" // Do not crop non-square images
                 }
             },
             onClick() {

--- a/src/plugins/_api/badges/index.tsx
+++ b/src/plugins/_api/badges/index.tsx
@@ -162,7 +162,8 @@ export default definePlugin({
             props: {
                 style: {
                     borderRadius: "50%",
-                    transform: "scale(0.9)" // The image is a bit too big compared to default badges
+                    transform: "scale(0.9)", // The image is a bit too big compared to default badges
+                    objectFit: "contain" // Do not crop non-square images
                 }
             },
             onClick() {


### PR DESCRIPTION
It seems the donor badge I provided is not actually square, and the `object-fit` is set to `cover`, giving this:

![attachment](https://github.com/Vendicated/Vencord/assets/52103563/af4741af-3053-4916-a993-d489d598af0c)

And here is how it looks with `object-fit: contain`:

![attachment](https://github.com/Vendicated/Vencord/assets/52103563/7743a4fe-1edd-453c-a86b-9b1f1caf61cb)

Now, maybe the solution is to replace my badge and make it actually square 😅 but I'm probably not the only one in this situation.