### PR TITLE
Decor: Update notice about joining the server for clarity

### DIFF
--- a/src/plugins/decor/ui/modals/CreateDecorationModal.tsx
+++ b/src/plugins/decor/ui/modals/CreateDecorationModal.tsx
@@ -138,7 +138,7 @@ function CreateDecorationModal(props: ModalProps) {
                         }}
                     >
                         Decor's Discord server
-                    </Link> and enable your direct messages.
+                    </Link> and allow direct messages.
                 </HelpMessage>
             </ErrorBoundary>
         </ModalContent>

--- a/src/plugins/decor/ui/modals/CreateDecorationModal.tsx
+++ b/src/plugins/decor/ui/modals/CreateDecorationModal.tsx
@@ -20,7 +20,7 @@ import { AvatarDecorationModalPreview } from "../components";
 const FileUpload = findComponentByCodeLazy("fileUploadInput,");
 
 const { HelpMessage, HelpMessageTypes } = mapMangledModuleLazy('POSITIVE=3]="POSITIVE', {
-    HelpMessageTypes: filters.byProps("POSITIVE", "WARNING"),
+    HelpMessageTypes: filters.byProps("POSITIVE", "WARNING", "INFO"),
     HelpMessage: filters.byCode(".iconDiv")
 });
 
@@ -119,8 +119,8 @@ function CreateDecorationModal(props: ModalProps) {
                         />
                     </div>
                 </div>
-                <Forms.FormText type="description" className={Margins.bottom16}>
-                    <br />You can receive updates on your decoration's review by joining <Link
+                <HelpMessage messageType={HelpMessageTypes.INFO}>
+                    To receive updates on your decoration's review, join <Link
                         href={`https://discord.gg/${INVITE_KEY}`}
                         onClick={async e => {
                             e.preventDefault();
@@ -138,8 +138,8 @@ function CreateDecorationModal(props: ModalProps) {
                         }}
                     >
                         Decor's Discord server
-                    </Link>.
-                </Forms.FormText>
+                    </Link> and enable your direct messages.
+                </HelpMessage>
             </ErrorBoundary>
         </ModalContent>
         <ModalFooter className={cl("modal-footer")}>


### PR DESCRIPTION
had a few people upset about getting banned (or getting upset on someone elses behalf) over resubmitting decors that were rejected because they didn't receive the dm, this should make it clearer that should be in the server and enable dms there if dms arent allowed globally

![image](https://github.com/user-attachments/assets/e484f737-1753-43fd-ae3c-184dae233319)
![image](https://github.com/user-attachments/assets/488c515c-620e-4be2-9a82-b73a0460238c)

