### PR TITLE
fix(showHiddenChannels): Disable hidden channel name obfuscation

### DIFF
--- a/src/plugins/showHiddenChannels/index.tsx
+++ b/src/plugins/showHiddenChannels/index.tsx
@@ -37,6 +37,7 @@ const enum ShowMode {
 }
 
 const CONNECT = 1n << 20n;
+const CHANNEL_OBFUSCATE = 1 << 15;
 
 export const settings = definePluginSettings({
     hideUnreads: {
@@ -64,7 +65,7 @@ export const settings = definePluginSettings({
 export default definePlugin({
     name: "ShowHiddenChannels",
     description: "Show channels that you do not have access to view.",
-    authors: [Devs.BigDuck, Devs.AverageReactEnjoyer, Devs.D3SOX, Devs.Ven, Devs.Nuckyz, Devs.Nickyux, Devs.dzshn],
+    authors: [Devs.BigDuck, Devs.AverageReactEnjoyer, Devs.D3SOX, Devs.Ven, Devs.Nuckyz, Devs.Nickyux, Devs.dzshn, Devs.Davri],
     settings,
 
     patches: [
@@ -472,6 +473,14 @@ export default definePlugin({
                 // Make active now voice states on hidden channels
                 match: /(getVoiceStateForUser.{0,150}?)&&\i\.\i\.canWithPartialContext.{0,20}VIEW_CHANNEL.+?}\)(?=\?)/,
                 replace: "$1"
+            }
+        },
+        // Disable channel name obfuscation flag in the IDENTIFY gateway event
+        {
+            find: "doIdentify",
+            replacement: {
+                match: /capabilities:/,
+                replace: `capabilities:~${CHANNEL_OBFUSCATE}&`
             }
         }
     ],

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -575,6 +575,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n,
     },
+    Davri: {
+        name: "Davri",
+        id: 457579346282938368n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This patch aims to revert the channel name obfuscation experiment, which might get added to the default gateway flags in the future.

![image](https://github.com/user-attachments/assets/1f2605b7-5c99-4543-be6d-4ed817bb4521)
