### PR TITLE
chore(RCE): drop restartneeded from message sat

### DIFF
--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -61,8 +61,7 @@ const settings = definePluginSettings({
         type: OptionType.SLIDER,
         description: "Intensity of message coloring.",
         markers: makeRange(0, 100, 10),
-        default: 30,
-        restartNeeded: true
+        default: 30
     },
 });
 


### PR DESCRIPTION
because of the `settings.use` in `useMessageColor`, a restart is not actually needed for the setting to apply