### PR TITLE
feat(clearURLs): Replace URLs to Enhance Embed Functionality

### DIFF
--- a/src/plugins/clearURLs/defaultRules.ts
+++ b/src/plugins/clearURLs/defaultRules.ts
@@ -16,6 +16,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+export const urlMap = {
+    "https://twitter.com/": "https://fxtwitter.com/",
+    "https://x.com/": "https://fxtwitter.com/",
+    "https://www.tiktok.com/": "https://tiktok.com.xdd.moe/",
+    "https://vm.tiktok.com/": "https://tiktok.com.xdd.moe/",
+    "https://tiktok.com/": "http://tiktok.com.xdd.moe/",
+    "https://www.instagram.com/": "https://www.instagram.com.xdd.moe/",
+    "https://www.reddit.com/": "https://www.rxddit.com/",
+};
+
 export const defaultRules = [
     "action_object_map",
     "action_type_map",

--- a/src/plugins/clearURLs/index.ts
+++ b/src/plugins/clearURLs/index.ts
@@ -26,7 +26,7 @@ import {
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 
-import { defaultRules } from "./defaultRules";
+import { defaultRules, urlMap } from "./defaultRules";
 
 // From lodash
 const reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
@@ -34,7 +34,7 @@ const reHasRegExpChar = RegExp(reRegExpChar.source);
 
 export default definePlugin({
     name: "ClearURLs",
-    description: "Removes tracking garbage from URLs",
+    description: "Removes tracking garbage from URLs and replaces URLs with improved ones to fix embeds",
     authors: [Devs.adryd],
     dependencies: ["MessageEventsAPI"],
 
@@ -90,6 +90,13 @@ export default definePlugin({
     },
 
     replacer(match: string) {
+        for (const [oldUrl, newUrl] of Object.entries(urlMap)) {
+            if (match.startsWith(oldUrl)) {
+                match = match.replace(oldUrl, newUrl);
+                break;
+            }
+        }
+
         // Parse URL without throwing errors
         try {
             var url = new URL(match);


### PR DESCRIPTION
This PR replaces URLs to improve embed functionality for various social media platforms, including TikTok, Instagram, Twitter/X, and Reddit. The improved URLs ensure that embeds display correctly and consistently across these platforms.