### PR TITLE
feat(plugin): Letter emoji shortcuts (for easier typing of the blue letters)

### DIFF
--- a/src/plugins/letterEmojiShortcut/index.tsx
+++ b/src/plugins/letterEmojiShortcut/index.tsx
@@ -1,0 +1,89 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+
+const EmojiLib = findByPropsLazy("getByName", "getCategories", "getDefaultDiversitySurrogate", "convertNameToSurrogate");
+
+/* old method of just adding emojis
+   may have better compatibility? keeping for future refrence
+{
+    find: "\"raised_hand_with_part_between_middle_and_ring_fingers\"",
+    replacement: {
+        match: /"regional_indicator_([a-z])"/g,
+        replace: "$&,\"$1$1\""
+    }
+}
+*/
+
+const doubleMatch = /^([a-zA-Z])\1?$/;
+
+const settings = definePluginSettings({
+    autocomplete: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Makes e.g. :b: and :bb: suggest 🇧 as the first option (only inserted on tab-complete, simply typing :bb: will not work)",
+        restartNeeded: false
+    },
+    alias: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Makes e.g. :bb: alias to 🇧. This makes just typing :bb: work (and it sends the real 🇧), but has the side effect of rendering the plaintext of :bb: as an emoji.",
+        restartNeeded: false
+    }
+});
+
+export default definePlugin({
+    name: "LetterEmojiShortcut",
+    description: "Adds shortcuts for typing the blue letter emojis",
+    authors: [Devs.UnmatchedBracket],
+    settings,
+    patches: [
+        {
+            find: /searchWithoutFetchingLatest\(\i\){/,
+            replacement: {
+                match: /searchWithoutFetchingLatest\((\i)\){(.*?unlocked:)(this.getSearchResultsOrder.*?),locked/,
+                replace: "searchWithoutFetchingLatest($1){$2$self.addEmojiToList($3, $1),locked"
+            }
+        },
+        {
+            find: "getDefaultDiversitySurrogate:function()",
+            replacement: {
+                match: /convertNameToSurrogate:(\i),/,
+                replace: "convertNameToSurrogate:$self.convertNameToSurrogatePatch($1),"
+            }
+        }
+    ],
+    addEmojiToList(list: Object[], query: { query: string; }) {
+        if (!Vencord.Settings.plugins.LetterEmojiShortcut.autocomplete)
+            return list;
+
+        let match = doubleMatch.exec(query.query);
+        if (match) {
+            let emoji = EmojiLib.getByName("regional_indicator_" + match[1]);
+            if (emoji) {
+                list.unshift(emoji);
+            }
+        }
+        return list;
+    },
+    convertNameToSurrogatePatch(original: Function) {
+        return (name: string, default_: string | undefined) => {
+            if (!Vencord.Settings.plugins.LetterEmojiShortcut.alias)
+                return original(name, default_);
+
+            let match = doubleMatch.exec(name);
+            if (match) {
+                default_ = original("regional_indicator_" + match[1], default_);
+            }
+            let ret = original(name, default_);
+            return ret;
+        };
+    }
+});

--- a/src/plugins/letterEmojiShortcut/index.tsx
+++ b/src/plugins/letterEmojiShortcut/index.tsx
@@ -23,7 +23,8 @@ const EmojiLib = findByPropsLazy("getByName", "getCategories", "getDefaultDivers
 */
 
 const alphabet = [..."abcdefghijklmnopqrstuvwxyz"];
-const doubleMatch = /^([a-zA-Z])\1?$/;
+const singleOrDoubleMatch = /^([a-zA-Z])\1?$/;
+const doubleMatch = /^([a-zA-Z])\1$/;
 
 const settings = definePluginSettings({
     autocomplete: {
@@ -69,7 +70,7 @@ export default definePlugin({
     ],
     addEmojiToList(list: Object[], query: { query: string; }) {
         if (Vencord.Settings.plugins.LetterEmojiShortcut.autocomplete) {
-            let match = doubleMatch.exec(query.query);
+            let match = singleOrDoubleMatch.exec(query.query);
             if (match) {
                 let emoji = EmojiLib.getByName("regional_indicator_" + match[1]);
                 if (emoji) {

--- a/src/plugins/letterEmojiShortcut/index.tsx
+++ b/src/plugins/letterEmojiShortcut/index.tsx
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2023 Vendicated and contributors
+ * Copyright (c) 2024 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
@@ -10,17 +10,6 @@ import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
 
 const EmojiLib = findByPropsLazy("getByName", "getCategories", "getDefaultDiversitySurrogate", "convertNameToSurrogate");
-
-/* old method of just adding emojis
-   may have better compatibility? keeping for future refrence
-{
-    find: "\"raised_hand_with_part_between_middle_and_ring_fingers\"",
-    replacement: {
-        match: /"regional_indicator_([a-z])"/g,
-        replace: "$&,\"$1$1\""
-    }
-}
-*/
 
 const alphabet = [..."abcdefghijklmnopqrstuvwxyz"];
 const singleOrDoubleMatch = /^([a-zA-Z])\1?$/;
@@ -48,7 +37,7 @@ const settings = definePluginSettings({
 });
 
 export default definePlugin({
-    name: "LetterEmojiShortcut",
+    name: "LetterEmojiShortcuts",
     description: "Adds shortcuts for typing the blue letter emojis",
     authors: [Devs.UnmatchedBracket],
     settings,

--- a/src/plugins/letterEmojiShortcut/index.tsx
+++ b/src/plugins/letterEmojiShortcut/index.tsx
@@ -34,7 +34,7 @@ const settings = definePluginSettings({
     },
     alias: {
         type: OptionType.BOOLEAN,
-        default: true,
+        default: false,
         description: "Makes e.g. :bb: alias to 🇧. This makes just typing :bb: work (and it sends the real 🇧), but has the side effect of rendering the plaintext of :bb: as an emoji.",
         restartNeeded: false
     },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -575,9 +575,13 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n,
     },
-        SomeAspy: {
+    SomeAspy: {
         name: "SomeAspy",
         id: 516750892372852754n,
+    },
+    UnmatchedBracket: {
+        name: "UnmatchedBracket",
+        id: 971943551816581161n,
     },
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
This plugin adds easier ways to type the blue letter emojis (`:regional_indicator_*:`).

----------

## Option 1: Autocomplete
Makes e.g. `a` and `aa` suggest 🇦 first, `b` and `bb` suggest 🇧 first, etc.

https://github.com/user-attachments/assets/8a8dc738-6c55-406c-a57b-078a1354eda3

This will not insert the emoji if e.g. `:bb:` is typed.
## Option 2: Alias
Makes typing e.g. `:cc:` correct to 🇨. Single letters like `:c:` don't work to avoid conflicts with 🅰️ and 🅱️.

https://github.com/user-attachments/assets/4d817803-6c90-47ed-83e4-711e96d6d159

Defaults to off due to the side-effect of making the plaintext `:cc:` render as 🇨.
## Option 3: All Letters Autocomplete
Makes `ltr`, `letter`, and `letters` suggest every letter, most useful for typing with reactions/typing lots of letters as emojis.

https://github.com/user-attachments/assets/68efa72d-de72-4e13-8c69-ca232d441c4e


----------
Each option is individually toggleable without reload:
![plugin settings popup](https://github.com/user-attachments/assets/27383b67-5add-4d04-8448-babba8edbfac)