### PR TITLE
FakeNitro: fix voice calls showing the patched menu

### DIFF
--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -204,6 +204,14 @@ export default definePlugin({
 
     patches: [
         {
+            find: "emojiItemDisabled]",
+            predicate: () => settings.store.enableEmojiBypass,
+            replacement: {
+                match: /CHAT/,
+                replace: "STATUS"
+            }
+        },
+        {
             find: ".PREMIUM_LOCKED;",
             group: true,
             predicate: () => settings.store.enableEmojiBypass,

--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -203,6 +203,7 @@ export default definePlugin({
     settings,
 
     patches: [
+        // Patch the emoji picker in voice calls to not be bypassed by fake nitro
         {
             find: "emojiItemDisabled]",
             predicate: () => settings.store.enableEmojiBypass,


### PR DESCRIPTION
the intentions for `STATUS` seem to be the same as `CHAT`, and fake nitro doesn't patch `STATUS`
closes: https://github.com/Vendicated/Vencord/issues/2897