### PR TITLE
blurNSFW update to also include DMs

### DIFF
--- a/src/plugins/blurNsfw/index.ts
+++ b/src/plugins/blurNsfw/index.ts
@@ -24,21 +24,33 @@ let style: HTMLStyleElement;
 
 function setCss() {
     style.textContent = `
+        /* Blur for NSFW channels */
         .vc-nsfw-img [class^=imageWrapper] img,
         .vc-nsfw-img [class^=wrapperPaused] video {
             filter: blur(${Settings.plugins.BlurNSFW.blurAmount}px);
             transition: filter 0.2s;
         }
+        
+        /* Blur for DMs when enabled */
+        .vc-dm-blur [class^=imageWrapper] img,
+        .vc-dm-blur [class^=wrapperPaused] video {
+            filter: blur(${Settings.plugins.BlurNSFW.blurAmount}px);
+            transition: filter 0.2s;
+        }
+        
+        /* Remove blur on hover for both NSFW and DMs */
         .vc-nsfw-img [class^=imageWrapper]:hover img,
-        .vc-nsfw-img [class^=wrapperPaused]:hover video {
+        .vc-nsfw-img [class^=wrapperPaused]:hover video,
+        .vc-dm-blur [class^=imageWrapper]:hover img,
+        .vc-dm-blur [class^=wrapperPaused]:hover video {
             filter: unset;
         }
-        `;
+    `;
 }
 
 export default definePlugin({
     name: "BlurNSFW",
-    description: "Blur attachments in NSFW channels until hovered",
+    description: "Blur attachments in NSFW channels and DMs until hovered",
     authors: [Devs.Ven],
 
     patches: [
@@ -46,7 +58,7 @@ export default definePlugin({
             find: ".embedWrapper,embed",
             replacement: [{
                 match: /\.container/,
-                replace: "$&+(this.props.channel.nsfw? ' vc-nsfw-img': '')"
+                replace: "$&+(this.props.channel.nsfw?' vc-nsfw-img':'')+(this.props.channel.type===1&&Settings.plugins.BlurNSFW.blurDirectMessage?' vc-dm-blur':'')"
             }]
         }
     ],
@@ -57,14 +69,19 @@ export default definePlugin({
             description: "Blur Amount",
             default: 10,
             onChange: setCss
+        },
+        blurDirectMessage: {
+            type: OptionType.BOOLEAN,
+            description: "Blur Images in Direct Messages",
+            default: false,
+            onChange: setCss
         }
     },
 
     start() {
         style = document.createElement("style");
-        style.id = "VcBlurNsfw";
+        style.id = "VcBlurNSFW";
         document.head.appendChild(style);
-
         setCss();
     },
 


### PR DESCRIPTION
## Description
Enhanced the BlurNSFW plugin to support blurring images in DMs. Added a toggle option in settings to enable/disable DM blurring independently of NSFW channel blurring. 

## Changes
- Added new blurDirectMessage toggle option in settings
- Added DM detection and blur functionality
- Maintained all existing NSFW channel blur functionality

## Testing
Tested functionality in:
- NSFW channels (existing blur working as expected)
- Direct Messages (new blur working with toggle)
- Settings menu (blur amount and DM toggle working properly)