### PR TITLE
Add button to enable plugin on veebot plugin embeds

### DIFF
--- a/src/plugins/_core/supportHelper.tsx
+++ b/src/plugins/_core/supportHelper.tsx
@@ -323,9 +323,9 @@ export default definePlugin({
                         );
                     }
 
-                    const plugin_name = props.message.embeds[0]?.url?.match(/vencord.dev\/plugins\/([^/?#]+)/);
-                    if (plugin_name) {
-                        const pluginKey = plugin_name[1];
+                    const pluginName = props.message.embeds[0]?.url?.match(/vencord.dev\/plugins\/([^/?#]+)/);
+                    if (pluginName) {
+                        const pluginKey = pluginName[1];
                         buttons.push(
                             <Button
                                 key="vc-enable-plugin"

--- a/src/plugins/_core/supportHelper.tsx
+++ b/src/plugins/_core/supportHelper.tsx
@@ -322,6 +322,26 @@ export default definePlugin({
                             </Button>
                         );
                     }
+
+                    const plugin_name = props.message.embeds[0]?.url?.match(/vencord.dev\/plugins\/([^/?#]+)/);
+                    if (plugin_name) {
+                        const pluginKey = plugin_name[1];
+                        buttons.push(
+                            <Button
+                                key="vc-enable-plugin"
+                                onClick={async () => {
+                                    if (Vencord.Settings.plugins[pluginKey]) {
+                                        Vencord.Settings.plugins[pluginKey].enabled = true;
+                                        showToast("Plugin enabled successfully! Please restart your discord to see effects!", Toasts.Type.SUCCESS);
+                                    } else {
+                                        showToast("Plugin not found. Update Vencord?", Toasts.Type.FAILURE);
+                                    }
+                                }}
+                            >
+                                Enable Plugin
+                            </Button>
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
Maybe this is too niche, but I've seen an outstanding amount of users not know what to do when prompted with these embeds.

![image](https://github.com/user-attachments/assets/973761e1-00a1-40c2-be38-65189393cc5c)
![image](https://github.com/user-attachments/assets/e8e029cc-ff9b-4698-a964-ca9d49dcd784)

Could force a restart after the plugin is enabled too (or maybe add another button to do that?) but I don't even know if this will be accepted, let alone that.