### PR TITLE
PronounDB: fix pronoun tooltip

### DIFF
--- a/src/plugins/pronoundb/index.ts
+++ b/src/plugins/pronoundb/index.ts
@@ -57,7 +57,7 @@ export default definePlugin({
                 },
                 {
                     match: /text:\i\.\i.Messages.USER_PROFILE_PRONOUNS/,
-                    replace: '$&+vcHasPendingPronouns?"":` (${vcPronounSource})`'
+                    replace: '$&+(vcHasPendingPronouns?"":` (${vcPronounSource})`)'
                 },
                 {
                     match: /(\.pronounsText.+?children:)(\i)/,


### PR DESCRIPTION
The text in the tooltip (after patching) is:
```js
d.Z.Messages.USER_PROFILE_PRONOUNS + vcHasPendingPronouns ? "" : ` (${vcPronounSource})`
```
... which ends up checking if `'Pronomsfalse'` is truthy, so the whole thing ends up evaluating to `''`, and we end up with an empty tooltip on the pronouns field in the profile.

Adding parentheses makes sure it's checking `vcHasPendingPronouns` only:
```js
d.Z.Messages.USER_PROFILE_PRONOUNS + (vcHasPendingPronouns ? "" : ` (${vcPronounSource})`)
```
This evaluates to `'Pronoms (Discord)'` as intended.