### PR TITLE
TimeBarAllActivities: Fix patch

### DIFF
--- a/src/plugins/timeBarAllActivities/index.tsx
+++ b/src/plugins/timeBarAllActivities/index.tsx
@@ -40,7 +40,7 @@ export default definePlugin({
     settings,
     patches: [
         {
-            find: 'location:"UserProfileActivityCard"',
+            find: ".gameState,children:",
             replacement: [
                 // Insert Spotify time bar component
                 {

--- a/src/plugins/timeBarAllActivities/index.tsx
+++ b/src/plugins/timeBarAllActivities/index.tsx
@@ -40,7 +40,7 @@ export default definePlugin({
     settings,
     patches: [
         {
-            find: ".Messages.USER_ACTIVITY_PLAYING",
+            find: 'location:"UserProfileActivityCard"',
             replacement: [
                 // Insert Spotify time bar component
                 {


### PR DESCRIPTION
Discord moved where they keep the activity message text, so here's a fix for the patch.