### PR TITLE
Fix: Moving channels (read desc.)

### DIFF
--- a/src/plugins/showHiddenChannels/index.tsx
+++ b/src/plugins/showHiddenChannels/index.tsx
@@ -61,6 +61,10 @@ export const settings = definePluginSettings({
     }
 });
 
+function isUncatagorized(objChannel: { channel: Channel; comparator: number; }) {
+    return objChannel.channel.id === "null" && objChannel.channel.name === "Uncategorized" && objChannel.comparator === -1;
+}
+
 export default definePlugin({
     name: "ShowHiddenChannels",
     description: "Show channels that you do not have access to view.",
@@ -503,7 +507,7 @@ export default definePlugin({
             res[key] ??= [];
 
             for (const objChannel of maybeObjChannels) {
-                if (objChannel.channel.id === null || !this.isHiddenChannel(objChannel.channel)) res[key].push(objChannel);
+                if (isUncatagorized(objChannel) || objChannel.channel.id === null || !this.isHiddenChannel(objChannel.channel)) res[key].push(objChannel);
             }
         }
 


### PR DESCRIPTION
This fixes a bug in show hidden channels where you could not move things down if they **were not** in a category.
You also could not move uncategorized channels up or down.

This bug was caused by the `Uncategorized` category being filtered out, breaking discords code.