### PR TITLE
messageTags: add feat. tag variables

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -170,6 +170,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Luny",
         id: 821472922140803112n
     },
+    SUDO: {
+        name: "SUDO",
+        id: 480495309491798037n
+    },
     Vap: {
         name: "Vap0r1ze",
         id: 454072114492866560n
@@ -575,7 +579,7 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n,
     },
-        SomeAspy: {
+    SomeAspy: {
         name: "SomeAspy",
         id: 516750892372852754n,
     },


### PR DESCRIPTION
This Pull request adds the feature for MessageTags to take on variable inputs so that tags can be customized before being sent. (operates like a template)

Image below shows off this functionality;

![image](https://github.com/user-attachments/assets/452574af-5f95-4aaa-ae60-47b5b3a96425)

P.S. I have reached out to the original author, who welcomed this PR.