### PR TITLE
Make Hex Tester + Improve Chat Colors in RoleColorEverywhere

### DIFF
--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -76,13 +76,6 @@ const settings = definePluginSettings({
 
 const ColorPicker = findComponentByCodeLazy(".Messages.USER_SETTINGS_PROFILE_COLOR_SELECT_COLOR", ".BACKGROUND_PRIMARY)");
 
-const colorPresets = [
-    "#1E1514", "#172019", "#13171B", "#1C1C28", "#402D2D",
-    "#3A483D", "#344242", "#313D4B", "#2D2F47", "#322B42",
-    "#3C2E42", "#422938", "#b6908f", "#bfa088", "#d3c77d",
-    "#86ac86", "#88aab3", "#8693b5", "#8a89ba", "#ad94bb",
-];
-
 function newColor(hex: any, sim: any, pound: boolean) {
     var hex = hex.replace("#", "");
     var converted = Math.round((0.5 + ((sim - 1) * 0.5 / 9)) * 10) / 10;
@@ -132,7 +125,6 @@ function ColorTester(this: any) {
                         color={parseInt(displayColor, 16)}
                         onChange={handleColorChange}
                         showEyeDropper={false}
-                        suggestedColors={colorPresets}
                     />
                     <ColorPicker
                         color={parseInt(secondColor, 16)}

--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -16,13 +16,15 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import "./roleColorEverywhere.css";
+
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { makeRange } from "@components/PluginSettings/components";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
-import { findByCodeLazy } from "@webpack";
-import { ChannelStore, GuildMemberStore, GuildStore } from "@webpack/common";
+import { findByCodeLazy, findComponentByCodeLazy } from "@webpack";
+import { ChannelStore, Forms, GuildMemberStore, GuildStore, React } from "@webpack/common";
 
 const useMessageAuthor = findByCodeLazy('"Result cannot be null because the message is not null"');
 
@@ -57,19 +59,94 @@ const settings = definePluginSettings({
         description: "Color chat messages based on the author's role color",
         restartNeeded: true,
     },
-    messageSaturation: {
+    messageSimilarity: {
         type: OptionType.SLIDER,
-        description: "Intensity of message coloring.",
-        markers: makeRange(0, 100, 10),
-        default: 30,
-        restartNeeded: true
+        description: "Similarity of message color to white",
+        markers: makeRange(1, 10, 1),
+        default: 8,
+        restartNeeded: false
     },
+    color: {
+        type: OptionType.COMPONENT,
+        description: "test color",
+        default: "d31414",
+        component: () => <ColorTester />
+    }
 });
 
+const ColorPicker = findComponentByCodeLazy(".Messages.USER_SETTINGS_PROFILE_COLOR_SELECT_COLOR", ".BACKGROUND_PRIMARY)");
+
+const colorPresets = [
+    "#1E1514", "#172019", "#13171B", "#1C1C28", "#402D2D",
+    "#3A483D", "#344242", "#313D4B", "#2D2F47", "#322B42",
+    "#3C2E42", "#422938", "#b6908f", "#bfa088", "#d3c77d",
+    "#86ac86", "#88aab3", "#8693b5", "#8a89ba", "#ad94bb",
+];
+
+function newColor(hex: any, sim: any, pound: boolean) {
+    var hex = hex.replace("#", "");
+    var converted = Math.round((0.5 + ((sim - 1) * 0.5 / 9)) * 10) / 10;
+    var r = Math.round(parseInt(hex.substring(0, 2), 16) + (255 - parseInt(hex.substring(0, 2), 16)) * converted - (converted * 20));
+    var g = Math.round(parseInt(hex.substring(2, 4), 16) + (255 - parseInt(hex.substring(2, 4), 16)) * converted - (converted * 20));
+    var b = Math.round(parseInt(hex.substring(4, 6), 16) + (255 - parseInt(hex.substring(4, 6), 16)) * converted - (converted * 20));
+    var toHex = (component: number) => component.toString(16).padStart(2, "0");
+    if (pound)
+        var color = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+    else
+        var color = `${toHex(r)}${toHex(g)}${toHex(b)}`;
+    return color;
+}
+
+function onPickColor(color: number) {
+    const hexColor = color.toString(16).padStart(6, "0");
+    settings.store.color = hexColor;
+}
+
+function ColorTester(this: any) {
+    const { messageSimilarity } = settings.use(["messageSimilarity"]);
+
+    const [displayColor, setDisplayColor] = React.useState(settings.store.color);
+    const [secondColor, setSecondColor] = React.useState(newColor(displayColor, messageSimilarity, false));
+
+    React.useEffect(() => {
+        setDisplayColor(settings.store.color);
+        setSecondColor(newColor(settings.store.color, messageSimilarity, false));
+    }, [settings.store.color, messageSimilarity]);
+
+    const handleColorChange = color => {
+        const hexColor = color.toString(16).padStart(6, "0");
+        settings.store.color = hexColor;
+        setDisplayColor(hexColor);
+        setSecondColor(newColor(hexColor, messageSimilarity, false));
+    };
+
+    return (
+        <div className="role-color-settings">
+            <div className="role-color-container">
+                <div className="role-color-settings-labels">
+                    <Forms.FormTitle tag="h3">Hex Tester</Forms.FormTitle>
+                    <Forms.FormText>Preview the changed message role color</Forms.FormText>
+                </div>
+                <div className="role-color-pickers">
+                    <ColorPicker
+                        color={parseInt(displayColor, 16)}
+                        onChange={handleColorChange}
+                        showEyeDropper={false}
+                        suggestedColors={colorPresets}
+                    />
+                    <ColorPicker
+                        color={parseInt(secondColor, 16)}
+                        showEyeDropper={false}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}
 
 export default definePlugin({
     name: "RoleColorEverywhere",
-    authors: [Devs.KingFish, Devs.lewisakura, Devs.AutumnVN, Devs.Kyuuhachi],
+    authors: [Devs.KingFish, Devs.lewisakura, Devs.AutumnVN, Devs.Kyuuhachi, Devs.AlphaLeoli],
     description: "Adds the top role color anywhere possible",
     patches: [
         // Chat Mentions
@@ -177,13 +254,13 @@ export default definePlugin({
 
     useMessageColor(message: any) {
         try {
-            const { messageSaturation } = settings.use(["messageSaturation"]);
+            const { messageSimilarity } = settings.use(["messageSimilarity"]);
             const author = useMessageAuthor(message);
-            if (author.colorString !== undefined && messageSaturation !== 0)
-                return `color-mix(in oklab, ${author.colorString} ${messageSaturation}%, var(--text-normal))`;
+            if (author.colorString !== undefined)
+                return newColor(author.colorString, messageSimilarity, true);
         } catch (e) {
             console.error("[RCE] failed to get message color", e);
         }
         return undefined;
-    },
+    }
 });

--- a/src/plugins/roleColorEverywhere/roleColorEverywhere.css
+++ b/src/plugins/roleColorEverywhere/roleColorEverywhere.css
@@ -1,0 +1,20 @@
+.role-color-container {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+
+.role-color-settings-labels {
+    display: flex;
+    flex-direction: column;
+    margin-right: 20px;
+}
+
+.role-color-pickers {
+    display: flex;
+    gap: 15px;
+}
+
+.color-picker-container {
+    margin-left: 10px;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -37,6 +37,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Vee",
         id: 343383572805058560n
     },
+    AlphaLeoli: {
+        name: "AlphaLeoli",
+        id: 659477225011281930n
+    },
     Arjix: {
         name: "ArjixWasTaken",
         id: 674710789138939916n,


### PR DESCRIPTION
1. u can put in the color of a role and the output color will be based off of your settings and will represent what color the text will be
2. it doesn't just reduce saturation, there is a formula and it makes the result color better imo
3. example images below

![image](https://github.com/user-attachments/assets/97ed66e2-d0a4-406b-8184-d0bef39ac915)

These colors are with a whiteness similarity of 8 (so pretty similar if i do say so myself🗿)
![image](https://github.com/user-attachments/assets/7e3150b0-7849-4e13-9a2a-ef43f4a51224)