### PR TITLE
SilentTyping: allow channel exceptions

### DIFF
--- a/src/plugins/silentTyping/index.tsx
+++ b/src/plugins/silentTyping/index.tsx
@@ -40,7 +40,12 @@ const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         description: "Toggle functionality",
         default: true,
-    }
+    },
+    excludeChannels: {
+        type: OptionType.STRING,
+        description: "Comma-separated list of channel IDs to show typing in",
+        default: ""
+    },
 });
 
 const SilentTypingToggle: ChatBarButton = ({ isMainChat }) => {
@@ -124,7 +129,9 @@ export default definePlugin({
     }],
 
     async startTyping(channelId: string) {
-        if (settings.store.isEnabled) return;
+        if (settings.store.isEnabled && !settings.store.excludeChannels.includes(channelId)) {
+            return;
+        }
         FluxDispatcher.dispatch({ type: "TYPING_START_LOCAL", channelId });
     },
 


### PR DESCRIPTION
Lets users add server and DM channels to allow typing in for the SilentTyping plugin, while silencing the typing elsewhere.