### PR TITLE
BlurNSFW with DM/Group Chat support

### DIFF
--- a/src/plugins/blurNsfw/index.ts
+++ b/src/plugins/blurNsfw/index.ts
@@ -24,21 +24,33 @@ let style: HTMLStyleElement;
 
 function setCss() {
     style.textContent = `
+        /* Blur for NSFW channels */
         .vc-nsfw-img [class^=imageWrapper] img,
         .vc-nsfw-img [class^=wrapperPaused] video {
             filter: blur(${Settings.plugins.BlurNSFW.blurAmount}px);
             transition: filter 0.2s;
         }
+        
+        /* Blur for DMs when enabled */
+        .vc-dm-blur [class^=imageWrapper] img,
+        .vc-dm-blur [class^=wrapperPaused] video {
+            filter: blur(${Settings.plugins.BlurNSFW.blurAmount}px);
+            transition: filter 0.2s;
+        }
+        
+        /* Remove blur on hover for both NSFW and DMs */
         .vc-nsfw-img [class^=imageWrapper]:hover img,
-        .vc-nsfw-img [class^=wrapperPaused]:hover video {
+        .vc-nsfw-img [class^=wrapperPaused]:hover video,
+        .vc-dm-blur [class^=imageWrapper]:hover img,
+        .vc-dm-blur [class^=wrapperPaused]:hover video {
             filter: unset;
         }
-        `;
+    `;
 }
 
 export default definePlugin({
     name: "BlurNSFW",
-    description: "Blur attachments in NSFW channels until hovered",
+    description: "Blur attachments in NSFW channels and DMs until hovered",
     authors: [Devs.Ven],
 
     patches: [
@@ -46,7 +58,7 @@ export default definePlugin({
             find: ".embedWrapper,embed",
             replacement: [{
                 match: /\.container/,
-                replace: "$&+(this.props.channel.nsfw? ' vc-nsfw-img': '')"
+                replace: "$&+(this.props.channel.nsfw?' vc-nsfw-img':'')+(this.props.channel.type===1&&Settings.plugins.BlurNSFW.blurDirectMessage?' vc-dm-blur':'')"
             }]
         }
     ],
@@ -57,14 +69,19 @@ export default definePlugin({
             description: "Blur Amount",
             default: 10,
             onChange: setCss
+        },
+        blurDirectMessage: {
+            type: OptionType.BOOLEAN,
+            description: "Blur Images in Direct Messages",
+            default: false,
+            onChange: setCss
         }
     },
 
     start() {
         style = document.createElement("style");
-        style.id = "VcBlurNsfw";
+        style.id = "VcBlurNSFW";
         document.head.appendChild(style);
-
         setCss();
     },
 

--- a/src/plugins/blurNsfw/index.ts
+++ b/src/plugins/blurNsfw/index.ts
@@ -16,25 +16,42 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Settings } from "@api/Settings";
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    blurAmount: {
+        type: OptionType.NUMBER,
+        description: "Blur Amount",
+        default: 10,
+        onChange: () => setCss()
+    },
+    blurDirectMessage: {
+        type: OptionType.BOOLEAN,
+        description: "Blur Images in Direct Messages",
+        default: false,
+    }
+});
 
 let style: HTMLStyleElement;
 
 function setCss() {
+    if (!style) return;
+    const blurValue = settings.store.blurAmount ?? 10;
+    
     style.textContent = `
         /* Blur for NSFW channels */
         .vc-nsfw-img [class^=imageWrapper] img,
         .vc-nsfw-img [class^=wrapperPaused] video {
-            filter: blur(${Settings.plugins.BlurNSFW.blurAmount}px);
+            filter: blur(${blurValue}px);
             transition: filter 0.2s;
         }
         
         /* Blur for DMs when enabled */
         .vc-dm-blur [class^=imageWrapper] img,
         .vc-dm-blur [class^=wrapperPaused] video {
-            filter: blur(${Settings.plugins.BlurNSFW.blurAmount}px);
+            filter: blur(${blurValue}px);
             transition: filter 0.2s;
         }
         
@@ -48,6 +65,13 @@ function setCss() {
     `;
 }
 
+function getDmClass(channel: any) {
+    if (!channel) return '';
+    // Check for both DM (1) and Group DM (3)
+    if (channel.type !== 1 && channel.type !== 3) return '';
+    return settings.store.blurDirectMessage ? ' vc-dm-blur' : '';
+}
+
 export default definePlugin({
     name: "BlurNSFW",
     description: "Blur attachments in NSFW channels and DMs until hovered",
@@ -56,27 +80,17 @@ export default definePlugin({
     patches: [
         {
             find: ".embedWrapper,embed",
-            replacement: [{
+            replacement: {
                 match: /\.container/,
-                replace: "$&+(this.props.channel.nsfw?' vc-nsfw-img':'')+(this.props.channel.type===1&&Settings.plugins.BlurNSFW.blurDirectMessage?' vc-dm-blur':'')"
-            }]
+                replace: (_match: string) => {
+                    return `.container+(this.props.channel.nsfw?' vc-nsfw-img':'')+$self.getDmClass(this.props.channel)`;
+                }
+            }
         }
     ],
 
-    options: {
-        blurAmount: {
-            type: OptionType.NUMBER,
-            description: "Blur Amount",
-            default: 10,
-            onChange: setCss
-        },
-        blurDirectMessage: {
-            type: OptionType.BOOLEAN,
-            description: "Blur Images in Direct Messages",
-            default: false,
-            onChange: setCss
-        }
-    },
+    getDmClass,
+    settings,
 
     start() {
         style = document.createElement("style");


### PR DESCRIPTION
## Description
Enhanced the BlurNSFW plugin to support blurring images in DMs and group chats. Added a toggle option in settings to enable/disable DM blurring independently of NSFW channel blurring. 

## Changes
- Added new blur direct message toggle option in settings
- Added DM and group DM detection and blur functionality
- Blur amount settings affect both channel and DM blurring

## Testing
Tested functionality in:
- NSFW channels (existing blur working as expected)
- Direct Messages (new blur working with toggle)
- Group DMs (blur working with same toggle as DMs)
- Settings menu:
  - Blur amount slider affecting both NSFW and DM images
  - DM toggle properly enabling/disabling blur in DMs and group chats
  - Settings persisting after Discord restart
- Hover functionality working correctly in all contexts


Originally uploaded this a few hours ago but from testing with another user, they were experiencing crashes where I wasn't. I have since solved those issues.

Apologies for how much the code changed, the original code wasn't very happy with my DM toggle setting.
