### PR TITLE
fix crashing on canary when searching slash commands

### DIFF
--- a/src/api/Commands/index.ts
+++ b/src/api/Commands/index.ts
@@ -138,6 +138,8 @@ export function registerCommand<C extends Command>(command: C, plugin: string) {
         throw new Error(`Command '${command.name}' already exists.`);
 
     command.isVencordCommand = true;
+    command.untranslatedName = command.name;
+    command.untranslatedDescription = command.description;
     command.id ??= `-${BUILT_IN.length + 1}`;
     command.applicationId ??= "-1"; // BUILT_IN;
     command.type ??= ApplicationCommandType.CHAT_INPUT;

--- a/src/api/Commands/index.ts
+++ b/src/api/Commands/index.ts
@@ -138,8 +138,8 @@ export function registerCommand<C extends Command>(command: C, plugin: string) {
         throw new Error(`Command '${command.name}' already exists.`);
 
     command.isVencordCommand = true;
-    command.untranslatedName = command.name;
-    command.untranslatedDescription = command.description;
+    command.untranslatedName ??= command.name;
+    command.untranslatedDescription ??= command.description;
     command.id ??= `-${BUILT_IN.length + 1}`;
     command.applicationId ??= "-1"; // BUILT_IN;
     command.type ??= ApplicationCommandType.CHAT_INPUT;

--- a/src/api/Commands/types.ts
+++ b/src/api/Commands/types.ts
@@ -93,8 +93,10 @@ export interface Command {
     isVencordCommand?: boolean;
 
     name: string;
+    untranslatedName: string;
     displayName?: string;
     description: string;
+    untranslatedDescription: string;
     displayDescription?: string;
 
     options?: Option[];

--- a/src/api/Commands/types.ts
+++ b/src/api/Commands/types.ts
@@ -93,10 +93,10 @@ export interface Command {
     isVencordCommand?: boolean;
 
     name: string;
-    untranslatedName: string;
+    untranslatedName?: string;
     displayName?: string;
     description: string;
-    untranslatedDescription: string;
+    untranslatedDescription?: string;
     displayDescription?: string;
 
     options?: Option[];


### PR DESCRIPTION
this fixes a crash caused by vencord commands lacking the `untranslatedName` and `untranslatedDescription` fields by.. adding them

(ty aaamia for finding this bug)