### PR TITLE
fix: pronoundb duplicate pronouns in normal mode

### DIFF
--- a/src/plugins/pronoundb/components/PronounsChatComponent.tsx
+++ b/src/plugins/pronoundb/components/PronounsChatComponent.tsx
@@ -19,7 +19,7 @@
 import ErrorBoundary from "@components/ErrorBoundary";
 import { classes } from "@utils/misc";
 import { findByPropsLazy } from "@webpack";
-import { UserStore } from "@webpack/common";
+import { Timestamp, UserStore } from "@webpack/common";
 import { Message } from "discord-types/general";
 
 import { useFormattedPronouns } from "../api";
@@ -40,14 +40,14 @@ function shouldShow(message: Message): boolean {
     return true;
 }
 
-export const PronounsChatComponentWrapper = ErrorBoundary.wrap(({ message }: { message: Message; }) => {
-    return shouldShow(message)
+export const PronounsChatComponentWrapper = ErrorBoundary.wrap(({ message, compact }: { message: Message, compact: bool }) => {
+    return !compact && shouldShow(message)
         ? <PronounsChatComponent message={message} />
         : null;
 }, { noop: true });
 
-export const CompactPronounsChatComponentWrapper = ErrorBoundary.wrap(({ message }: { message: Message; }) => {
-    return shouldShow(message)
+export const CompactPronounsChatComponentWrapper = ErrorBoundary.wrap(({ message, compact }: { message: Message, compact: bool }) => {
+    return compact && shouldShow(message)
         ? <CompactPronounsChatComponent message={message} />
         : null;
 }, { noop: true });


### PR DESCRIPTION
PronounDB had a bug for me on Vesktop where the compact mode pronouns would show up in normal mode, resulting in two sets of pronouns being visible. This change fixes that issue by explicitly checking if compact mode is enabled