### PR TITLE
Improve readability and cleanliness of clearURLs

### DIFF
--- a/src/plugins/clearURLs/index.ts
+++ b/src/plugins/clearURLs/index.ts
@@ -95,7 +95,7 @@ export default definePlugin({
 
     handleMessage(msg: MessageObject) {
         // Only run on messages that contain URLs
-        if (msg.content.match(/http(s)?:\/\//)) return;
+        if (!msg.content.match(/http(s)?:\/\//)) return;
 
         msg.content = msg.content.replace(
             /(https?:\/\/[^\s<]+[^<.,:;"'>)|\]\s])/g,

--- a/src/plugins/clearURLs/index.ts
+++ b/src/plugins/clearURLs/index.ts
@@ -1,20 +1,8 @@
 /*
- * Vencord, a modification for Discord's desktop app
- * Copyright (c) 2022 Vendicated and contributors
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
-*/
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 import {
     addPreEditListener,
@@ -44,102 +32,81 @@ export default definePlugin({
             : (str || "");
     },
 
+    universalRules: new Set<RegExp>(),
+    rulesByHost: new Map<string, Set<RegExp>>(),
+    hostRules: new Map<string, RegExp>(),
     createRules() {
         // Can be extended upon once user configs are available
         // Eg. (useDefaultRules: boolean, customRules: Array[string])
         const rules = defaultRules;
 
-        this.universalRules = new Set();
-        this.rulesByHost = new Map();
-        this.hostRules = new Map();
-
         for (const rule of rules) {
-            const splitRule = rule.split("@");
-            const paramRule = new RegExp(
-                "^" +
-                this.escapeRegExp(splitRule[0]).replace(/\\\*/, ".+?") +
-                "$"
-            );
+            const [param, domain] = rule.split("@");
+            const paramRule = new RegExp(`^${this.escapeRegExp(param).replace(/\\\*/, ".+?")}$`);
 
-            if (!splitRule[1]) {
+            if (!domain) {
                 this.universalRules.add(paramRule);
                 continue;
             }
-            const hostRule = new RegExp(
-                "^(www\\.)?" +
-                this.escapeRegExp(splitRule[1])
-                    .replace(/\\\./, "\\.")
-                    .replace(/^\\\*\\\./, "(.+?\\.)?")
-                    .replace(/\\\*/, ".+?") +
-                "$"
-            );
+            const hostRule = new RegExp("^(www\\.)?" + this.escapeRegExp(domain)
+                .replace(/\\\./, "\\.")
+                .replace(/^\\\*\\\./, "(.+?\\.)?")
+                .replace(/\\\*/, ".+?") +
+                "$");
             const hostRuleIndex = hostRule.toString();
 
             this.hostRules.set(hostRuleIndex, hostRule);
-            if (this.rulesByHost.get(hostRuleIndex) == null) {
+            if (!this.rulesByHost.get(hostRuleIndex))
                 this.rulesByHost.set(hostRuleIndex, new Set());
-            }
-            this.rulesByHost.get(hostRuleIndex).add(paramRule);
+            this.rulesByHost.get(hostRuleIndex)!.add(paramRule);
         }
     },
 
-    removeParam(rule: string | RegExp, param: string, parent: URLSearchParams) {
-        if (param === rule || rule instanceof RegExp && rule.test(param)) {
-            parent.delete(param);
+    execRule(rule: RegExp, url: URL) {
+        for (const [param] of url.searchParams) {
+            if (rule.test(param)) url.searchParams.delete(param);
         }
     },
 
     replacer(match: string) {
-        // Parse URL without throwing errors
-        try {
-            var url = new URL(match);
-        } catch (error) {
-            // Don't modify anything if we can't parse the URL
-            return match;
-        }
+        let url: URL;
+        // don't modify anything if we can't parse the URL
+        try { url = new URL(match) as URL; }
+        catch { return match; }
 
         // Cheap way to check if there are any search params
-        if (url.searchParams.entries().next().done) {
-            // If there are none, we don't need to modify anything
+        // If there are none, we don't need to modify anything
+        if (url.searchParams.entries().next().done)
             return match;
-        }
 
         // Check all universal rules
-        this.universalRules.forEach(rule => {
-            url.searchParams.forEach((_value, param, parent) => {
-                this.removeParam(rule, param, parent);
-            });
-        });
+        for (const rule of this.universalRules)
+            this.execRule(rule, url);
 
-        // Check rules for each hosts that match
-        this.hostRules.forEach((regex, hostRuleName) => {
-            if (!regex.test(url.hostname)) return;
-            this.rulesByHost.get(hostRuleName).forEach(rule => {
-                url.searchParams.forEach((_value, param, parent) => {
-                    this.removeParam(rule, param, parent);
-                });
-            });
-        });
+        // Check host rules
+        for (const [hostRuleName, regex] of this.hostRules) {
+            if (!regex.test(url.hostname)) continue;
+            for (const rule of this.rulesByHost.get(hostRuleName)!)
+                this.execRule(rule, url);
+        }
 
         return url.toString();
     },
 
-    onSend(msg: MessageObject) {
+    handleMessage(msg: MessageObject) {
         // Only run on messages that contain URLs
-        if (msg.content.match(/http(s)?:\/\//)) {
-            msg.content = msg.content.replace(
-                /(https?:\/\/[^\s<]+[^<.,:;"'>)|\]\s])/g,
-                match => this.replacer(match)
-            );
-        }
+        if (msg.content.match(/http(s)?:\/\//)) return;
+
+        msg.content = msg.content.replace(
+            /(https?:\/\/[^\s<]+[^<.,:;"'>)|\]\s])/g,
+            match => this.replacer(match)
+        );
     },
 
     start() {
         this.createRules();
-        this.preSend = addPreSendListener((_, msg) => this.onSend(msg));
-        this.preEdit = addPreEditListener((_cid, _mid, msg) =>
-            this.onSend(msg)
-        );
+        this.preSend = addPreSendListener((_, msg) => this.handleMessage(msg));
+        this.preEdit = addPreEditListener((_cid, _mid, msg) => this.handleMessage(msg));
     },
 
     stop() {


### PR DESCRIPTION
Today when I was stealing the url cleaning from clearURLs for one of my personal projects, I found the code kinda disgusting.

This commit primarily is just because of the unnecessarily complex code `replacer` used for removing bad params. Otherwise its just light edits to reduce unnecessary indents/lines.

This should hopefully make the code easier to steal for people in the future.