### PR TITLE
feat(plugin):NoProfileEffect

### DIFF
--- a/src/plugins/NoProfileEffect/index.ts
+++ b/src/plugins/NoProfileEffect/index.ts
@@ -1,0 +1,18 @@
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+  name: "NoProfileEffect",
+  description: "Hide profile effects",
+  authors: [Devs.LonoxX],
+  patches: [],
+
+  start() {
+    const style = document.createElement('style');
+    style.innerHTML = `
+            [class^="profileEffects_"], [class*=" profileEffects_"] { display: none !important; }
+        `;
+    document.head.appendChild(style);
+  },
+
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -546,6 +546,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Lumap",
         id: 585278686291427338n,
     },
+    LonoxX: {
+        name: "LonoxX",
+        id: 396173519953592320n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Hide the effects in profiles, as some of them can be very overwhelming when viewing a profile.