### PR TITLE
PinDMs: Add ability to display on server list

### DIFF
--- a/src/plugins/pinDms/README.md
+++ b/src/plugins/pinDms/README.md
@@ -1,0 +1,6 @@
+# PinDMs
+
+Allows you to pin private channels to the top of your DM and Server list, with customizable categories
+
+![](https://github.com/user-attachments/assets/a632b90c-d447-49a7-9efe-b045504ae47f)
+![](https://github.com/user-attachments/assets/9942994b-8a95-418e-b323-dd8ce07ff807)

--- a/src/plugins/pinDms/components/CreateCategoryModal.tsx
+++ b/src/plugins/pinDms/components/CreateCategoryModal.tsx
@@ -7,7 +7,7 @@
 import { classNameFactory } from "@api/Styles";
 import { ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, openModalLazy } from "@utils/modal";
 import { extractAndLoadChunksLazy, findComponentByCodeLazy, findExportedComponentLazy } from "@webpack";
-import { Button, Forms, Text, TextInput, Toasts, useEffect, useState } from "@webpack/common";
+import { Button, Forms, Switch, Text, TextInput, Toasts, useEffect, useState } from "@webpack/common";
 
 import { DEFAULT_COLOR, SWATCHES } from "../constants";
 import { categories, Category, createCategory, getCategory, updateCategory } from "../data";
@@ -55,6 +55,7 @@ function useCategory(categoryId: string | null, initalChannelId: string | null) 
                 name: `Pin Category ${categories.length + 1}`,
                 color: DEFAULT_COLOR,
                 collapsed: false,
+                displayOnServerList: false,
                 channels: [initalChannelId]
             });
     }, [categoryId, initalChannelId]);
@@ -116,6 +117,17 @@ export function NewCategoryModal({ categoryId, modalProps, initalChannelId }: Pr
                                 />
                             )}
                         />
+                    </Forms.FormSection>
+                    <Forms.FormDivider />
+                    <Forms.FormSection>
+                        <Forms.FormTitle>Other</Forms.FormTitle>
+                        <Switch
+                            key="server-list-display"
+                            value={category.displayOnServerList ?? false}
+                            onChange={v => setCategory({ ...category, displayOnServerList: v })}
+                        >
+                            Display on Server List when expanded
+                        </Switch>
                     </Forms.FormSection>
                 </ModalContent>
                 <ModalFooter>

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -118,7 +118,7 @@ export function getAllUncollapsedChannels() {
 export function getAllGuildsBarChannels() {
     const privateChannelIds = PrivateChannelSortStore.getPrivateChannelIds();
 
-    if (settings.store.pinOrder === PinOrder.LastMessage && privateChannelIds.length != 0) {
+    if (settings.store.pinOrder === PinOrder.LastMessage && privateChannelIds.length !== 0) {
         const sortedChannels = PrivateChannelSortStore.getPrivateChannelIds();
         return categories.filter(c => c.displayOnServerList && !c.collapsed).flatMap(c => sortedChannels.filter(channel => c.channels.includes(channel)));
     }

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -17,6 +17,7 @@ export interface Category {
     color: number;
     channels: string[];
     collapsed?: boolean;
+    displayOnServerList?: boolean;
 }
 
 const CATEGORY_BASE_KEY = "PinDMsCategories-";
@@ -112,6 +113,17 @@ export function getAllUncollapsedChannels() {
     }
 
     return categories.filter(c => !c.collapsed).flatMap(c => c.channels);
+}
+
+export function getAllGuildsBarChannels() {
+    const privateChannelIds = PrivateChannelSortStore.getPrivateChannelIds();
+
+    if (settings.store.pinOrder === PinOrder.LastMessage && privateChannelIds.length != 0) {
+        const sortedChannels = PrivateChannelSortStore.getPrivateChannelIds();
+        return categories.filter(c => c.displayOnServerList && !c.collapsed).flatMap(c => sortedChannels.filter(channel => c.channels.includes(channel)));
+    }
+
+    return categories.filter(c => c.displayOnServerList && !c.collapsed).flatMap(c => c.channels);
 }
 
 export function getSections() {

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -18,7 +18,7 @@ import { Channel } from "discord-types/general";
 import { contextMenus } from "./components/contextMenu";
 import { openCategoryModal, requireSettingsMenu } from "./components/CreateCategoryModal";
 import { DEFAULT_CHUNK_SIZE } from "./constants";
-import { canMoveCategory, canMoveCategoryInDirection, categories, Category, categoryLen, collapseCategory, getAllUncollapsedChannels, getSections, init, isPinned, moveCategory, removeCategory } from "./data";
+import { canMoveCategory, canMoveCategoryInDirection, categories, Category, categoryLen, collapseCategory, getAllGuildsBarChannels, getAllUncollapsedChannels, getSections, init, isPinned, moveCategory, removeCategory } from "./data";
 
 interface ChannelComponentProps {
     children: React.ReactNode,
@@ -30,9 +30,14 @@ interface ChannelComponentProps {
 const headerClasses = findByPropsLazy("privateChannelsHeaderContainer");
 
 export const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as { getPrivateChannelIds: () => string[]; };
+const PrivateChannelReadStateStore = findStoreLazy("PrivateChannelReadStateStore");
 
 export let instance: any;
-export const forceUpdate = () => instance?.props?._forceUpdate?.();
+
+export function forceUpdate() {
+    instance?.props?._forceUpdate?.();
+    PrivateChannelReadStateStore.emitChange();
+};
 
 export const enum PinOrder {
     LastMessage,
@@ -61,7 +66,7 @@ export const settings = definePluginSettings({
 export default definePlugin({
     name: "PinDMs",
     description: "Allows you to pin private channels to the top of your DM list. To pin/unpin or reorder pins, right click DMs",
-    authors: [Devs.Ven, Devs.Aria],
+    authors: [Devs.Ven, Devs.Aria, Devs.niko],
     settings,
     contextMenus,
 
@@ -148,6 +153,15 @@ export default definePlugin({
                 replace: "$self.getAllUncollapsedChannels().concat($&.filter(c=>!$self.isPinned(c)))"
             }
         },
+
+        // Insert pinned dms to guilds bar
+        {
+            find: "{selectedVoiceGuildId:",
+            replacement: {
+                match: /\i\.\i\.getUnreadPrivateChannelIds\(\)/,
+                replace: "$self.getAllGuildsBarChannels().concat($&)"
+            }
+        }
     ],
     sections: null as number[] | null,
 
@@ -166,6 +180,7 @@ export default definePlugin({
     categoryLen,
     getSections,
     getAllUncollapsedChannels,
+    getAllGuildsBarChannels,
     requireSettingsMenu,
 
     makeProps(instance, { sections }: { sections: number[]; }) {

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -37,7 +37,7 @@ export let instance: any;
 export function forceUpdate() {
     instance?.props?._forceUpdate?.();
     PrivateChannelReadStateStore.emitChange();
-};
+}
 
 export const enum PinOrder {
     LastMessage,


### PR DESCRIPTION
This PR adds the ability to display categories of pinned DMs on the guilds bar/server list.
It also adds a README as it was missing.

![](https://github.com/user-attachments/assets/9942994b-8a95-418e-b323-dd8ce07ff807)

Closes Vencord/plugin-requests#439