### PR TITLE
Add Hide Groups plugin

### DIFF
--- a/src/plugins/_api/notices.ts
+++ b/src/plugins/_api/notices.ts
@@ -33,8 +33,8 @@ export default definePlugin({
                     replace: "if(Vencord.Api.Notices.currentNotice)return false;$&"
                 },
                 {
-                    match: /(?<=,NOTICE_DISMISS:function\(\i\){)return null!=(\i)/,
-                    replace: "if($1.id==\"VencordNotice\")return($1=null,Vencord.Api.Notices.nextNotice(),true);$&"
+                    match: /(?<=function (\i)\(\i\){)return null!=(\i)(?=.*NOTICE_DISMISS:\1)/,
+                    replace: "if($2.id==\"VencordNotice\")return($2=null,Vencord.Api.Notices.nextNotice(),true);$&"
                 }
             ]
         }

--- a/src/plugins/anonymiseFileNames/index.tsx
+++ b/src/plugins/anonymiseFileNames/index.tsx
@@ -71,7 +71,7 @@ export default definePlugin({
     description: "Anonymise uploaded file names",
     patches: [
         {
-            find: "instantBatchUpload:function",
+            find: "instantBatchUpload:",
             replacement: {
                 match: /uploadFiles:(\i),/,
                 replace:

--- a/src/plugins/consoleJanitor/index.ts
+++ b/src/plugins/consoleJanitor/index.ts
@@ -119,7 +119,7 @@ export default definePlugin({
         {
             find: "Slow dispatch on",
             replacement: {
-                match: /\i\.totalTime>100&&\i\.verbose\("Slow dispatch on ".+?\)\);/,
+                match: /\i\.totalTime>\i&&\i\.verbose\("Slow dispatch on ".+?\)\);/,
                 replace: ""
             }
         },

--- a/src/plugins/customidle/index.ts
+++ b/src/plugins/customidle/index.ts
@@ -37,8 +37,8 @@ export default definePlugin({
             find: 'type:"IDLE",idle:',
             replacement: [
                 {
-                    match: /(?<=Date\.now\(\)-\i>)\i\.\i/,
-                    replace: "$self.getIdleTimeout()"
+                    match: /(?<=Date\.now\(\)-\i>)\i\.\i\|\|/,
+                    replace: "$self.getIdleTimeout()||"
                 },
                 {
                     match: /Math\.min\((\i\.\i\.getSetting\(\)\*\i\.\i\.\i\.SECOND),\i\.\i\)/,

--- a/src/plugins/decor/index.tsx
+++ b/src/plugins/decor/index.tsx
@@ -54,7 +54,7 @@ export default definePlugin({
                     replace: "$self.DecorationGridItem=$&"
                 },
                 {
-                    match: /(?<==)\i=>{let{user:\i,avatarDecoration.{300,600}decorationGridItemChurned/,
+                    match: /(?<==)\i=>{let{user:\i,avatarDecoration/,
                     replace: "$self.DecorationGridDecoration=$&"
                 },
                 // Remove NEW label from decor avatar decorations

--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -254,11 +254,11 @@ export default definePlugin({
         },
         // Allow stickers to be sent everywhere
         {
-            find: "canUseCustomStickersEverywhere:function",
+            find: "canUseCustomStickersEverywhere:",
             predicate: () => settings.store.enableStickerBypass,
             replacement: {
-                match: /canUseCustomStickersEverywhere:function\(\i\){/,
-                replace: "$&return true;"
+                match: /(?<=canUseCustomStickersEverywhere:)\i/,
+                replace: "()=>true"
             },
         },
         // Make stickers always available
@@ -272,15 +272,15 @@ export default definePlugin({
         },
         // Allow streaming with high quality
         {
-            find: "canUseHighVideoUploadQuality:function",
+            find: "canUseHighVideoUploadQuality:",
             predicate: () => settings.store.enableStreamQualityBypass,
             replacement: [
                 "canUseHighVideoUploadQuality",
                 "canStreamQuality",
             ].map(func => {
                 return {
-                    match: new RegExp(`${func}:function\\(\\i(?:,\\i)?\\){`, "g"),
-                    replace: "$&return true;"
+                    match: new RegExp(`(?<=${func}:)\\i`, "g"),
+                    replace: "()=>true"
                 };
             })
         },
@@ -295,10 +295,10 @@ export default definePlugin({
         },
         // Allow client themes to be changeable
         {
-            find: "canUseClientThemes:function",
+            find: "canUseClientThemes:",
             replacement: {
-                match: /canUseClientThemes:function\(\i\){/,
-                replace: "$&return true;"
+                match: /(?<=canUseClientThemes:)\i/,
+                replace: "()=>true"
             }
         },
         {
@@ -306,8 +306,8 @@ export default definePlugin({
             replacement: [
                 {
                     // Overwrite incoming connection settings proto with our local settings
-                    match: /CONNECTION_OPEN:function\((\i)\){/,
-                    replace: (m, props) => `${m}$self.handleProtoChange(${props}.userSettingsProto,${props}.user);`
+                    match: /function (\i)\((\i)\){(?=.*CONNECTION_OPEN:\1)/,
+                    replace: (m, funcName, props) => `${m}$self.handleProtoChange(${props}.userSettingsProto,${props}.user);`
                 },
                 {
                     // Overwrite non local proto changes with our local settings
@@ -400,10 +400,10 @@ export default definePlugin({
         },
         // Allow using custom app icons
         {
-            find: "canUsePremiumAppIcons:function",
+            find: "canUsePremiumAppIcons:",
             replacement: {
-                match: /canUsePremiumAppIcons:function\(\i\){/,
-                replace: "$&return true;"
+                match: /(?<=canUsePremiumAppIcons:)\i/,
+                replace: "()=>true"
             }
         },
         // Separate patch for allowing using custom app icons
@@ -424,10 +424,10 @@ export default definePlugin({
         },
         // Allow using custom notification sounds
         {
-            find: "canUseCustomNotificationSounds:function",
+            find: "canUseCustomNotificationSounds:",
             replacement: {
-                match: /canUseCustomNotificationSounds:function\(\i\){/,
-                replace: "$&return true;"
+                match: /(?<=canUseCustomNotificationSounds:)\i/,
+                replace: "()=>true"
             }
         }
     ],

--- a/src/plugins/hideGroups/index.tsx
+++ b/src/plugins/hideGroups/index.tsx
@@ -48,11 +48,7 @@ let forceUpdate: () => void;
  * Sets the global force update function.
  */
 function setForceUpdate(func: () => void): undefined {
-    console.log("set force update", func);
-    forceUpdate = () => {
-        console.log("call to force update", func);
-        func();
-    };
+    forceUpdate = func;
     return undefined;
 }
 

--- a/src/plugins/hideGroups/index.tsx
+++ b/src/plugins/hideGroups/index.tsx
@@ -24,22 +24,6 @@ import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/Co
 import { FluxDispatcher, Menu } from "@webpack/common";
 import { createStore, entries, set } from "@api/DataStore";
 
-/**
- * Finds an element with the specified 'aria-label'.
- *
- * @param label The label to search for.
- */
-function findElement(label: string): HTMLElement[] {
-    const found: HTMLElement[] = [];
-    const elements = document.querySelectorAll("[aria-label]");
-    for (const element of elements) {
-        if (element.getAttribute("aria-label") === label) {
-            found.push(element as HTMLElement);
-        }
-    }
-    return found;
-}
-
 const mutationObserver = new MutationObserver(onChange);
 const hiddenGroupsStore = createStore("HiddenGroups", "HiddenGroupsList");
 
@@ -52,13 +36,14 @@ async function saveToStorage(): Promise<void> {
 
 function onChange(): void {
     // Check if the 'Direct Messages' panel is visible.
-    const dms = findElement("Direct Messages");
-    if (dms.length < 2) return;
-
-    const list = dms[1];
+    const dms = document.evaluate(
+        "/html/body/div[1]/div[3]/div[1]/div[1]/div/div[2]/div/div/div/div/div[1]/nav/div[2]/ul",
+        document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
+        .singleNodeValue as HTMLElement;
+    if (!dms) return;
 
     // Traverse and determine the channel IDs of each element.
-    for (const element of list.children) {
+    for (const element of dms.children) {
         const first = element.children[0];
         if (first == null) continue;
 

--- a/src/plugins/hideGroups/index.tsx
+++ b/src/plugins/hideGroups/index.tsx
@@ -103,25 +103,15 @@ export default definePlugin({
         {
             find: 'location:"private_channel"',
             replacement: {
-                match: /return .\.isMultiUserDM\(\)/,
-                replace: (match) => {
-                    const ret = match.split(".")[0];
-                    const varName = ret.charAt(ret.length - 1);
-
-                    return `return !$self.shouldRender(${varName}.id)?undefined:${varName}.isMultiUserDM()`;
-                }
+                match: /return (\i).isMultiUserDM\(\)/,
+                replace: "return !$self.shouldRender($1.id)?undefined:$1.isMultiUserDM()"
             }
         },
         {
             find: 'location:"private_channel"',
             replacement: {
-                match: /\i.default=\i=>{let{.+}=\i,/,
-                replace: (match) => {
-                    const declaration = match.split("=>")[0];
-                    const props = declaration.split("=")[1];
-
-                    return `${match}_a=$self.setForceUpdate(${props}._forceUpdate),`;
-                }
+                match: /\i.default=(\i)=>{let{.+}=\i,/,
+                replace: "$&_a=$self.setForceUpdate($1._forceUpdate),"
             }
         },
         {

--- a/src/plugins/hideGroups/index.tsx
+++ b/src/plugins/hideGroups/index.tsx
@@ -1,0 +1,153 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2024 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+
+import definePlugin, { OptionType, StartAt } from "@utils/types";
+import { definePluginSettings } from "@api/Settings";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { FluxDispatcher, Menu } from "@webpack/common";
+import { createStore, entries, set } from "@api/DataStore";
+
+/**
+ * Finds an element with the specified 'aria-label'.
+ *
+ * @param label The label to search for.
+ */
+function findElement(label: string): HTMLElement[] {
+    const found: HTMLElement[] = [];
+    const elements = document.querySelectorAll("[aria-label]");
+    for (const element of elements) {
+        if (element.getAttribute("aria-label") === label) {
+            found.push(element as HTMLElement);
+        }
+    }
+    return found;
+}
+
+const mutationObserver = new MutationObserver(onChange);
+const hiddenGroupsStore = createStore("HiddenGroups", "HiddenGroupsList");
+
+const hiddenGroups: string[] = [];
+const elements: { [key: string]: HTMLElement } = {};
+
+async function saveToStorage(): Promise<void> {
+    await set("list", JSON.stringify(hiddenGroups), hiddenGroupsStore);
+}
+
+function onChange(): void {
+    // Check if the 'Direct Messages' panel is visible.
+    const dms = findElement("Direct Messages");
+    if (dms.length < 2) return;
+
+    const list = dms[1];
+
+    // Traverse and determine the channel IDs of each element.
+    for (const element of list.children) {
+        const first = element.children[0];
+        if (first == null) continue;
+
+        const anchor = first.children[0];
+        if (!anchor) continue;
+
+        const { href } = anchor as HTMLAnchorElement;
+        const split = href.split("/");
+
+        if (split.length != 6) continue;
+        const channelId = split[split.length - 1];
+        elements[channelId] = element as HTMLElement;
+    }
+
+    // Hide elements.
+    for (const key in elements) {
+        if (!hiddenGroups.includes(key)) continue;
+
+        const element = elements[key];
+        element.style.display = "none";
+    }
+
+    saveToStorage().catch(console.error);
+}
+
+function removeIgnored(event: any) {
+    if (!settings.store.showOnMessage) return;
+
+    const { channelId, guildId } = event;
+    if (guildId != undefined || channelId == undefined) return;
+
+    if (!hiddenGroups.includes(channelId)) return;
+
+    // Append the channel to the list.
+    const groupDm = elements[channelId];
+    groupDm.style.display = "block";
+
+    // Remove the channel from the ignored list.
+    hiddenGroups.splice(hiddenGroups.indexOf(channelId), 1);
+    delete elements[channelId];
+
+    saveToStorage().catch(console.error);
+}
+
+const settings = definePluginSettings({
+    showOnMessage: {
+        description: "Reveals a hidden group when a message is received from it.",
+        type: OptionType.BOOLEAN,
+        default: true
+    }
+});
+
+const GroupDMContext: NavContextMenuPatchCallback = (children, { channel }) => {
+    const group = findGroupChildrenByChildId("mark-channel-read", children) ?? children;
+    group.push(
+        <Menu.MenuItem
+            id={"hide-group"}
+            label={"Hide Group"}
+            action={() => {
+                hiddenGroups.push(channel.id);
+                onChange(); // Instantly apply the changes.
+            }}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "Hide Groups",
+    authors: [Devs.Magix],
+    description: "Allows hiding group DMs.",
+    settings,
+
+    startAt: StartAt.DOMContentLoaded,
+    async start() {
+        // Import hidden DMs.
+        entries(hiddenGroupsStore).then(data => {
+            const [_, list] = data[0];
+            hiddenGroups.push(...JSON.parse(list));
+        });
+
+        FluxDispatcher.subscribe("MESSAGE_CREATE", removeIgnored);
+        mutationObserver.observe(document, { childList: true, subtree: true });
+    },
+    stop() {
+        FluxDispatcher.unsubscribe("MESSAGE_CREATE", removeIgnored);
+        mutationObserver.disconnect();
+    },
+
+    contextMenus: {
+        "gdm-context": GroupDMContext
+    }
+});

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -244,7 +244,7 @@ export default definePlugin({
 
     patches: [
         {
-            find: '="LocalActivityStore",',
+            find: '"LocalActivityStore"',
             replacement: [
                 {
                     match: /HANG_STATUS.+?(?=!\i\(\)\(\i,\i\)&&)(?<=(\i)\.push.+?)/,
@@ -253,7 +253,7 @@ export default definePlugin({
             ]
         },
         {
-            find: '="ActivityTrackingStore",',
+            find: '"ActivityTrackingStore"',
             replacement: {
                 match: /getVisibleRunningGames\(\).+?;(?=for)(?<=(\i)=\i\.\i\.getVisibleRunningGames.+?)/,
                 replace: (m, runningGames) => `${m}${runningGames}=${runningGames}.filter(({id,name})=>$self.isActivityNotIgnored({type:0,application_id:id,name}));`

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -323,35 +323,35 @@ export default definePlugin({
             replacement: [
                 {
                     // Add deleted=true to all target messages in the MESSAGE_DELETE event
-                    match: /MESSAGE_DELETE:function\((\i)\){let.+?((?:\i\.){2})getOrCreate.+?},/,
+                    match: /function (\i)\((\i)\){let.+?((?:\i\.){2})getOrCreate.+?}(?=function.*MESSAGE_DELETE:\1)/,
                     replace:
-                        "MESSAGE_DELETE:function($1){" +
-                        "   var cache = $2getOrCreate($1.channelId);" +
-                        "   cache = $self.handleDelete(cache, $1, false);" +
-                        "   $2commit(cache);" +
-                        "},"
+                        "function $1($2){" +
+                        "   var cache = $3getOrCreate($2.channelId);" +
+                        "   cache = $self.handleDelete(cache, $2, false);" +
+                        "   $3commit(cache);" +
+                        "}"
                 },
                 {
                     // Add deleted=true to all target messages in the MESSAGE_DELETE_BULK event
-                    match: /MESSAGE_DELETE_BULK:function\((\i)\){let.+?((?:\i\.){2})getOrCreate.+?},/,
+                    match: /function (\i)\((\i)\){let.+?((?:\i\.){2})getOrCreate.+?}(?=function.*MESSAGE_DELETE_BULK:\1)/,
                     replace:
-                        "MESSAGE_DELETE_BULK:function($1){" +
-                        "   var cache = $2getOrCreate($1.channelId);" +
-                        "   cache = $self.handleDelete(cache, $1, true);" +
-                        "   $2commit(cache);" +
-                        "},"
+                        "function $1($2){" +
+                        "   var cache = $3getOrCreate($2.channelId);" +
+                        "   cache = $self.handleDelete(cache, $2, true);" +
+                        "   $3commit(cache);" +
+                        "}"
                 },
                 {
                     // Add current cached content + new edit time to cached message's editHistory
-                    match: /(MESSAGE_UPDATE:function\((\i)\).+?)\.update\((\i)/,
+                    match: /(function (\i)\((\i)\).+?)\.update\((\i)(?=.*MESSAGE_UPDATE:\2)/,
                     replace: "$1" +
-                        ".update($3,m =>" +
-                        "   (($2.message.flags & 64) === 64 || $self.shouldIgnore($2.message, true)) ? m :" +
-                        "   $2.message.edited_timestamp && $2.message.content !== m.content ?" +
-                        "       m.set('editHistory',[...(m.editHistory || []), $self.makeEdit($2.message, m)]) :" +
+                        ".update($4,m =>" +
+                        "   (($3.message.flags & 64) === 64 || $self.shouldIgnore($3.message, true)) ? m :" +
+                        "   $3.message.edited_timestamp && $3.message.content !== m.content ?" +
+                        "       m.set('editHistory',[...(m.editHistory || []), $self.makeEdit($3.message, m)]) :" +
                         "       m" +
                         ")" +
-                        ".update($3"
+                        ".update($4"
                 },
                 {
                     // fix up key (edit last message) attempting to edit a deleted message
@@ -465,12 +465,12 @@ export default definePlugin({
             find: '"ReferencedMessageStore"',
             replacement: [
                 {
-                    match: /MESSAGE_DELETE:function\((\i)\).+?},/,
-                    replace: "MESSAGE_DELETE:function($1){},"
+                    match: /MESSAGE_DELETE:\i,/,
+                    replace: "MESSAGE_DELETE:()=>{},"
                 },
                 {
-                    match: /MESSAGE_DELETE_BULK:function\((\i)\).+?},/,
-                    replace: "MESSAGE_DELETE_BULK:function($1){},"
+                    match: /MESSAGE_DELETE_BULK:\i,/,
+                    replace: "MESSAGE_DELETE_BULK:()=>{},"
                 }
             ]
         },

--- a/src/plugins/moreUserTags/index.tsx
+++ b/src/plugins/moreUserTags/index.tsx
@@ -182,8 +182,8 @@ export default definePlugin({
         {
             find: ".ORIGINAL_POSTER=",
             replacement: {
-                match: /\((\i)=\{\}\)\)\[(\i)\.BOT/,
-                replace: "($1=$self.getTagTypes()))[$2.BOT"
+                match: /(\i)=\{\}\)\);(?=let \i=100)/,
+                replace: "$1=$self.getTagTypes()));"
             }
         },
         {
@@ -249,8 +249,8 @@ export default definePlugin({
                     match: /user:\i,nick:\i,/,
                     replace: "$&moreTags_channelId,"
                 }, {
-                    match: /,botType:(\i),(?<=user:(\i).+?)/g,
-                    replace: ",botType:$self.getTag({user:$2,channelId:moreTags_channelId,origType:$1,location:'not-chat'}),"
+                    match: /,botType:(\i),botVerified:(\i),(?!discriminatorClass:)(?<=user:(\i).+?)/g,
+                    replace: ",botType:$self.getTag({user:$3,channelId:moreTags_channelId,origType:$1,location:'not-chat'}),botVerified:$2,"
                 }
             ]
         },

--- a/src/plugins/noBlockedMessages/index.ts
+++ b/src/plugins/noBlockedMessages/index.ts
@@ -40,15 +40,15 @@ export default definePlugin({
             ]
         },
         ...[
-            '="MessageStore",',
+            '"MessageStore"',
             '"displayName","ReadStateStore")'
         ].map(find => ({
             find,
             predicate: () => Settings.plugins.NoBlockedMessages.ignoreBlockedMessages === true,
             replacement: [
                 {
-                    match: /(?<=MESSAGE_CREATE:function\((\i)\){)/,
-                    replace: (_, props) => `if($self.isBlocked(${props}.message))return;`
+                    match: /(?<=function (\i)\((\i)\){)(?=.*MESSAGE_CREATE:\1)/,
+                    replace: (_, _funcName, props) => `if($self.isBlocked(${props}.message))return;`
                 }
             ]
         }))

--- a/src/plugins/noPendingCount/index.ts
+++ b/src/plugins/noPendingCount/index.ts
@@ -74,10 +74,10 @@ export default definePlugin({
         // This prevents the Message Requests tab from always hiding due to the previous patch (and is compatible with spam requests)
         // In short, only the red badge is hidden. Button visibility behavior isn't changed.
         {
-            find: ".getSpamChannelsCount(),",
+            find: ".getSpamChannelsCount();",
             predicate: () => settings.store.hideMessageRequestsCount,
             replacement: {
-                match: /(?<=getSpamChannelsCount\(\),\i=)\i\.getMessageRequestsCount\(\)/,
+                match: /(?<=getSpamChannelsCount\(\);return )\i\.getMessageRequestsCount\(\)/,
                 replace: "$self.getRealMessageRequestCount()"
             }
         },

--- a/src/plugins/replyTimestamp/index.tsx
+++ b/src/plugins/replyTimestamp/index.tsx
@@ -69,8 +69,8 @@ export default definePlugin({
         {
             find: ".REPLY_QUOTE_MESSAGE_BLOCKED",
             replacement: {
-                match: /(?<="aria-label":\i,children:\[)(?=\i,\i,\i\])/,
-                replace: "$self.ReplyTimestamp(arguments[0]),"
+                match: /\.onClickReply,.+?}\),(?=\i,\i,\i\])/,
+                replace: "$&$self.ReplyTimestamp(arguments[0]),"
             }
         }
     ],

--- a/src/plugins/showHiddenChannels/index.tsx
+++ b/src/plugins/showHiddenChannels/index.tsx
@@ -444,7 +444,7 @@ export default definePlugin({
             }
         },
         {
-            find: '="GuildChannelStore",',
+            find: '"GuildChannelStore"',
             replacement: [
                 {
                     // Make GuildChannelStore contain hidden channels
@@ -453,7 +453,7 @@ export default definePlugin({
                 },
                 {
                     // Filter hidden channels from GuildChannelStore.getChannels unless told otherwise
-                    match: /(?<=getChannels\(\i)(\){.+?)return (.+?)}/,
+                    match: /(?<=getChannels\(\i)(\){.*?)return (.+?)}/,
                     replace: (_, rest, channels) => `,shouldIncludeHidden${rest}return $self.resolveGuildChannels(${channels},shouldIncludeHidden??arguments[0]==="@favorites");}`
                 }
             ]

--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -48,7 +48,7 @@ export default definePlugin({
     authors: [Devs.Rini, Devs.TheKodeToad],
     patches: [
         {
-            find: '?"@":"")',
+            find: '?"@":""',
             replacement: {
                 match: /(?<=onContextMenu:\i,children:).*?\)}/,
                 replace: "$self.renderUsername(arguments[0])}"

--- a/src/plugins/superReactionTweaks/index.ts
+++ b/src/plugins/superReactionTweaks/index.ts
@@ -42,8 +42,8 @@ export default definePlugin({
         {
             find: ",BURST_REACTION_EFFECT_PLAY",
             replacement: {
-                match: /(BURST_REACTION_EFFECT_PLAY:\i=>{.{50,100})(\i\(\i,\i\))>=\d+/,
-                replace: "$1!$self.shouldPlayBurstReaction($2)"
+                match: /((\i)=\i=>{.{50,100})(\i\(\i,\i\))>=\i(?=.*BURST_REACTION_EFFECT_PLAY:\2)/,
+                replace: "$1!$self.shouldPlayBurstReaction($3)"
             }
         },
         {

--- a/src/plugins/userVoiceShow/components.tsx
+++ b/src/plugins/userVoiceShow/components.tsx
@@ -21,7 +21,7 @@ const getDMChannelIcon = findByCodeLazy(".getChannelIconURL({");
 const VoiceStateStore = findStoreLazy("VoiceStateStore");
 
 const UserSummaryItem = findComponentByCodeLazy("defaultRenderUser", "showDefaultAvatarsForNullUsers");
-const Avatar = findComponentByCodeLazy(".AVATAR_STATUS_TYPING_16;");
+const Avatar = findComponentByCodeLazy(".status)/2):0");
 const GroupDMAvatars = findComponentByCodeLazy(".AvatarSizeSpecs[", "getAvatarURL");
 
 const ActionButtonClasses = findByPropsLazy("actionButton", "highlight");

--- a/src/plugins/volumeBooster/index.ts
+++ b/src/plugins/volumeBooster/index.ts
@@ -89,7 +89,7 @@ export default definePlugin({
             find: "AudioContextSettingsMigrated",
             replacement: [
                 {
-                    match: /(?<=isLocalMute\(\i,\i\),volume:.+?volume:)\i(?=})/,
+                    match: /(?<=isLocalMute\(\i,\i\),volume:(\i).+?\i\(\i,\i,)\1(?=\))/,
                     replace: "$&>200?200:$&"
                 },
                 {

--- a/src/plugins/whoReacted/index.tsx
+++ b/src/plugins/whoReacted/index.tsx
@@ -109,11 +109,12 @@ export default definePlugin({
                 match: /(\i)\?null:\(0,\i\.jsx\)\(\i\.\i,{className:\i\.reactionCount,.*?}\),/,
                 replace: "$&$1?null:$self.renderUsers(this.props),"
             }
-        }, {
+        },
+        {
             find: '"MessageReactionsStore"',
             replacement: {
-                match: /(?<=CONNECTION_OPEN:function\(\){)(\i)={}/,
-                replace: "$&;$self.reactions=$1"
+                match: /function (\i)\(\){(\i)={}(?=.*CONNECTION_OPEN:\1)/,
+                replace: "$&;$self.reactions=$2;"
             }
         },
         {


### PR DESCRIPTION
This plugin allows users to hide group DMs via the context menu.

(adjusted to merge into `dev` rather than `main`)