### PR TITLE
MessageLogger: deleted color tint support for Subtexes, Mentions, Voice Messages, Polls, Codeblocks and Spoilers

### DIFF
--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -10,12 +10,12 @@
 .messagelogger-deleted [class*=nonVisualMediaItemContainer] [class*=duration] {
   color: var(--status-danger, #f04747) !important;
 }
-.messagelogger-deleted [class*=nonVisualMediaItemContainer] path[d*="M12"],
-.messagelogger-deleted [class*=nonVisualMediaItemContainer] path[d*="M15"] {
+.messagelogger-deleted [class*=nonVisualMediaItemContainer] [class*=volumeButtonIcon] path[d*="M12"],
+.messagelogger-deleted [class*=nonVisualMediaItemContainer] [class*=volumeButtonIcon] path[d*="M15"] {
   fill: var(--status-danger, #f04747) !important;
 }
 .messagelogger-deleted [class*=nonVisualMediaItemContainer] [class*=waveform] {
-  filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><filter id='darker-red-tint-filter'><feColorMatrix type='matrix' values='1 0 0 0 0  0 0.1 0 0 0  0 0 0.1 0 0  0 0 0 2 0'/></filter></svg>#darker-red-tint-filter");
+  filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><filter id='darker-red-tint-filter'><feColorMatrix type='matrix' values='2 0 0 0 0  0 0.08 0 0 0  0 0 0.1 0 0  0 0 0 2 0'/></filter></svg>#darker-red-tint-filter");
 }
 .messagelogger-deleted [class*=nonVisualMediaItemContainer] [class*=playButtonContainer] {
   background: var(--status-danger, #f04747) !important;

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -6,6 +6,21 @@
     color: var(--status-danger, #f04747) !important;
 }
 
+/* Message Logger / Voice Message highlighting */
+.messagelogger-deleted [class*=nonVisualMediaItemContainer] [class*=duration] {
+  color: var(--status-danger, #f04747) !important;
+}
+.messagelogger-deleted [class*=nonVisualMediaItemContainer] path[d*="M12"],
+.messagelogger-deleted [class*=nonVisualMediaItemContainer] path[d*="M15"] {
+  fill: var(--status-danger, #f04747) !important;
+}
+.messagelogger-deleted [class*=nonVisualMediaItemContainer] [class*=waveform] {
+  filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><filter id='darker-red-tint-filter'><feColorMatrix type='matrix' values='1 0 0 0 0  0 0.1 0 0 0  0 0 0.1 0 0  0 0 0 2 0'/></filter></svg>#darker-red-tint-filter");
+}
+.messagelogger-deleted [class*=nonVisualMediaItemContainer] [class*=playButtonContainer] {
+  background: var(--status-danger, #f04747) !important;
+}
+
 /* Poll highlighting */
 .messagelogger-deleted [class*="pollContainer"] :is([class*=text]) {
   color: var(--status-danger, #f04747) !important;

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -6,6 +6,11 @@
     color: var(--status-danger, #f04747) !important;
 }
 
+/* Poll highlighting */
+.messagelogger-deleted [class*="pollContainer"] :is([class*=text]) {
+  color: var(--status-danger, #f04747) !important;
+}
+
 /* Code highlighting */
 .messagelogger-deleted [class*="codeContainer"] code,
 .messagelogger-deleted [class*="codeContainer"] span {

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,7 +1,8 @@
-/* Message content, sub-text and mention highlighting */
+/* Message content, sub-text, user and channel mention highlighting */
 .messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p),
 .messagelogger-deleted small,
-.messagelogger-deleted .mention {
+.messagelogger-deleted .mention,
+.messagelogger-deleted .channelMention {
     color: var(--status-danger, #f04747) !important;
 }
 

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,5 +1,6 @@
-/* Message content highlighting */
-.messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p) {
+/* Message content and mention highlighting */
+.messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p),
+.messagelogger-deleted .mention {
     color: var(--status-danger, #f04747) !important;
 }
 

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -11,6 +11,11 @@
   color: var(--status-danger, #f04747) !important;
 }
 
+/* Spoiler highlighting */
+.messagelogger-deleted  [class*=spoilerContent]:not(:has([aria-hidden="false"])) {
+  background-color: var(--status-danger, #f04747) !important;
+}
+
 /* Markdown title highlighting */
 .messagelogger-deleted [class*="contents"] :is(h1, h2, h3) {
     color: var(--status-danger, #f04747) !important;

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -12,7 +12,7 @@
 }
 
 /* Spoiler highlighting */
-.messagelogger-deleted  [class*=spoilerContent]:not(:has([aria-hidden="false"])) {
+.messagelogger-deleted [class*=spoilerContent]:not(:has([aria-hidden="false"])) {
   background-color: var(--status-danger, #f04747) !important;
 }
 

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,5 +1,6 @@
-/* Message content and mention highlighting */
+/* Message content, sub-text and mention highlighting */
 .messagelogger-deleted [class*="contents"] > :is(div, h1, h2, h3, p),
+.messagelogger-deleted small,
 .messagelogger-deleted .mention {
     color: var(--status-danger, #f04747) !important;
 }

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -4,6 +4,12 @@
     color: var(--status-danger, #f04747) !important;
 }
 
+/* Code highlighting */
+.messagelogger-deleted [class*="codeContainer"] code,
+.messagelogger-deleted [class*="codeContainer"] span {
+  color: var(--status-danger, #f04747) !important;
+}
+
 /* Markdown title highlighting */
 .messagelogger-deleted [class*="contents"] :is(h1, h2, h3) {
     color: var(--status-danger, #f04747) !important;


### PR DESCRIPTION
Mentions don't have the deleted color tint added to it, making it hard to tell if messages have been deleted if the content only consists of a mention only. This pull request will fix that.
![SlNbKCM](https://github.com/user-attachments/assets/1a504188-22b2-4d5e-a8f3-7b6bc6beed76)
