### PR TITLE
Remove dependency on virtual-merge, only required by fakeProfileThemes plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
         "fflate": "^0.8.2",
         "gifenc": "github:mattdesl/gifenc#64842fca317b112a8590f8fef2bf3825da8f6fe3",
         "monaco-editor": "^0.50.0",
-        "nanoid": "^5.0.7",
-        "virtual-merge": "^1.0.1"
+        "nanoid": "^5.0.7"
     },
     "devDependencies": {
         "@stylistic/eslint-plugin": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,6 @@ importers:
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
-      virtual-merge:
-        specifier: ^1.0.1
-        version: 1.0.1
     devDependencies:
       '@stylistic/eslint-plugin':
         specifier: ^2.6.1
@@ -2629,9 +2626,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  virtual-merge@1.0.1:
-    resolution: {integrity: sha512-h7rzV6n5fZJbDu2lP4iu+IOtsZ00uqECFUxFePK1uY0pz/S5B7FNDJpmdDVfyGL7poyJECEHfTaIpJaknNkU0Q==}
 
   vscode-oniguruma@1.7.0:
     resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
@@ -5283,8 +5277,6 @@ snapshots:
   use@3.1.1: {}
 
   util-deprecate@1.0.2: {}
-
-  virtual-merge@1.0.1: {}
 
   vscode-oniguruma@1.7.0: {}
 

--- a/src/plugins/fakeProfileThemes/index.tsx
+++ b/src/plugins/fakeProfileThemes/index.tsx
@@ -29,7 +29,6 @@ import definePlugin, { OptionType } from "@utils/types";
 import { extractAndLoadChunksLazy, findComponentByCodeLazy } from "@webpack";
 import { Button, Flex, Forms, React, Text, UserProfileStore, UserStore, useState } from "@webpack/common";
 import { User } from "discord-types/general";
-import virtualMerge from "virtual-merge";
 
 interface UserProfile extends User {
     themeColors?: Array<number>;
@@ -232,10 +231,7 @@ export default definePlugin({
             if (settings.store.nitroFirst && user.themeColors) return user;
             const colors = decode(user.bio);
             if (colors) {
-                return virtualMerge(user, {
-                    premiumType: 2,
-                    themeColors: colors
-                });
+                return { ...user, premiumType: 2, themeColors: colors };
             }
         }
         return user;


### PR DESCRIPTION
Removes dependency on [virtual-merge](https://www.npmjs.com/package/virtual-merge), this was only "required" by fakeProfileThemes, however you can just merge objects normally in this case, without worrying about reflecting the merge back onto the passed in `user` parameter. Will add myself as a plugin author if needed/wanted, but this feels like a simple enough change to not need it :3