### PR TITLE
AppleMusicRichPresence: fix metadata fetching

### DIFF
--- a/src/plugins/appleMusic.desktop/index.tsx
+++ b/src/plugins/appleMusic.desktop/index.tsx
@@ -120,7 +120,7 @@ const settings = definePluginSettings({
     stateString: {
         type: OptionType.STRING,
         description: "Activity state format string",
-        default: "{artist}"
+        default: "{artist} · {album}"
     },
     largeImageType: {
         type: OptionType.SELECT,

--- a/src/plugins/appleMusic.desktop/native.ts
+++ b/src/plugins/appleMusic.desktop/native.ts
@@ -38,6 +38,8 @@ interface RemoteData {
 
 let cachedRemoteData: { id: string, data: RemoteData; } | { id: string, failures: number; } | null = null;
 
+const ARTIST_ARTWORK_REGEX = /,"image":"(https:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)\.png)"/;
+
 async function fetchRemoteData({ id, name, artist, album }: { id: string, name: string, artist: string, album: string; }) {
     if (id === cachedRemoteData?.id) {
         if ("data" in cachedRemoteData) return cachedRemoteData.data;
@@ -50,7 +52,7 @@ async function fetchRemoteData({ id, name, artist, album }: { id: string, name: 
         ).then(r => r.json());
 
         const artistHtml = await fetch(artistViewUrl, requestOptions).then(r => r.text());
-        const extractedArtistArtwork = artistHtml.match(/,"image":"(https:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)\.png)"/);
+        const extractedArtistArtwork = artistHtml.match(ARTIST_ARTWORK_REGEX);
 
         cachedRemoteData = {
             id,


### PR DESCRIPTION
Apple got rid of the old `tools.applemediaservices.com` search endpoint, so now we have to fetch from the API that `music.apple.com` uses with an extracted hardcoded token. Cheers!
