### PR TITLE
feat(BetterFolders): add folder nesting & multi-column mode.

### DIFF
--- a/src/plugins/betterFolders/FolderSideBar.tsx
+++ b/src/plugins/betterFolders/FolderSideBar.tsx
@@ -27,17 +27,24 @@ const ChannelRTCStore = findStoreLazy("ChannelRTCStore");
 const Animations = findByPropsLazy("a", "animated", "useTransition");
 const GuildsBar = findComponentByCodeLazy('("guildsnav")');
 
+function generateSidebar(guildsBarProps, expandedFolders, id: number) {
+    return (
+        <GuildsBar
+            {...guildsBarProps}
+            betterFoldersId={id}
+            betterFoldersExpandedIds={expandedFolders}
+        />
+    );
+}
+
 export default ErrorBoundary.wrap(guildsBarProps => {
     const expandedFolders = useStateFromStores([ExpandedGuildFolderStore], () => ExpandedGuildFolderStore.getExpandedFolders());
     const isFullscreen = useStateFromStores([ChannelRTCStore], () => ChannelRTCStore.isFullscreenInContext());
 
-    const Sidebar = (
-        <GuildsBar
-            {...guildsBarProps}
-            isBetterFolders={true}
-            betterFoldersExpandedIds={expandedFolders}
-        />
-    );
+    console.log("EXPANDED FOLDERS");
+    console.log(expandedFolders);
+
+    const Sidebars = Array.from(expandedFolders).map(e => generateSidebar(guildsBarProps, new Set([e]), 1));
 
     const visible = !!expandedFolders.size;
     const guilds = document.querySelector(guildsBarProps.className.split(" ").map(c => `.${c}`).join(""));
@@ -50,25 +57,18 @@ export default ErrorBoundary.wrap(guildsBarProps => {
 
     if (!guilds || !settings.store.sidebarAnim) {
         return visible
-            ? <div style={barStyle}>{Sidebar}</div>
+            ? <div style={barStyle}>{Sidebars}</div>
             : null;
     }
 
+    const animStyle = {
+        width: guilds.getBoundingClientRect().width * Sidebars.length,
+        transition: "width .2s ease-out"
+    } as CSSProperties;
+
     return (
-        <Animations.Transition
-            items={visible}
-            from={{ width: 0 }}
-            enter={{ width: guilds.getBoundingClientRect().width }}
-            leave={{ width: 0 }}
-            config={{ duration: 200 }}
-        >
-            {(animationStyle, show) =>
-                show && (
-                    <Animations.animated.div style={{ ...animationStyle, ...barStyle }}>
-                        {Sidebar}
-                    </Animations.animated.div>
-                )
-            }
-        </Animations.Transition>
+        <div style={{ ...animStyle, ...barStyle }}>
+            {Sidebars}
+        </div>
     );
 }, { noop: true });

--- a/src/plugins/betterFolders/index.tsx
+++ b/src/plugins/betterFolders/index.tsx
@@ -360,7 +360,18 @@ export default definePlugin({
     },
 
     shouldShowFolderIconAndBackground(props: any, expandedFolderIds?: Set<any>) {
-        if (!props.betterFoldersId) return settings.store.nestMode != NestMode.NESTED || !props.folderNode?.name?.includes("/");
+        if (!props.betterFoldersId) {
+            if (settings.store.nestMode != NestMode.NESTED) {
+                return true;
+            }
+            if (props.folderNode?.name?.includes("/")) {
+                // check if parent folder exists
+                const parentName = props.folderNode.name.substring(0, props.folderNode.name.lastIndexOf("/"));
+                const allFolders = SortedGuildStore.getGuildFolders();
+                return !allFolders.find(e => e.folderName === parentName);
+            }
+            return true;
+        }
 
         switch (settings.store.showFolderIcon) {
             case FolderIconDisplay.Never:

--- a/src/plugins/betterFolders/index.tsx
+++ b/src/plugins/betterFolders/index.tsx
@@ -94,7 +94,7 @@ export const settings = definePluginSettings({
     },
     nestMode: {
         type: OptionType.SELECT,
-        description: "Use nested extra columns (folders split by `/`) for displaying folder contents",
+        description: "Use multiple columns for displaying folder contents. When enabled folder names will be split by `/` and nested",
         options: [
             { label: "Disabled", value: NestMode.DISABLED, default: true },
             { label: "Seperate Columns", value: NestMode.SEPERATE_COLUMNS },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -575,6 +575,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n,
     },
+    Wagyourtail: {
+        name: "Wagyourtail",
+        id: 100748674849579008n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
I have implemented 2 new modes for better folders.
the first simply makes each folder open in its own column:
![image](https://github.com/user-attachments/assets/2e924a15-dedf-4404-9f7c-74ad0217416c)

and the nested mode actually implements a tree-like structure:
![image](https://github.com/user-attachments/assets/4509a932-2457-4cd3-b4f4-106c75a0ee25)

for the nest mode, folders are simply parsed by name and split on `/`, so on an unmodified client, the folders would simply be displayed next to eachother. 