### PR TITLE
Using `displayName` properties for sub command display names instead of `name` properties

### DIFF
--- a/src/api/Commands/index.ts
+++ b/src/api/Commands/index.ts
@@ -113,11 +113,11 @@ function registerSubCommands(cmd: Command, plugin: string) {
             type: ApplicationCommandType.CHAT_INPUT,
             name: `${cmd.name} ${o.name}`,
             id: `${o.name}-${cmd.id}`,
-            displayName: `${cmd.name} ${o.name}`,
+            displayName: `${cmd.displayName ?? cmd.name} ${o.displayName ?? o.name}`,
             subCommandPath: [{
                 name: o.name,
                 type: o.type,
-                displayName: o.name
+                displayName: o.displayName
             }],
             rootCommand: cmd
         };


### PR DESCRIPTION
Before, the `displayName` properties were ignored for sub commands.  
Fixing it so that registered sub commands actually use the specified display names instead of the regular name properties in the command picker.

I don't know if the change to `subCommandPath` actually does anything, but it seems the correct thing to do.

<details>
<summary><strong>Example</strong></summary>

Given the command object:
```ts
{
    name: "name",
    displayName: "displayName",
    options: [
        {
            name: "subcommand1_name",
            displayName: "subcommand1_displayName",
            type: ApplicationCommandOptionType.SUB_COMMAND,
        },
        {
            name: "subcommand2_name",
            displayName: "subcommand2_displayName",
            type: ApplicationCommandOptionType.SUB_COMMAND,
        },
    ],
}
```

Before patch:  
![close-up screenshot of the Discord command picker not showing the display names](https://github.com/user-attachments/assets/632cfacc-b28c-4bbb-9a31-5ab900eb36f7)

After patch:  
![close-up screenshot of the Discord command picker, this time showing the display names correctly](https://github.com/user-attachments/assets/5f4a622b-8d16-4c62-ad20-b2a274bf93b5)
</details>