### PR TITLE
Expose "translate to" settings publicly

### DIFF
--- a/src/plugins/translate/settings.ts
+++ b/src/plugins/translate/settings.ts
@@ -30,7 +30,7 @@ export const settings = definePluginSettings({
         type: OptionType.STRING,
         description: "Language that received messages should be translated to",
         default: "en",
-        hidden: true
+        hidden: false
     },
     sentInput: {
         type: OptionType.STRING,
@@ -42,7 +42,7 @@ export const settings = definePluginSettings({
         type: OptionType.STRING,
         description: "Language that your own messages should be translated to",
         default: "en",
-        hidden: true
+        hidden: false
     },
 
     showChatBarButton: {


### PR DESCRIPTION
Reason: I recommended this plugin to my non-English-speaking friends, and apparently you can't edit the target language without manually exporting/importing the settings. I realize it's probably not the best impl. since it's unconstrained to the list of languages unlike the select option type, but I am not sure if you can supplement a dynamicly changing list of languages based on translation provider since I am not familiar with the "framework" you people are working in. If anyone can nudge me in the right direction and/or implement the option list it would be great.