### PR TITLE
Added the normalEmojis plugin

### DIFF
--- a/src/plugins/normalEmojis/index.ts
+++ b/src/plugins/normalEmojis/index.ts
@@ -1,0 +1,35 @@
+import definePlugin from "@utils/types";
+import style from "./style.css";
+
+let interval: NodeJS.Timeout;
+let styleElement: HTMLStyleElement;
+export default definePlugin({
+    name: "Normal Emojis",
+    description: "Automatically remove src attributes from emojis.",
+    authors: [{ name: "Tijme", id: 331821337586827265n }],
+    start() {
+        interval = setInterval(
+            () =>
+                document
+                    .querySelectorAll(
+                        "img.emoji:not([data-id]):not(.primaryEmoji_e58351)",
+                    )
+                    .forEach((e) => e.setAttribute("src", "")),
+            100,
+        );
+
+        // Inject CSS (style.css)
+        styleElement = injectCSS(style);
+    },
+    stop() {
+        clearInterval(interval);
+        styleElement.remove();
+    },
+});
+
+const injectCSS = (css: string) => {
+    let el = document.createElement("style");
+    el.innerText = css;
+    document.head.appendChild(el);
+    return el;
+};

--- a/src/plugins/normalEmojis/style.css
+++ b/src/plugins/normalEmojis/style.css
@@ -1,0 +1,20 @@
+img.emoji:not([alt^=":"]):not([data-id]) {
+    text-indent: unset;
+    visibility: collapse;
+    display: inline-flex;
+    content: unset;
+}
+
+img.emoji:not([alt^=":"]):not([data-id])::before {
+    content: attr(alt);
+    visibility: visible;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+}
+
+img.emoji.jumboable:not([alt^=":"]):not([data-id])::before {
+    font-size: 2cqw;
+}


### PR DESCRIPTION
I have always wanted Apple Emojis on my Linux installation. With this plugin, you get that. 

I remove the source attribute of the `img` tag, and create a `::before` element with the actual emoji character as content. This way, the emoji gets rendered as the font you have installed for emojis.

This is what it looks like:
![image](https://github.com/user-attachments/assets/ca271e91-4f34-47ff-862b-b93817b8f6c8)
