### PR TITLE
feat(Plugin): Add HideActivityTab

### DIFF
--- a/src/plugins/hideActivityTab/index.tsx
+++ b/src/plugins/hideActivityTab/index.tsx
@@ -1,0 +1,37 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+let style: HTMLStyleElement;
+
+export default definePlugin({
+    name: "HideActivityTab",
+    description: "This plugin hides the recent activity tab on the members list",
+    authors: [Devs.dpaulos6],
+
+    async start() {
+        style = document.createElement("style");
+        style.id = "VencordHideActivityTab";
+        document.head.appendChild(style);
+
+        await this.buildCss();
+    },
+
+    stop() {
+        style.remove();
+    },
+
+    async buildCss() {
+        style.textContent = `
+            .content_eed6a8 .container_c64476,
+            .membersGroup_cbd271:has(> .headerContainer_bc6acb) {
+                display: none;
+            }
+        `;
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -546,6 +546,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Lumap",
         id: 585278686291427338n,
     },
+    dpaulos6: {
+        name: "paulos",
+        id: 256154963602964480n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This plugin hides the newly added Activity Tab on the members list.