### PR TITLE
make prerelease builds for commits & branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload latest release (devbuild)
-              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' && github.event.created
+              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' && !github.event.deleted
               run: |
                   gh release upload devbuild --clobber dist/*
                   gh release edit devbuild --title "DevBuild $COMMIT_SHORT"
@@ -60,7 +60,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload branch release
-              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name != 'main' && github.event.created
+              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name != 'main' && !github.event.deleted
               run: |
                   gh release create branch-$GITHUB_REF_NAME --latest=false --prerelease --target $GITHUB_REF_NAME --title "PreBuild $GITHUB_REF_NAME" || true
                   gh release upload branch-$GITHUB_REF_NAME --clobber dist/*
@@ -68,7 +68,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload commit release
-              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.event.created
+              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && !github.event.deleted
               continue-on-error: true
               run: |
                   gh release create commit-$COMMIT_SHORT --latest=false --prerelease --target $GITHUB_SHA --title "PreBuild $COMMIT_SHORT"
@@ -77,7 +77,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload DevBuild to builds repo
-              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' && github.event.created
+              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' && !github.event.deleted
               run: |
                   git config --global user.name "$USERNAME"
                   git config --global user.email actions@github.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,8 @@ jobs:
               if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && !github.event.deleted
               continue-on-error: true
               run: |
-                  gh release create commit-$COMMIT_SHORT --latest=false --prerelease --target $GITHUB_SHA --title "PreBuild $COMMIT_SHORT"
-                  gh release upload commit-$COMMIT_SHORT --clobber dist/*
+                  gh release create "commit-$COMMIT_SHORT" --latest=false --prerelease --target $GITHUB_SHA --title "PreBuild $COMMIT_SHORT"
+                  gh release upload "commit-$COMMIT_SHORT" --clobber dist/*
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
-name: Build DevBuild
+name: Build releases
 on:
     push:
-        branches:
-            - main
         paths:
             - .github/workflows/build.yml
             - src/**
@@ -45,21 +43,39 @@ jobs:
                   rm -rf dist/*-unpacked dist/monaco Vencord.user.css vencordDesktopRenderer.css vencordDesktopRenderer.css.map
 
             - name: Get some values needed for the release
-              id: release_values
               run: |
-                  echo "release_tag=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+                  echo "commit_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+                  gh release view devbuild &> /dev/null \
+                    && echo "devbuild_exists=true" >> $GITHUB_ENV \
+                    || echo "devbuild_exists=false" >> $GITHUB_ENV
 
-            - name: Upload DevBuild as release
-              if: github.repository == 'Vendicated/Vencord'
+            - name: Upload latest release (devbuild)
+              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' && github.event.created
               run: |
                   gh release upload devbuild --clobber dist/*
-                  gh release edit devbuild --title "DevBuild $RELEASE_TAG"
+                  gh release edit devbuild --title "DevBuild $COMMIT_SHORT"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  RELEASE_TAG: ${{ env.release_tag }}
+
+            - name: Upload branch release
+              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name != 'main' && github.event.created
+              run: |
+                  gh release create branch-$GITHUB_REF_NAME --latest=false --prerelease --title "PreBuild $GITHUB_REF_NAME" || true
+                  gh release upload branch-$GITHUB_REF_NAME --clobber dist/*
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Upload commit release
+              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.event.created
+              continue-on-error: true
+              run: |
+                  gh release create commit-$COMMIT_SHORT --latest=false --prerelease --title "PreBuild $COMMIT_SHORT"
+                  gh release upload commit-$COMMIT_SHORT --clobber dist/*
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload DevBuild to builds repo
-              if: github.repository == 'Vendicated/Vencord'
+              if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' && github.event.created
               run: |
                   git config --global user.name "$USERNAME"
                   git config --global user.email actions@github.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Upload branch release
               if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name != 'main' && github.event.created
               run: |
-                  gh release create branch-$GITHUB_REF_NAME --latest=false --prerelease --title "PreBuild $GITHUB_REF_NAME" || true
+                  gh release create branch-$GITHUB_REF_NAME --latest=false --prerelease --target $GITHUB_REF_NAME --title "PreBuild $GITHUB_REF_NAME" || true
                   gh release upload branch-$GITHUB_REF_NAME --clobber dist/*
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
               if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.event.created
               continue-on-error: true
               run: |
-                  gh release create commit-$COMMIT_SHORT --latest=false --prerelease --title "PreBuild $COMMIT_SHORT"
+                  gh release create commit-$COMMIT_SHORT --latest=false --prerelease --target $GITHUB_SHA --title "PreBuild $COMMIT_SHORT"
                   gh release upload commit-$COMMIT_SHORT --clobber dist/*
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,8 @@ jobs:
                   gh release view devbuild &> /dev/null \
                     && echo "devbuild_exists=true" >> $GITHUB_ENV \
                     || echo "devbuild_exists=false" >> $GITHUB_ENV
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload latest release (devbuild)
               if: env.devbuild_exists == 'true' && startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' && github.event.created

--- a/browser/VencordNativeStub.ts
+++ b/browser/VencordNativeStub.ts
@@ -59,6 +59,7 @@ window.VencordNative = {
     },
 
     updater: {
+        setUpdateSource: async () => void 0,
         getRepo: async () => ({ ok: true, value: "https://github.com/Vendicated/Vencord" }),
         getUpdates: async () => ({ ok: true, value: [] }),
         update: async () => ({ ok: true, value: false }),

--- a/scripts/build/common.mjs
+++ b/scripts/build/common.mjs
@@ -193,7 +193,13 @@ export const gitRemotePlugin = {
         build.onLoad({ filter, namespace: "git-remote" }, async () => {
             let remote = process.env.VENCORD_REMOTE;
             if (!remote) {
-                const res = await promisify(exec)("git remote get-url origin", { encoding: "utf-8" });
+                const headRefRes = await promisify(exec)("git symbolic-ref -q HEAD", { encoding: "utf-8" }).catch(() => ({ stdout: "" }));
+                const headRef = headRefRes.stdout.trim();
+                const upstreamRes = await promisify(exec)(`git for-each-ref --format=%(upstream:short) "${headRef}"`, { encoding: "utf-8" })
+                    .catch(() => ({ stdout: "" }));
+                const remoteName = upstreamRes.stdout.trim().split("/")[0] || "origin";
+                const res = await promisify(exec)(`git remote get-url ${remoteName}`, { encoding: "utf-8" });
+
                 remote = res.stdout.trim()
                     .replace("https://github.com/", "")
                     .replace("git@github.com:", "")

--- a/src/VencordNative.ts
+++ b/src/VencordNative.ts
@@ -40,6 +40,7 @@ export default {
     },
 
     updater: {
+        setUpdateSource: (source: "latest" | "branch" | "commit", name: string) => invoke<void>(IpcEvents.SET_UPDATE_SOURCE, source, name),
         getUpdates: () => invoke<IpcRes<Record<"hash" | "author" | "message", string>[]>>(IpcEvents.GET_UPDATES),
         update: () => invoke<IpcRes<boolean>>(IpcEvents.UPDATE),
         rebuild: () => invoke<IpcRes<boolean>>(IpcEvents.BUILD),

--- a/src/main/updater/git.ts
+++ b/src/main/updater/git.ts
@@ -25,6 +25,7 @@ import { promisify } from "util";
 import { serializeErrors } from "./common";
 
 const VENCORD_SRC_DIR = join(__dirname, "..");
+const REMOTE_NAME = "origin";
 
 const execFile = promisify(cpExecFile);
 
@@ -40,7 +41,7 @@ function git(...args: string[]) {
 }
 
 async function getRepo() {
-    const res = await git("remote", "get-url", "origin");
+    const res = await git("remote", "get-url", REMOTE_NAME);
     return res.stdout.trim()
         .replace(/git@(.+):/, "https://$1/")
         .replace(/\.git$/, "");
@@ -51,10 +52,10 @@ async function calculateGitChanges() {
 
     const branch = (await git("branch", "--show-current")).stdout.trim();
 
-    const existsOnOrigin = (await git("ls-remote", "origin", branch)).stdout.length > 0;
-    if (!existsOnOrigin) return [];
+    const existsOnRemote = (await git("ls-remote", REMOTE_NAME, branch)).stdout.length > 0;
+    if (!existsOnRemote) return [];
 
-    const res = await git("log", `HEAD...origin/${branch}`, "--pretty=format:%an/%h/%s");
+    const res = await git("log", `HEAD...${REMOTE_NAME}/${branch}`, "--pretty=format:%an/%h/%s");
 
     const commits = res.stdout.trim();
     return commits ? commits.split("\n").map(line => {
@@ -84,7 +85,12 @@ async function build() {
     return !res.stderr.includes("Build failed");
 }
 
+async function setUpdateSource() {
+    // noop
+}
+
 ipcMain.handle(IpcEvents.GET_REPO, serializeErrors(getRepo));
 ipcMain.handle(IpcEvents.GET_UPDATES, serializeErrors(calculateGitChanges));
 ipcMain.handle(IpcEvents.UPDATE, serializeErrors(pull));
 ipcMain.handle(IpcEvents.BUILD, serializeErrors(build));
+ipcMain.handle(IpcEvents.SET_UPDATE_SOURCE, serializeErrors(setUpdateSource));

--- a/src/main/updater/git.ts
+++ b/src/main/updater/git.ts
@@ -25,7 +25,6 @@ import { promisify } from "util";
 import { serializeErrors } from "./common";
 
 const VENCORD_SRC_DIR = join(__dirname, "..");
-const REMOTE_NAME = "origin";
 
 const execFile = promisify(cpExecFile);
 
@@ -41,7 +40,7 @@ function git(...args: string[]) {
 }
 
 async function getRepo() {
-    const res = await git("remote", "get-url", REMOTE_NAME);
+    const res = await git("remote", "get-url", "origin");
     return res.stdout.trim()
         .replace(/git@(.+):/, "https://$1/")
         .replace(/\.git$/, "");
@@ -52,10 +51,10 @@ async function calculateGitChanges() {
 
     const branch = (await git("branch", "--show-current")).stdout.trim();
 
-    const existsOnRemote = (await git("ls-remote", REMOTE_NAME, branch)).stdout.length > 0;
-    if (!existsOnRemote) return [];
+    const existsOnOrigin = (await git("ls-remote", "origin", branch)).stdout.length > 0;
+    if (!existsOnOrigin) return [];
 
-    const res = await git("log", `HEAD...${REMOTE_NAME}/${branch}`, "--pretty=format:%an/%h/%s");
+    const res = await git("log", `HEAD...origin/${branch}`, "--pretty=format:%an/%h/%s");
 
     const commits = res.stdout.trim();
     return commits ? commits.split("\n").map(line => {

--- a/src/main/updater/http.ts
+++ b/src/main/updater/http.ts
@@ -47,7 +47,7 @@ async function calculateGitChanges() {
     const isOutdated = await fetchUpdates();
     if (!isOutdated) return [];
 
-    const res = await githubGet(`/compare/${gitHash}...HEAD`);
+    const res = await githubGet(`/compare/${gitHash}...${UpdateSource.ref}`);
 
     const data = JSON.parse(res.toString("utf-8"));
     return data.commits.map((c: any) => ({
@@ -59,7 +59,7 @@ async function calculateGitChanges() {
 }
 
 async function fetchUpdates() {
-    const release = await githubGet("/releases/latest");
+    const release = await githubGet(`/releases${UpdateSource.release}`);
 
     const data = JSON.parse(release.toString());
     const hash = data.name.slice(data.name.lastIndexOf(" ") + 1);
@@ -86,7 +86,7 @@ async function applyUpdates() {
 }
 
 async function setUpdateSource(source: "latest" | "branch" | "commit", name: string) {
-    if (source === "latest") UpdateSource = { release: "latest", ref: "HEAD" };
+    if (source === "latest") UpdateSource = { release: "/latest", ref: "HEAD" };
     else if (source === "branch") UpdateSource = { release: `/tags/branch-${name}`, ref: `refs/heads/${name}` };
     else if (source === "commit") UpdateSource = { release: `/tags/commit-${name}`, ref: name };
 }

--- a/src/shared/IpcEvents.ts
+++ b/src/shared/IpcEvents.ts
@@ -32,6 +32,7 @@ export const enum IpcEvents {
     SET_SETTINGS = "VencordSetSettings",
     OPEN_EXTERNAL = "VencordOpenExternal",
     OPEN_QUICKCSS = "VencordOpenQuickCss",
+    SET_UPDATE_SOURCE = "VencordSetUpdateSource",
     GET_UPDATES = "VencordGetUpdates",
     GET_REPO = "VencordGetRepo",
     UPDATE = "VencordUpdate",


### PR DESCRIPTION
this makes it so commits create/update a `commit-{SHA1}` & `branch-{BRANCH}` tagged release, and gives us an API we can use like `VencordNative.updater.setUpdateSource("branch", "asar-bundle")` to make updater testing easier