### PR TITLE
feat(MessageLinkEmbeds): add tooltip to links and replies

### DIFF
--- a/src/plugins/messageLinkEmbeds/MessageTooltip.tsx
+++ b/src/plugins/messageLinkEmbeds/MessageTooltip.tsx
@@ -9,7 +9,6 @@ import ErrorBoundary from "@components/ErrorBoundary";
 import { findComponentByCodeLazy } from "@webpack";
 import {
     ChannelStore,
-    Clickable,
     Constants,
     MessageStore,
     PermissionsBits,

--- a/src/plugins/messageLinkEmbeds/MessageTooltip.tsx
+++ b/src/plugins/messageLinkEmbeds/MessageTooltip.tsx
@@ -26,7 +26,7 @@ import type { Message } from "discord-types/general";
 const ChannelMessage = findComponentByCodeLazy("childrenExecutedCommand:", ".hideAccessories");
 const MessageDisplayCompact = getUserSettingLazy("textAndImages", "messageDisplayCompact")!;
 
-export function MessageTooltip({ messageId, channelId, children }) {
+export default function MessageTooltip({ messageId, channelId, children }) {
     if(!messageId) return children;
     return <Tooltip
         tooltipClassName="vc-message-link-tooltip"

--- a/src/plugins/messageLinkEmbeds/index.tsx
+++ b/src/plugins/messageLinkEmbeds/index.tsx
@@ -44,7 +44,7 @@ import {
 } from "@webpack/common";
 import { Channel, Message } from "discord-types/general";
 
-import { MessageTooltip } from "./tooltip.jsx";
+import MessageTooltip from "./MessageTooltip.jsx";
 
 const messageCache = new Map<string, {
     message?: Message;

--- a/src/plugins/messageLinkEmbeds/index.tsx
+++ b/src/plugins/messageLinkEmbeds/index.tsx
@@ -44,7 +44,7 @@ import {
 } from "@webpack/common";
 import { Channel, Message } from "discord-types/general";
 
-import { wrapMentionComponent } from "./tooltip.jsx";
+import { wrapMentionComponent, wrapReplyComponent } from "./tooltip.jsx";
 
 const messageCache = new Map<string, {
     message?: Message;
@@ -79,7 +79,12 @@ const messageFetchQueue = new Queue();
 
 const settings = definePluginSettings({
     tooltip: {
-        description: "Show message content as a tooltip",
+        description: "Show tooltip for linked messages",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    replyTooltip: {
+        description: "Show tooltip for replied messages",
         type: OptionType.BOOLEAN,
         default: true
     },
@@ -392,10 +397,20 @@ export default definePlugin({
                 replace: "$self.wrapMentionComponent(arguments[0], $1)"
             },
             predicate: () => settings.store.tooltip
-        }
+        },
+        {
+            find: "Messages.REPLY_QUOTE_MESSAGE_NOT_LOADED",
+            replacement: {
+                // Should match two places
+                match: /(\i\.Clickable)/g,
+                replace: "$self.wrapReplyComponent(arguments[0], $1)"
+            },
+            predicate: () => settings.store.replyTooltip
+        },
     ],
 
     wrapMentionComponent,
+    wrapReplyComponent,
 
     start() {
         addAccessory("messageLinkEmbed", props => {

--- a/src/plugins/messageLinkEmbeds/index.tsx
+++ b/src/plugins/messageLinkEmbeds/index.tsx
@@ -384,7 +384,7 @@ function AutomodEmbedAccessory(props: MessageEmbedProps): JSX.Element | null {
 export default definePlugin({
     name: "MessageLinkEmbeds",
     description: "Adds a preview to messages that link another message",
-    authors: [Devs.TheSun, Devs.Ven, Devs.RyanCaoDev],
+    authors: [Devs.TheSun, Devs.Ven, Devs.RyanCaoDev, Devs.Kyuuhachi],
     dependencies: ["MessageAccessoriesAPI", "MessageUpdaterAPI", "UserSettingsAPI"],
 
     settings,

--- a/src/plugins/messageLinkEmbeds/index.tsx
+++ b/src/plugins/messageLinkEmbeds/index.tsx
@@ -411,14 +411,14 @@ export default definePlugin({
 
     MentionTooltip({ Component, vcProps, ...props }) {
         return <MessageTooltip messageId={vcProps.messageId} channelId={vcProps.channelId}>
-            {(p) => <Component {...props} {...p} />}
+            {p => <Component {...props} {...p} />}
         </MessageTooltip>;
     },
 
     ReplyTooltip({ Component, vcProps, ...props }) {
         const ref = vcProps.baseMessage.messageReference;
         return <MessageTooltip messageId={ref.message_id} channelId={ref.channel_id}>
-            {(p) => <Component {...props} {...p} />}
+            {p => <Component {...props} {...p} />}
         </MessageTooltip>;
     },
 

--- a/src/plugins/messageLinkEmbeds/style.css
+++ b/src/plugins/messageLinkEmbeds/style.css
@@ -1,0 +1,5 @@
+.vc-message-link-tooltip {
+    width: max-content;
+    max-width: 80vw;
+}
+

--- a/src/plugins/messageLinkEmbeds/tooltip.tsx
+++ b/src/plugins/messageLinkEmbeds/tooltip.tsx
@@ -26,24 +26,6 @@ import type { Message } from "discord-types/general";
 const ChannelMessage = findComponentByCodeLazy("childrenExecutedCommand:", ".hideAccessories");
 const MessageDisplayCompact = getUserSettingLazy("textAndImages", "messageDisplayCompact")!;
 
-// TODO wrapping components like this probably makes react's equality check fail
-export function wrapMentionComponent({ messageId, channelId }, Component) {
-    return props => {
-        return <MessageTooltip messageId={messageId} channelId={channelId}>
-            <Component {...props} />
-        </MessageTooltip>;
-    };
-}
-
-export function wrapReplyComponent(p, Component) {
-    const { channel_id, message_id } = p.baseMessage.messageReference;
-    return props => {
-        return <MessageTooltip messageId={message_id} channelId={channel_id}>
-            <Component {...props} />
-        </MessageTooltip>;
-    };
-}
-
 export function MessageTooltip({ messageId, channelId, children }) {
     if(!messageId) return children;
     return <Tooltip
@@ -56,13 +38,8 @@ export function MessageTooltip({ messageId, channelId, children }) {
                 />
             </ErrorBoundary>
         }
-    >
-        {({ onMouseEnter, onMouseLeave }) =>
-            <Clickable onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-                {children}
-            </Clickable>
-        }
-    </Tooltip>;
+        children={({ onMouseEnter, onMouseLeave }) => children({ onMouseEnter, onMouseLeave })}
+    />;
 }
 
 function MessagePreview({ channelId, messageId }) {

--- a/src/plugins/messageLinkEmbeds/tooltip.tsx
+++ b/src/plugins/messageLinkEmbeds/tooltip.tsx
@@ -112,7 +112,7 @@ async function fetchMessage(channelId, messageId): Promise<{ status: MessageStat
         const message = MessageStore.getMessages(channelId)
             .receiveMessage(res.body[0])
             .get(messageId);
-        return { status: MessageStatus.LOADED, message };
+        return message ? { status: MessageStatus.LOADED, message } : { status: MessageStatus.ERROR };
     } catch (e) {
         console.error("error fetching message", e);
         return { status: MessageStatus.ERROR };

--- a/src/plugins/messageLinkEmbeds/tooltip.tsx
+++ b/src/plugins/messageLinkEmbeds/tooltip.tsx
@@ -1,0 +1,120 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { getUserSettingLazy } from "@api/UserSettings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { findComponentByCodeLazy } from "@webpack";
+import {
+    ChannelStore,
+    Constants,
+    Spinner,
+    MessageStore,
+    PermissionsBits,
+    PermissionStore,
+    RestAPI,
+    Tooltip,
+    useEffect,
+    useState,
+    useStateFromStores,
+} from "@webpack/common";
+import type { ComponentType } from "react";
+import type { Message } from "discord-types/general";
+
+const ChannelMessage = findComponentByCodeLazy("childrenExecutedCommand:", ".hideAccessories");
+const MessageDisplayCompact = getUserSettingLazy("textAndImages", "messageDisplayCompact")!;
+
+export function wrapMentionComponent(p, Component: ComponentType) {
+    let { messageId, channelId } = p;
+    return props => {
+        if(!messageId) return <Component {...props} />;
+        return <Tooltip
+            tooltipClassName="vc-message-link-tooltip"
+            text={
+                <ErrorBoundary>
+                    <MessagePreview
+                        channelId={channelId}
+                        messageId={messageId}
+                    />
+                </ErrorBoundary>
+            }
+        >
+            {({ onMouseEnter, onMouseLeave }) =>
+                <Component
+                    {...props}
+                    onMouseEnter={onMouseEnter}
+                    onMouseLeave={onMouseLeave}
+                />
+            }
+        </Tooltip>;
+    };
+}
+
+function MessagePreview({ channelId, messageId }) {
+    const channel = ChannelStore.getChannel(channelId);
+    const compact = MessageDisplayCompact.useSetting();
+    const { status, message } = useMessage(channelId, messageId);
+
+    switch (status) {
+        case MessageStatus.LOADING:
+            return <Spinner type={Spinner.Type.PULSING_ELLIPSIS} />;
+        case MessageStatus.LOADED:
+            return <ChannelMessage
+                id={`message-link-tooltip-${messageId}`}
+                message={message}
+                channel={channel}
+                subscribeToComponentDispatch={false}
+                compact={compact}
+            />;
+        case MessageStatus.ERROR:
+            return <span className="vc-mle-tooltip-error">Failed to load message.</span>;
+        case MessageStatus.PRIVATE:
+            return <span className="vc-mle-tooltip-error">Channel is private.</span>;
+    }
+}
+
+const enum MessageStatus {
+    LOADING,
+    LOADED,
+    ERROR,
+    PRIVATE,
+}
+
+function useMessage(channelId, messageId): { status: MessageStatus, message?: Message } {
+    const cachedMessage = useStateFromStores(
+        [MessageStore],
+        () => MessageStore.getMessage(channelId, messageId)
+    );
+    const [message, setMessage] = useState(cachedMessage ? { status: MessageStatus.LOADED, message: cachedMessage } : { status: MessageStatus.LOADING });
+    useEffect(() => {
+        if(message.status === MessageStatus.LOADING)
+            fetchMessage(channelId, messageId).then(setMessage);
+    });
+    return message;
+}
+
+async function fetchMessage(channelId, messageId): Promise<{ status: MessageStatus, message?: Message }> {
+    const channel = ChannelStore.getChannel(channelId);
+    if (!channel || (!channel.isPrivate() && !PermissionStore.can(PermissionsBits.VIEW_CHANNEL, channel))) {
+        return { status: MessageStatus.PRIVATE };
+    }
+    try {
+        const res = await RestAPI.get({
+            url: Constants.Endpoints.MESSAGES(channelId),
+            query: {
+                limit: 1,
+                around: messageId,
+            },
+            retries: 2,
+        });
+        const message = MessageStore.getMessages(channelId)
+            .receiveMessage(res.body[0])
+            .get(messageId);
+        return { status: MessageStatus.LOADED, message };
+    } catch (e) {
+        console.error("error fetching message", e);
+        return { status: MessageStatus.ERROR };
+    }
+}

--- a/src/plugins/messageLinkEmbeds/tooltip.tsx
+++ b/src/plugins/messageLinkEmbeds/tooltip.tsx
@@ -20,14 +20,12 @@ import {
     useState,
     useStateFromStores,
 } from "@webpack/common";
-import type { ComponentType } from "react";
 import type { Message } from "discord-types/general";
 
 const ChannelMessage = findComponentByCodeLazy("childrenExecutedCommand:", ".hideAccessories");
 const MessageDisplayCompact = getUserSettingLazy("textAndImages", "messageDisplayCompact")!;
 
-export function wrapMentionComponent(p, Component: ComponentType) {
-    let { messageId, channelId } = p;
+export function wrapMentionComponent({ messageId, channelId }, Component) {
     return props => {
         if(!messageId) return <Component {...props} />;
         return <Tooltip

--- a/src/webpack/common/components.ts
+++ b/src/webpack/common/components.ts
@@ -50,6 +50,8 @@ export let ScrollerThin: t.ScrollerThin;
 export let Clickable: t.Clickable;
 export let Avatar: t.Avatar;
 export let FocusLock: t.FocusLock;
+export let Spinner: t.Spinner;
+export let SpinnerType: t.SpinnerType;
 // token lagger real
 /** css colour resolver stuff, no clue what exactly this does, just copied usage from Discord */
 export let useToken: t.useToken;
@@ -83,7 +85,9 @@ waitFor(["FormItem", "Button"], m => {
         Clickable,
         Avatar,
         FocusLock,
-        Heading
+        Heading,
+        Spinner,
+        SpinnerType,
     } = m);
     Forms = m;
 });

--- a/src/webpack/common/types/components.d.ts
+++ b/src/webpack/common/types/components.d.ts
@@ -500,3 +500,22 @@ export type Avatar = ComponentType<PropsWithChildren<{
 type FocusLock = ComponentType<PropsWithChildren<{
     containerRef: RefObject<HTMLElement>;
 }>>;
+
+export declare enum SpinnerType {
+    WANDERING_CUBES = "wanderingCubes",
+    CHASING_DOTS = "chasingDots",
+    PULSING_ELLIPSIS = "pulsingEllipsis",
+    SPINNING_CIRCLE = "spinningCircle",
+    SPINNING_CIRCLE_SIMPLE = "spinningCircleSimple",
+    LOW_MOTION = "lowMotion",
+}
+
+export type Spinner = ComponentType<{
+    type?: SpinnerType;
+    animated?: boolean;
+    className?: string;
+    itemClassName?: string;
+    "aria-label"?: string;
+}> & {
+    Type: typeof SpinnerType;
+};


### PR DESCRIPTION
What it says on the tin. Merged/rewritten from my [MessageLinkTooltip](https://github.com/Kyuuhachi/VencordPlugins/blob/main/MessageLinkTooltip) plugin, as well as implementing https://github.com/Vencord/plugin-requests/issues/961.