### PR TITLE
Update source code options for dev build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - main
+            - Update-source-code-options-for-dev-build
         paths:
             - .github/workflows/build.yml
             - src/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
                   echo "release_tag=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
             - name: Upload DevBuild as release
-              if: github.repository == 'Vendicated/Vencord'
+              # if: github.repository == 'Vendicated/Vencord'
               run: |
                   gh release upload devbuild --clobber dist/*
                   gh release edit devbuild --title "DevBuild $RELEASE_TAG"
@@ -60,6 +60,7 @@ jobs:
                   RELEASE_TAG: ${{ env.release_tag }}
 
             - name: Update source code options of DevBuild release
+              # if: github.repository == 'Vendicated/Vencord'
               run: |
                   git tag -f ${{ env.release_tag }}
                   git push -f origin ${{ env.release_tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
     push:
         branches:
             - main
-            - Update-source-code-options-for-dev-build
         paths:
             - .github/workflows/build.yml
             - src/**
@@ -51,7 +50,7 @@ jobs:
                   echo "release_tag=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
             - name: Upload DevBuild as release
-              # if: github.repository == 'Vendicated/Vencord'
+              if: github.repository == 'Vendicated/Vencord'
               run: |
                   gh release upload devbuild --clobber dist/*
                   gh release edit devbuild --title "DevBuild $RELEASE_TAG"
@@ -60,7 +59,7 @@ jobs:
                   RELEASE_TAG: ${{ env.release_tag }}
 
             - name: Update source code options of DevBuild release
-              # if: github.repository == 'Vendicated/Vencord'
+              if: github.repository == 'Vendicated/Vencord'
               run: |
                   git tag -f devbuild
                   git push -f origin devbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,8 @@ jobs:
             - name: Update source code options of DevBuild release
               # if: github.repository == 'Vendicated/Vencord'
               run: |
-                  git tag -f ${{ env.release_tag }}
-                  git push -f origin ${{ env.release_tag }}
+                  git tag -f devbuild
+                  git push -f origin devbuild
 
             - name: Upload DevBuild to builds repo
               if: github.repository == 'Vendicated/Vencord'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,11 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   RELEASE_TAG: ${{ env.release_tag }}
 
+            - name: Update source code options of DevBuild release
+              run: |
+                  git tag -f ${{ env.release_tag }}
+                  git push -f origin ${{ env.release_tag }}
+
             - name: Upload DevBuild to builds repo
               if: github.repository == 'Vendicated/Vencord'
               run: |


### PR DESCRIPTION
I have seen `Github doesn't let you change the source code zip so it is outdated, please refer to the main branch for the latest source code.` being in the description of the DevBuild, so I thought I make a change that also updates the source code options. I searched for `source code` in both pull requests and issues but didn't find something there.

It basically just updates and force-pushes the devbuild tag.

I'm not sure if commits are squashed, so it would be nice to know if I should squash the commits into one or similar.

I have read the contributing guidelines, but I didn't find something regarding CI changes, so I hope I didn't miss anything.

This is my test PR, where you should be able to see the workflow runs: https://github.com/Wissididom/Vencord/pull/1