### PR TITLE
Add warning about hiding recent listening info to last.fm plugin sett…

### DIFF
--- a/src/plugins/lastfm/index.tsx
+++ b/src/plugins/lastfm/index.tsx
@@ -203,7 +203,8 @@ export default definePlugin({
                 Application name: Discord Rich Presence <br />
                 Application description: (personal use) <br /> <br />
 
-                And copy the API key (not the shared secret!)
+                And copy the API key (not the shared secret!) <br />
+                Make sure "Hide recent listening information" is disabled in your last.fm privacy settings.
             </Forms.FormText>
         </>
     ),


### PR DESCRIPTION
Adds a warning to the last.fm plugin settings telling the user to disable the "Hide recent listening information" setting for the plugin to work
