### PR TITLE
Fix FakeNitro patch for FakeStickers

### DIFF
--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -350,7 +350,7 @@ export default definePlugin({
                 {
                     // Filter attachments to remove fake nitro stickers or emojis
                     predicate: () => settings.store.transformStickers,
-                    match: /renderAttachments\(\i\){let{attachments:(\i).+?;/,
+                    match: /{attachments:(\i).+?;/,
                     replace: (m, attachments) => `${m}${attachments}=$self.filterAttachments(${attachments});`
                 }
             ]


### PR DESCRIPTION
Fix FakeNitro patch for rendering FakeStickers
This patch might be a little sensitive but it doesn't currently conflict with any other code in the module and I don't think it will
An alternative less sensitive patch would be a lookbehind for the function's name "renderAttachments"

To test this patch enable these 3 options and send a FakeNitro's FakeSticker
![image](https://github.com/user-attachments/assets/f555d3c3-38a4-48a4-ba86-83918fba04ff)
If the patch applied correctly it should look like a regular FakeSticker in the message