### PR TITLE
Allow trailing comma in patch helper

### DIFF
--- a/src/components/VencordSettings/PatchHelperTab.tsx
+++ b/src/components/VencordSettings/PatchHelperTab.tsx
@@ -247,7 +247,8 @@ function FullPatchInput({ setFind, setParsedFind, setMatch, setReplacement }: Fu
         }
 
         try {
-            const parsed = (0, eval)(`(${fullPatch})`) as Patch;
+            const trimmed = fullPatch.replace(/,\s*$/, "");
+            const parsed = (0, eval)(`(${trimmed})`) as Patch;
 
             if (!parsed.find) throw new Error("No 'find' field");
             if (!parsed.replacement) throw new Error("No 'replacement' field");


### PR DESCRIPTION
Saves a second every time you copypaste a patch.