### PR TITLE
Fix broken find in ClientTheme

### DIFF
--- a/src/plugins/clientTheme/index.tsx
+++ b/src/plugins/clientTheme/index.tsx
@@ -30,7 +30,7 @@ function onPickColor(color: number) {
     updateColorVars(hexColor);
 }
 
-const saveClientTheme = findByCodeLazy('type:"UNSYNCED_USER_SETTINGS_UPDATE",settings:{useSystemTheme:"system"===');
+const saveClientTheme = findByCodeLazy('type:"UNSYNCED_USER_SETTINGS_UPDATE",settings:{useSystemTheme:null!=');
 
 function setTheme(theme: string) {
     saveClientTheme({ theme });


### PR DESCRIPTION
This affects that red button in the plugin settings, that errors out instead of switching to dark theme:

<img width="631" alt="Capture d’écran 2024-07-24 à 09 42 18" src="https://github.com/user-attachments/assets/e25f0fba-918c-4e8f-9e72-cf063360e4ba">
