### PR TITLE
LastFM: Added dropdown for activity type

### DIFF
--- a/src/plugins/lastfm/index.tsx
+++ b/src/plugins/lastfm/index.tsx
@@ -65,7 +65,9 @@ interface TrackData {
 // only relevant enum values
 const enum ActivityType {
     PLAYING = 0,
+    STREAMING = 1,
     LISTENING = 2,
+    WATCHING = 3
 }
 
 const enum ActivityFlag {
@@ -160,10 +162,28 @@ const settings = definePluginSettings({
             }
         ],
     },
-    useListeningStatus: {
-        description: 'show "Listening to" status instead of "Playing"',
-        type: OptionType.BOOLEAN,
-        default: false,
+    activityType: {
+        description: 'Activity Type',
+        type: OptionType.SELECT,
+        options: [
+            {
+                label: "Playing",
+                value: ActivityType.PLAYING,
+                default: true
+            },
+            {
+                label: "Listening",
+                value: ActivityType.LISTENING
+            },
+            {
+                label: "Streaming",
+                value: ActivityType.STREAMING
+            },
+            {
+                label: "Watching",
+                value: ActivityType.WATCHING
+            }
+        ]
     },
     missingArt: {
         description: "When album or album art is missing",
@@ -344,7 +364,7 @@ export default definePlugin({
                 button_urls: buttons.map(v => v.url),
             },
 
-            type: settings.store.useListeningStatus ? ActivityType.LISTENING : ActivityType.PLAYING,
+            type: settings.store.activityType,
             flags: ActivityFlag.INSTANCE,
         };
     }


### PR DESCRIPTION
Activity type now uses a dropdown rather than 1 toggle between playing and listening.

Note: Streaming will show as Playing in the member list, however, it will show as streaming on profiles. The purple status indicator also only appears in the bottom left user card. Watching won't show the 3rd label (album name) but it seems to show how long it has been active instead.

![image](https://github.com/user-attachments/assets/978c97a6-183c-4d84-984c-e0661f49a10e)
![image](https://github.com/user-attachments/assets/20085b8f-069a-4fdc-9edc-9f309a7303ba)
![image](https://github.com/user-attachments/assets/10fb50dc-bf7b-486f-a736-19775c7fbb70)