### PR TITLE
GifPaste: add customization settings to modify behavior when shift is held

### DIFF
--- a/src/plugins/gifPaste/index.ts
+++ b/src/plugins/gifPaste/index.ts
@@ -24,12 +24,25 @@ import { ExpressionPickerStore, SelectedChannelStore } from "@webpack/common";
 
 let shiftHeld = false;
 
+const enum PickBehavior {
+    InputBox,
+    Send,
+}
+
 export const settings = definePluginSettings({
+    behavior: {
+        description: "Modify the default behavior when selecting a gif",
+        type: OptionType.SELECT,
+        options: [
+            { label: "Insert link into the chatbox", value: PickBehavior.InputBox, default: true },
+            { label: "Instantly send", value: PickBehavior.Send },
+        ],
+    },
     shiftOverride: {
+        description: "Use alternate behavior when holding shift",
         type: OptionType.BOOLEAN,
-        description: "Whether to instantly send the gif when holding shift",
-        default: true,
-    }
+        default: true
+    },
 });
 
 export default definePlugin({
@@ -58,7 +71,9 @@ export default definePlugin({
 
     handleSelect(gif?: { url: string; }) {
         if (!gif) return;
-        if (shiftHeld && settings.store.shiftOverride) {
+        const preferSend = settings.store.behavior === PickBehavior.Send;
+        const shouldSend = settings.store.shiftOverride ? preferSend !== shiftHeld : preferSend;
+        if (shouldSend) {
             sendMessage(SelectedChannelStore.getChannelId(), { content: gif.url });
         } else {
             insertTextIntoChatInputBox(gif.url + " ");

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -538,6 +538,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Joona",
         id: 297410829589020673n
     },
+    iilwy: {
+        name: "iminlikewithyou",
+        id: 971202946895339550n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
this makes GifPaste have two selectable behaviors from the settings modal:
1. insert the gif into the input box
2. instantly send the gif

you can select between the two behaviors, and this PR adds another setting which handily allows you to use the alternate behavior when the shift key is held down.

in essence, if your behavior is set to "Insert link into the chatbox", you can now hold shift to instantly send a gif. (similar to skipping a modal)

conversely, if your behavior is set to "Instantly send", you can hold shift to put the link in the chatbox instead. you cannot disable the shift override setting when using this behavior, since that's akin to just disabling the plugin entirely