### PR TITLE
Ignore blocked users in whoReacted avatars

### DIFF
--- a/src/plugins/whoReacted/index.tsx
+++ b/src/plugins/whoReacted/index.tsx
@@ -29,6 +29,7 @@ import { Message, ReactionEmoji, User } from "discord-types/general";
 
 const UserSummaryItem = findComponentByCodeLazy("defaultRenderUser", "showDefaultAvatarsForNullUsers");
 const AvatarStyles = findByPropsLazy("moreUsers", "emptyUser", "avatarContainer", "clickableAvatar");
+const RelationshipStore = findByPropsLazy("getRelationships", "isBlocked");
 let Scroll: any = null;
 const queue = new Queue();
 let reactions: Record<string, ReactionCacheEntry>;
@@ -100,7 +101,7 @@ function handleClickAvatar(event: React.MouseEvent<HTMLElement, MouseEvent>) {
 export default definePlugin({
     name: "WhoReacted",
     description: "Renders the avatars of users who reacted to a message",
-    authors: [Devs.Ven, Devs.KannaDev, Devs.newwares],
+    authors: [Devs.Ven, Devs.KannaDev, Devs.newwares, Devs.lannoene],
 
     patches: [
         {
@@ -155,7 +156,7 @@ export default definePlugin({
         }, [message.id]);
 
         const reactions = getReactionsWithQueue(message, emoji, type);
-        const users = Object.values(reactions).filter(Boolean) as User[];
+        const users = Object.values(reactions).filter((v) => {return v && !RelationshipStore.isBlocked(v.id)}) as User[];
 
         return (
             <div

--- a/src/plugins/whoReacted/index.tsx
+++ b/src/plugins/whoReacted/index.tsx
@@ -21,26 +21,17 @@ import { Devs } from "@utils/constants";
 import { sleep } from "@utils/misc";
 import { Queue } from "@utils/Queue";
 import { useForceUpdater } from "@utils/react";
-import definePlugin, { OptionType } from "@utils/types";
+import definePlugin from "@utils/types";
 import { findByPropsLazy, findComponentByCodeLazy } from "@webpack";
 import { ChannelStore, Constants, FluxDispatcher, React, RestAPI, Tooltip, RelationshipStore } from "@webpack/common";
 import { CustomEmoji } from "@webpack/types";
 import { Message, ReactionEmoji, User } from "discord-types/general";
-import { definePluginSettings } from "@api/Settings";
 
 const UserSummaryItem = findComponentByCodeLazy("defaultRenderUser", "showDefaultAvatarsForNullUsers");
 const AvatarStyles = findByPropsLazy("moreUsers", "emptyUser", "avatarContainer", "clickableAvatar");
 let Scroll: any = null;
 const queue = new Queue();
 let reactions: Record<string, ReactionCacheEntry>;
-
-const settings = definePluginSettings({
-    hideBlockedUsers: {
-        description: "Hide blocked users from showing up in the avatar list",
-        type: OptionType.BOOLEAN,
-        default: false,
-    },
-});
 
 function fetchReactions(msg: Message, emoji: ReactionEmoji, type: number) {
     const key = emoji.name + (emoji.id ? `:${emoji.id}` : "");
@@ -110,7 +101,6 @@ export default definePlugin({
     name: "WhoReacted",
     description: "Renders the avatars of users who reacted to a message",
     authors: [Devs.Ven, Devs.KannaDev, Devs.newwares],
-    settings,
 
     patches: [
         {
@@ -165,7 +155,7 @@ export default definePlugin({
         }, [message.id]);
 
         const reactions = getReactionsWithQueue(message, emoji, type);
-        const users = Object.values(reactions).filter((v) => v && (!RelationshipStore.isBlocked(v.id) || !settings.store.hideBlockedUsers)) as User[];
+        const users = Object.values(reactions).filter((v) => v && (!RelationshipStore.isBlocked(v.id) || !Vencord.Plugins.isPluginEnabled("NoBlockedMessages"))) as User[];
 
         return (
             <div

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -546,10 +546,6 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Lumap",
         id: 585278686291427338n,
     },
-    lannoene: {
-        name: "lannoene",
-        id: 527210953956130818n
-    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -546,6 +546,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Lumap",
         id: 585278686291427338n,
     },
+    lannoene: {
+        name: "lannoene",
+        id: 527210953956130818n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
yeah that's it. i took the relationship store thing from noblockedmessages and there they used a try catch when getting the blocked status for users. i haven't had any issues without it though. if i should add it, feel free to tell me.