### PR TITLE
docs: make `noDevtoolsWarning`  description less ambigous

### DIFF
--- a/src/plugins/noDevtoolsWarning/index.ts
+++ b/src/plugins/noDevtoolsWarning/index.ts
@@ -21,7 +21,7 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "NoDevtoolsWarning",
-    description: "Disables the 'HOLD UP' banner in the console. As a side effect, also prevents Discord from hiding your token, which prevents random logouts.",
+    description: "Disables the 'HOLD UP' banner in the console. Also stops random logouts when using DevTools.",
     authors: [Devs.Ven],
     patches: [{
         find: "setDevtoolsCallbacks",

--- a/src/plugins/noDevtoolsWarning/index.ts
+++ b/src/plugins/noDevtoolsWarning/index.ts
@@ -21,7 +21,7 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "NoDevtoolsWarning",
-    description: "Disables the 'HOLD UP' banner in the console. Also stops random logouts when using DevTools.",
+    description: "Disables the 'HOLD UP' banner in the console. Also stops random logouts & token hiding when using DevTools.",
     authors: [Devs.Ven],
     patches: [{
         find: "setDevtoolsCallbacks",


### PR DESCRIPTION
[as discussed in discord](https://discord.com/channels/1015060230222131221/1026515880080842772/1283952481759662111), current description was ambiguous.

EDIT:

> Disables the 'HOLD UP' banner in the console. As a side effect, also prevents Discord from hiding your token, which prevents random logouts. 

This can be interpreted in two ways:

- `noDevtoolsWarning` prevents discord from hiding your tokens.
- `noDevtoolsWarning` prevents random logouts.

OR:

+ `noDevtoolsWarning` prevents discord from hiding your tokens.
+ `Discord hiding your token` prevents random logouts.