### PR TITLE
Extend command argument value types

### DIFF
--- a/src/api/Commands/types.ts
+++ b/src/api/Commands/types.ts
@@ -79,7 +79,7 @@ export interface CommandReturnValue {
 export interface Argument {
     type: ApplicationCommandOptionType;
     name: string;
-    value: string;
+    value: string | number | boolean;
     focused: undefined;
     options: Argument[];
 }


### PR DESCRIPTION
They can be a bunch of different things, could also do any if that makes it easier but string is annoying because I have to keep writing @ts-ignore

![example boolean option](https://github.com/user-attachments/assets/2a997440-4d59-4b23-b314-0dd931495ec4)
