### PR TITLE
moreUserTags: Add an option to change the [APP] tag back to [BOT]

### DIFF
--- a/src/plugins/moreUserTags/index.tsx
+++ b/src/plugins/moreUserTags/index.tsx
@@ -175,7 +175,7 @@ const settings = definePluginSettings({
 export default definePlugin({
     name: "MoreUserTags",
     description: "Adds tags for webhooks and moderative roles (owner, admin, etc.)",
-    authors: [Devs.Cyn, Devs.TheSun, Devs.RyanCaoDev, Devs.LordElias, Devs.AutumnVN],
+    authors: [Devs.Cyn, Devs.TheSun, Devs.RyanCaoDev, Devs.LordElias, Devs.AutumnVN, Devs.Cootshk],
     settings,
     patches: [
         // add tags to the tag list

--- a/src/plugins/moreUserTags/index.tsx
+++ b/src/plugins/moreUserTags/index.tsx
@@ -165,6 +165,11 @@ const settings = definePluginSettings({
         description: "Only show extra tags for bots / Hide [BOT] text",
         type: OptionType.BOOLEAN
     },
+    useBotNotApp: {
+        description: "Use [BOT] instead of [APP] for bot tags",
+        type: OptionType.BOOLEAN,
+        default: false
+    },
     tagSettings: {
         type: OptionType.COMPONENT,
         component: SettingsComponent,

--- a/src/plugins/moreUserTags/index.tsx
+++ b/src/plugins/moreUserTags/index.tsx
@@ -301,18 +301,19 @@ export default definePlugin({
     isOPTag: (tag: number) => tag === Tag.Types.ORIGINAL_POSTER || tags.some(t => tag === Tag.Types[`${t.name}-OP`]),
 
     getTagText(passedTagName: string, strings: Record<string, string>) {
-        if (!passedTagName) return strings.APP_TAG;
+        const APP_TAG = (this.settings.store.useBotNotApp) ? "BOT" : strings.APP_TAG;
+        if (!passedTagName) return APP_TAG;
         const [tagName, variant] = passedTagName.split("-");
         const tag = tags.find(({ name }) => tagName === name);
-        if (!tag) return strings.APP_TAG;
-        if (variant === "BOT" && tagName !== "WEBHOOK" && this.settings.store.dontShowForBots) return strings.APP_TAG;
+        if (!tag) return APP_TAG;
+        if (variant === "BOT" && tagName !== "WEBHOOK" && this.settings.store.dontShowForBots) return APP_TAG;
 
         const tagText = settings.store.tagSettings?.[tag.name]?.text || tag.displayName;
         switch (variant) {
             case "OP":
                 return `${strings.BOT_TAG_FORUM_ORIGINAL_POSTER} • ${tagText}`;
             case "BOT":
-                return `${strings.APP_TAG} • ${tagText}`;
+                return `${APP_TAG} • ${tagText}`;
             default:
                 return tagText;
         }

--- a/src/plugins/moreUserTags/index.tsx
+++ b/src/plugins/moreUserTags/index.tsx
@@ -165,7 +165,7 @@ const settings = definePluginSettings({
         description: "Only show extra tags for bots / Hide [BOT] text",
         type: OptionType.BOOLEAN
     },
-    useBotNotApp: {
+    useBotInsteadOfApp: {
         description: "Use [BOT] instead of [APP] for bot tags",
         type: OptionType.BOOLEAN,
         default: false
@@ -301,7 +301,7 @@ export default definePlugin({
     isOPTag: (tag: number) => tag === Tag.Types.ORIGINAL_POSTER || tags.some(t => tag === Tag.Types[`${t.name}-OP`]),
 
     getTagText(passedTagName: string, strings: Record<string, string>) {
-        const APP_TAG = (this.settings.store.useBotNotApp) ? "BOT" : strings.APP_TAG;
+        const APP_TAG = (this.settings.store.useBotInsteadOfApp) ? "BOT" : strings.APP_TAG; // strings.APP_TAG is "APP"
         if (!passedTagName) return APP_TAG;
         const [tagName, variant] = passedTagName.split("-");
         const tag = tags.find(({ name }) => tagName === name);

--- a/src/plugins/moreUserTags/index.tsx
+++ b/src/plugins/moreUserTags/index.tsx
@@ -271,6 +271,7 @@ export default definePlugin({
             showInChat: true,
             showInNotChat: true
         };
+        settings.store.useBotInsteadOfApp ??= false;
     },
 
     getPermissions(user: User, channel: Channel): string[] {

--- a/src/plugins/moreUserTags/index.tsx
+++ b/src/plugins/moreUserTags/index.tsx
@@ -168,7 +168,8 @@ const settings = definePluginSettings({
     useBotInsteadOfApp: {
         description: "Use [BOT] instead of [APP] for bot tags",
         type: OptionType.BOOLEAN,
-        default: false
+        default: false,
+        restartNeeded: true // blame caching
     },
     tagSettings: {
         type: OptionType.COMPONENT,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -575,6 +575,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n,
     },
+    Cootshk: {
+        name: "Cootshk",
+        id: 921605971577548820n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This was requested [here](https://github.com/Vencord/plugin-requests/issues/430#issuecomment-2081255001).

It requires a restart because of some [weird caching issues](https://github.com/user-attachments/assets/e7d542ff-7372-4b34-aa91-22bf1a95167c)


Disabled:
![[APP] venbot](https://github.com/user-attachments/assets/aaf64bff-81b3-4560-a514-0df354136dd4)
Enabled:
![[BOT] venbot](https://github.com/user-attachments/assets/8347f358-53a0-42d9-8799-29d5f167f330)

