### PR TITLE
fix: CopyFileContents

### DIFF
--- a/src/plugins/copyFileContents/index.tsx
+++ b/src/plugins/copyFileContents/index.tsx
@@ -37,7 +37,7 @@ export default definePlugin({
         const [recentlyCopied, setRecentlyCopied] = useState(false);
 
         return (
-            <Tooltip text={recentlyCopied ? "Copied!" : bytesLeft > 0 ? "File too large to copy" : "Copy File Contents"}>
+            <Tooltip text={recentlyCopied ? "Copied!" : bytesLeft > 0 ? "File too large to copy" : "Copy file contents"}>
                 {tooltipProps => (
                     <div
                         {...tooltipProps}


### PR DESCRIPTION
Changed the copy button's tooltip to sentence case, as the default buttons already present in Discord (‘Expand {number} lines’, ‘View whole file’, ‘Change language’) do not use title case, either.