### PR TITLE
feat(CustomRPC): Adds a button to disable CustomRPC directly from the account panel 

### DIFF
--- a/src/plugins/customRPC/style.css
+++ b/src/plugins/customRPC/style.css
@@ -1,0 +1,3 @@
+[class*="panels"] [class*="avatarWrapper"] {
+    min-width: 88px;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -434,6 +434,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "nin0dev",
         id: 886685857560539176n
     },
+    loosaz: {
+        name: "LoosaZ",
+        id:310099824777232394n,
+    },
     Elvyra: {
         name: "Elvyra",
         id: 708275751816003615n,


### PR DESCRIPTION
Using the GameToggleActivity button code I was able to add a similar feature to CustomRPC, where before this, you would need to enter the plugins page and disable it from there, now, all you need to do is click on the "Disable CustomRPC" button added to the account panel.
![Button](https://github.com/user-attachments/assets/f4b04343-3ae5-4cb6-8f33-5169677ec38f)

