### PR TITLE
[Plugin] Hide server activity

### DIFF
--- a/src/plugins/hideServerActivity/README.md
+++ b/src/plugins/hideServerActivity/README.md
@@ -1,0 +1,3 @@
+# Hide Server Activity
+
+A very simple plugin that completely hides the server activity section in the users list.

--- a/src/plugins/hideServerActivity/index.ts
+++ b/src/plugins/hideServerActivity/index.ts
@@ -1,0 +1,62 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+let activityRemoved = false;
+
+export default definePlugin({
+    name: "HideServerActivity",
+    description: "Hide the server activity from the user list.",
+    authors: [Devs.Faab007NL],
+
+    start() {
+        setInterval(() => {
+            this.hideServerActivity();
+        }, 1000);
+    },
+    stop() {
+        this.showServerActivity();
+    },
+
+    hideServerActivity() {
+        const membersListEl = document.querySelector('div[aria-label="Members"]');
+        if (!membersListEl) {
+            activityRemoved = false;
+            return;
+        }
+
+        const { children } = membersListEl;
+        const activityTitleEl = children[1];
+        const activityContentEl = children[2];
+
+        if (!activityTitleEl || !activityContentEl) {
+            activityRemoved = false;
+            return;
+        }
+
+        if(activityRemoved) return;
+
+        activityTitleEl.style.display = "none";
+        activityContentEl.style.display = "none";
+    },
+
+    showServerActivity() {
+        const membersListEl = document.querySelector('div[aria-label="Members"]');
+        if (!membersListEl) return;
+
+        const { children } = membersListEl;
+        const activityTitleEl = children[1];
+        const activityContentEl = children[2];
+
+        if (!activityTitleEl || !activityContentEl) return;
+
+        activityTitleEl.style.display = "block";
+        activityContentEl.style.display = "block";
+    }
+
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -570,6 +570,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n,
     },
+    Faab007NL: {
+        name: "Faab007NL",
+        id: 1026515880080842772n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
A very simple plugin that completely hides the server activity section in the users list.