### PR TITLE
mutual server members tab

### DIFF
--- a/src/plugins/serverInfo/README.md
+++ b/src/plugins/serverInfo/README.md
@@ -1,6 +1,6 @@
 # ServerInfo
 
-Allows you to view info about servers and see friends and blocked users
+Allows you to view info about servers and see friends, blocked users, and mutual server members
 
 ![](https://github.com/Vendicated/Vencord/assets/45497981/a49783b5-e8fc-41d8-968f-58600e9f6580)
 ![](https://github.com/Vendicated/Vencord/assets/45497981/5efc158a-e671-4196-a15a-77edf79a2630)

--- a/src/plugins/serverInfo/index.tsx
+++ b/src/plugins/serverInfo/index.tsx
@@ -29,7 +29,7 @@ migratePluginSettings("ServerInfo", "ServerProfile"); // what was I thinking wit
 export default definePlugin({
     name: "ServerInfo",
     description: "Allows you to view info about a server",
-    authors: [Devs.Ven, Devs.Nuckyz],
+    authors: [Devs.Ven, Devs.Nuckyz, Devs.Z1xus],
     dependencies: ["DynamicImageModalAPI"],
     tags: ["guild", "info", "ServerProfile"],
 

--- a/src/plugins/serverInfo/styles.css
+++ b/src/plugins/serverInfo/styles.css
@@ -93,6 +93,74 @@
     max-height: 500px;
 }
 
+.vc-gp-member-row {
+    display: flex;
+    align-items: center;
+    padding-right: 16px;
+    cursor: pointer;
+    position: relative;
+    margin: 1px 0;
+    width: 100%;
+}
+
+.vc-gp-member-row:hover {
+    background-color: var(--background-modifier-hover);
+}
+
+.vc-gp-member-content {
+    flex: 1;
+    min-width: 0;
+    width: 100%;
+    position: relative;
+}
+
+.vc-gp-member-icons {
+    user-select: none;
+    position: absolute;
+    right: 20px;
+    z-index: 2;
+}
+
+.vc-gp-mutual-guilds {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    padding-left: 8px;
+}
+
+.vc-gp-guild-icon {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--background-tertiary);
+    overflow: hidden;
+}
+
+.vc-gp-guild-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.vc-gp-guild-acronym {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 8px;
+    font-weight: 600;
+    color: var(--text-normal);
+    text-transform: uppercase;
+}
+
+.vc-gp-guild-count {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
 .vc-gp-scroller [class^="listRow"] {
     margin: 1px 0;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -575,10 +575,14 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n,
     },
-        SomeAspy: {
+    SomeAspy: {
         name: "SomeAspy",
         id: 516750892372852754n,
     },
+    Z1xus: {
+        name: "Z1xus",
+        id: 377450600797044746n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
adds a new tab to serverinfo plugin that shows server members that are also in your other servers, sorted by amount of mutual servers
![image](https://github.com/user-attachments/assets/1f18011c-c15b-4b53-bbf9-1fbd7311a93c)
