### PR TITLE
fix(ReplaceGoogleSearch): DuckDuckGo URL

### DIFF
--- a/src/plugins/replaceGoogleSearch/index.tsx
+++ b/src/plugins/replaceGoogleSearch/index.tsx
@@ -12,7 +12,7 @@ import { Flex, Menu } from "@webpack/common";
 
 const DefaultEngines = {
     Google: "https://www.google.com/search?q=",
-    DuckDuckGo: "https://duckduckgo.com/",
+    DuckDuckGo: "https://duckduckgo.com/?q=",
     Brave: "https://search.brave.com/search?q=",
     Bing: "https://www.bing.com/search?q=",
     Yahoo: "https://search.yahoo.com/search?p=",


### PR DESCRIPTION
Without the `?q=`, some searches will go to the wrong place such as the download for DuckDuckGo if you put anything that starts with `x`.