### PR TITLE
Prevent preview message button from appearing on chat input commands

### DIFF
--- a/src/plugins/previewMessage/index.tsx
+++ b/src/plugins/previewMessage/index.tsx
@@ -81,8 +81,9 @@ const PreviewButton: ChatBarButton = ({ isMainChat, isEmpty, type: { attachments
 
     const hasAttachments = attachments && UploadStore.getUploads(channelId, DraftType.ChannelMessage).length > 0;
     const hasContent = !isEmpty && draft?.length > 0;
+    const isCommand = draft?.split(" ")[0]?.match(/^\/[-_\p{L}\p{N}]{1,32}$/gmu) !== null;
 
-    if (!hasContent && !hasAttachments) return null;
+    if (!hasContent && !hasAttachments || isCommand) return null;
 
     return (
         <ChatBarButton


### PR DESCRIPTION
Change the `previewMessage` plugin to hide the preview button on messages where the first word matches `/^\/[-_\p{L}\p{N}]{1,32}$/gmu` as the preview will simply be `/ping option:option value` which you can get by copying the command with ctrl + c