### PR TITLE
feat(RCE): Add a touch of color to message contents

### DIFF
--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -64,7 +64,7 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "RoleColorEverywhere",
-    authors: [Devs.KingFish, Devs.lewisakura, Devs.AutumnVN],
+    authors: [Devs.KingFish, Devs.lewisakura, Devs.AutumnVN, Devs.Kyuuhachi],
     description: "Adds the top role color anywhere possible",
     patches: [
         // Chat Mentions

--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -53,7 +53,7 @@ const settings = definePluginSettings({
     },
     messageSaturation: {
         type: OptionType.SLIDER,
-        description: "Message color saturation",
+        description: "Intensity of message coloring. 0 to disable.",
         markers: makeRange(0, 100, 10),
         default: 30,
         // This is called only once at startup, but late enough that the store is initialized.
@@ -131,7 +131,7 @@ export default definePlugin({
             find: '.Messages.MESSAGE_EDITED,")"',
             replacement: {
                 match: /(?<=isUnsupported\]:(\i)\.isUnsupported\}\),)(?=children:\[)/,
-                replace: 'style:{"color":$self.useMessageColor($1)},'
+                replace: "style:{color:$self.useMessageColor($1)},"
             },
             predicate: () => settings.store.messageSaturation !== 0,
         },
@@ -175,7 +175,7 @@ export default definePlugin({
             const { messageSaturation } = settings.use(["messageSaturation"]);
             const author = useMessageAuthor(message);
             if (author.colorString !== undefined)
-                return `color-mix(in lab, ${author.colorString} ${messageSaturation}%, var(--text-normal))`;
+                return `color-mix(in oklch, ${author.colorString} ${messageSaturation}%, var(--text-normal))`;
         } catch(e) {
             console.error("[RCE] failed to get message color", e);
         }

--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -175,7 +175,7 @@ export default definePlugin({
             const { messageSaturation } = settings.use(["messageSaturation"]);
             const author = useMessageAuthor(message);
             if (author.colorString !== undefined)
-                return `color-mix(in lab, ${author.colorString} calc(${messageSaturation} * 1%), var(--text-normal))`;
+                return `color-mix(in lab, ${author.colorString} ${messageSaturation}%, var(--text-normal))`;
         } catch(e) {
             console.error("[RCE] failed to get message color", e);
         }

--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -174,7 +174,7 @@ export default definePlugin({
         try {
             const { messageSaturation } = settings.use(["messageSaturation"]);
             const author = useMessageAuthor(message);
-            if (author.colorString !== undefined)
+            if (author.colorString !== undefined && messageSaturation !== 0)
                 return `color-mix(in oklch, ${author.colorString} ${messageSaturation}%, var(--text-normal))`;
         } catch(e) {
             console.error("[RCE] failed to get message color", e);

--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -175,7 +175,7 @@ export default definePlugin({
             const { messageSaturation } = settings.use(["messageSaturation"]);
             const author = useMessageAuthor(message);
             if (author.colorString !== undefined && messageSaturation !== 0)
-                return `color-mix(in oklch, ${author.colorString} ${messageSaturation}%, var(--text-normal))`;
+                return `color-mix(in oklab, ${author.colorString} ${messageSaturation}%, var(--text-normal))`;
         } catch(e) {
             console.error("[RCE] failed to get message color", e);
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0175c82e-e16d-4ed5-921e-49ebb6cad8f5)

Adapted from my [ColorMessage](<https://github.com/Kyuuhachi/VencordPlugins/tree/main/ColorMessage>) plugin.