### PR TITLE
feat(Plugin): Add AlwaysExpandRoles

### DIFF
--- a/src/plugins/alwaysExpandRoles/index.ts
+++ b/src/plugins/alwaysExpandRoles/index.ts
@@ -1,0 +1,17 @@
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "AlwaysExpandRoles",
+    description: "Always expands the role list in profile popouts",
+    authors: [Devs.surgedevs],
+    patches: [
+        {
+            find: "action:\"EXPAND_ROLES\"",
+            replacement: {
+                match: /(let\s+\i=\d+===\i\?\i:)\d+;/,
+                replace: "$1Number.MAX_VALUE;"
+            }
+        }
+    ]
+});


### PR DESCRIPTION
Adds a plugin to always expand the role list in profile popouts.
This was highly requested and sparked drama in the Discord server, very small plugin, not sure what else to say.