### PR TITLE
feat(roleColorEverywhere): color blending from multiple roles

### DIFF
--- a/src/plugins/roleColorEverywhere/blendColors.ts
+++ b/src/plugins/roleColorEverywhere/blendColors.ts
@@ -1,0 +1,54 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export function blendColors(color1hex: string, color2hex: string, percentage: number) {
+    // check input
+    color1hex = color1hex || "#000000";
+    color2hex = color2hex || "#ffffff";
+    percentage = percentage || 0.5;
+
+    // 2: check to see if we need to convert 3 char hex to 6 char hex, else slice off hash
+    //      the three character hex is just a representation of the 6 hex where each character is repeated
+    //      ie: #060 => #006600 (green)
+    if (color1hex.length === 4)
+        color1hex = color1hex[1] + color1hex[1] + color1hex[2] + color1hex[2] + color1hex[3] + color1hex[3];
+    else
+        color1hex = color1hex.substring(1);
+    if (color2hex.length === 4)
+        color2hex = color2hex[1] + color2hex[1] + color2hex[2] + color2hex[2] + color2hex[3] + color2hex[3];
+    else
+        color2hex = color2hex.substring(1);
+
+    // 3: we have valid input, convert colors to rgb
+    const color1rgb = [parseInt(color1hex[0] + color1hex[1], 16), parseInt(color1hex[2] + color1hex[3], 16), parseInt(color1hex[4] + color1hex[5], 16)];
+    const color2rgb = [parseInt(color2hex[0] + color2hex[1], 16), parseInt(color2hex[2] + color2hex[3], 16), parseInt(color2hex[4] + color2hex[5], 16)];
+
+    // 4: blend
+    const color3rgb = [
+        (1 - percentage) * color1rgb[0] + percentage * color2rgb[0],
+        (1 - percentage) * color1rgb[1] + percentage * color2rgb[1],
+        (1 - percentage) * color1rgb[2] + percentage * color2rgb[2]
+    ];
+
+    // 5: convert to hex
+    const color3hex = "#" + intToHex(color3rgb[0]) + intToHex(color3rgb[1]) + intToHex(color3rgb[2]);
+
+    return color3hex;
+}
+
+/*
+    convert a Number to a two character hex string
+    must round, or we will end up with more digits than expected (2)
+    note: can also result in single digit, which will need to be padded with a 0 to the left
+    @param: num         => the number to conver to hex
+    @returns: string    => the hex representation of the provided number
+*/
+function intToHex(num: number) {
+    var hex = Math.round(num).toString(16);
+    if (hex.length === 1)
+        hex = "0" + hex;
+    return hex;
+}

--- a/src/plugins/roleColorEverywhere/components/ContextMenu.tsx
+++ b/src/plugins/roleColorEverywhere/components/ContextMenu.tsx
@@ -1,0 +1,44 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@api/Styles";
+import { openModal } from "@utils/modal";
+import { Menu } from "@webpack/common";
+
+import { toggleRole } from "../storeHelper";
+import { RoleModal } from "./RolesModal";
+import { Guild } from "@vencord/discord-types";
+
+export function ContextMenu({ colorsStore, guild, roleId, classFactory }: { guild: Guild, roleId: string, colorsStore: ColorsStore, classFactory: ReturnType<typeof classNameFactory> }) {
+    const cl = classFactory;
+    const togglelabel = (colorsStore[guild.id]?.includes(roleId) ?
+        "Remove role from" :
+        "Add role to") + " coloring list";
+
+    return (
+        <Menu.MenuItem
+            id={cl("context-menu")}
+            label="Coloring"
+        >
+            <Menu.MenuItem
+                id={cl("toggle-role-for-guild")}
+                label={togglelabel}
+                action={() => toggleRole(colorsStore, guild.id, roleId)}
+            />
+            <Menu.MenuItem
+                id={cl("show-color-roles")}
+                label="Show roles"
+                action={() => openModal(modalProps => (
+                    <RoleModal
+                        colorsStore={colorsStore}
+                        modalProps={modalProps}
+                        guild={guild}
+                    />
+                ))}
+            />
+        </Menu.MenuItem>
+    );
+}

--- a/src/plugins/roleColorEverywhere/components/RolesModal.tsx
+++ b/src/plugins/roleColorEverywhere/components/RolesModal.tsx
@@ -1,0 +1,28 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { ModalProps } from "@utils/modal";
+import { GuildRoleStore, React } from "@webpack/common";
+
+import { toggleRole } from "../storeHelper";
+import { RoleModalList } from "./RolesView";
+import { Guild } from "@vencord/discord-types";
+
+export function RoleModal({ modalProps, guild, colorsStore }: { modalProps: ModalProps, guild: Guild, colorsStore: Record<string, string[]> }) {
+    const [ids, setIds] = React.useState(colorsStore[guild.id]);
+    const roles = React.useMemo(() => ids.map(id => GuildRoleStore.getRole(guild.id, id)), [ids]);
+
+    return <RoleModalList
+        modalProps={modalProps}
+        roleList={roles}
+        header={`${guild.name} highlighted roles.`}
+        onRoleRemove={id => {
+            toggleRole(colorsStore, guild.id, id);
+            setIds(colorsStore[guild.id]);
+        }}
+    />;
+}
+

--- a/src/plugins/roleColorEverywhere/components/RolesView.tsx
+++ b/src/plugins/roleColorEverywhere/components/RolesView.tsx
@@ -1,0 +1,107 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classes } from "@utils/misc";
+import { ModalCloseButton, ModalContent, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import { Role } from "@vencord/discord-types";
+import { filters, findBulk, proxyLazyWebpack } from "@webpack";
+import { Text } from "@webpack/common";
+
+const Classes = proxyLazyWebpack(() =>
+    Object.assign({}, ...findBulk(
+        filters.byProps("role", "pill"),
+        filters.byProps("roleCircle", "dotBorderBase", "dotBorderColor"),
+        filters.byProps("roleNameOverflow", "root", "roleName", "roleRemoveButton", "roleRemoveButtonCanRemove", "roleRemoveIcon", "roleIcon")
+    ))
+) as Record<"role" | "pill" | "rolePillBorder" | "desaturateUserColors" | "flex" | "alignCenter" | "justifyCenter" | "svg" | "background" | "dot" | "dotBorderColor" | "roleCircle" | "dotBorderBase" | "flex" | "alignCenter" | "justifyCenter" | "wrap" | "root" | "role" | "roleRemoveButton" | "roleDot" | "roleFlowerStar" | "roleRemoveIcon" | "roleRemoveIconFocused" | "roleVerifiedIcon" | "roleName" | "roleNameOverflow" | "actionButton" | "overflowButton" | "addButton" | "addButtonIcon" | "overflowRolesPopout" | "overflowRolesPopoutArrowWrapper" | "overflowRolesPopoutArrow" | "popoutBottom" | "popoutTop" | "overflowRolesPopoutHeader" | "overflowRolesPopoutHeaderIcon" | "overflowRolesPopoutHeaderText" | "roleIcon" | "roleRemoveButtonCanRemove" | "roleRemoveIcon" | "roleIcon", string>;
+
+export function RoleCard({ onRoleRemove, data, border }: { onRoleRemove: (id: string) => void, data: Role, border: boolean }) {
+    const { role, roleRemoveButton, roleRemoveButtonCanRemove, roleRemoveIcon, roleIcon, roleNameOverflow, pill, rolePillBorder, roleCircle, roleName } = Classes;
+
+    return (
+        <div className={classes(role, pill, border ? rolePillBorder : null)}>
+            <div
+                className={classes(roleRemoveButton, roleRemoveButtonCanRemove)}
+                onClick={() => onRoleRemove(data.id)}
+            >
+                <span
+                    className={roleCircle}
+                    style={{ backgroundColor: data.colorString }}
+                />
+                <svg
+                    role="img"
+                    className={roleRemoveIcon}
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                >
+                    <path fill="var(--primary-630)" d="M18.4 4L12 10.4L5.6 4L4 5.6L10.4 12L4 18.4L5.6 20L12 13.6L18.4 20L20 18.4L13.6 12L20 5.6L18.4 4Z"/>
+                </svg>
+            </div>
+            <span>
+                <img alt="" className={roleIcon} height="16" src={`https://cdn.discordapp.com/role-icons/${data.id}/${data.icon}.webp?size=16&quality=lossless`}/>
+            </span>
+            <div className={roleName}>
+                <Text
+                    className={roleNameOverflow}
+                    variant="text-xs/medium"
+                >
+                    {data.name}
+                </Text>
+            </div>
+        </div>
+    );
+}
+
+export function RoleList({ roleData, onRoleRemove }: { onRoleRemove: (id: string) => void, roleData: Role[] }) {
+    const { root } = Classes;
+
+    return (
+        <div>
+            {!roleData?.length && (
+                <span>No roles</span>
+            )}
+
+            {roleData?.length !== 0 && (
+                <div className={classes(root)}>
+                    {roleData.map(data => (
+                        <RoleCard
+                            key={data.id}
+                            data={data}
+                            onRoleRemove={onRoleRemove}
+                            border={false}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function RoleModalList({ roleList, header, onRoleRemove, modalProps }: {
+    roleList: Role[]
+    modalProps: ModalProps
+    header: string
+    onRoleRemove: (id: string) => void
+}) {
+    return (
+        <ModalRoot
+            {...modalProps}
+            size={ModalSize.SMALL}
+        >
+            <ModalHeader>
+                <Text className="vc-role-list-title" variant="heading-lg/semibold">{header}</Text>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+            <ModalContent>
+                <RoleList
+                    roleData={roleList}
+                    onRoleRemove={onRoleRemove}
+                />
+            </ModalContent>
+        </ModalRoot >
+    );
+}

--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -128,7 +128,7 @@ export default definePlugin({
             find: "#{intl::GUEST_NAME_SUFFIX})]",
             replacement: [
                 {
-                    match: /#{intl::GUEST_NAME_SUFFIX}.{0,50}?""\](?<=guildId:(\i),.+?user:(\i).+?)/,
+                    match: /#{intl::GUEST_NAME_SUFFIX}[^"]+""[^}]+(?<=guildId:(\i),.+?user:(\i).+?)/,
                     replace: "$&,style:$self.getColorStyle($2.id,$1),"
                 }
             ],

--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -17,12 +17,22 @@
 */
 
 import { definePluginSettings } from "@api/Settings";
+import { classNameFactory } from "@utils/css";
+import { getUserSettingLazy } from "@api/UserSettings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
 import definePlugin, { makeRange, OptionType } from "@utils/types";
 import { findByCodeLazy } from "@webpack";
-import { ChannelStore, GuildMemberStore, GuildRoleStore, GuildStore } from "@webpack/common";
+
+import { brewUserColor } from "./witchCauldron";
+
+import { ChannelStore, GuildMemberStore, GuildRoleStore, GuildStore, React } from "@webpack/common";
+import { ContextMenu } from "./components/ContextMenu";
+import { getCurrentGuild } from "@utils/discord";
+
+const cl = classNameFactory("rolecolor");
+const DeveloperMode = getUserSettingLazy("appearance", "developerMode")!;
 
 const useMessageAuthor = findByCodeLazy('"Result cannot be null because the message is not null"');
 
@@ -69,11 +79,13 @@ const settings = definePluginSettings({
         markers: makeRange(0, 100, 10),
         default: 30
     }
-});
+}).withPrivateSettings<{
+    userColorFromRoles: Record<string, string[]>
+}>();
 
 export default definePlugin({
     name: "RoleColorEverywhere",
-    authors: [Devs.KingFish, Devs.lewisakura, Devs.AutumnVN, Devs.Kyuuhachi, Devs.jamesbt365],
+    authors: [Devs.KingFish, Devs.lewisakura, Devs.AutumnVN, Devs.Kyuuhachi, Devs.jamesbt365, Devs.EnergoStalin],
     description: "Adds the top role color anywhere possible",
     tags: ["Roles", "Appearance"],
     settings,
@@ -167,13 +179,20 @@ export default definePlugin({
         try {
             const guildId = ChannelStore.getChannel(channelOrGuildId)?.guild_id ?? GuildStore.getGuild(channelOrGuildId)?.id;
             if (guildId == null) return null;
+            const member = GuildMemberStore.getMember(guildId, userId)!;
 
-            return GuildMemberStore.getMember(guildId, userId)?.colorString ?? null;
+            return brewUserColor(settings.store.userColorFromRoles, member.roles, channelOrGuildId) ?? member.colorString;
         } catch (e) {
             new Logger("RoleColorEverywhere").error("Failed to get color string", e);
         }
 
         return null;
+    },
+
+    start() {
+        DeveloperMode.updateSetting(true);
+
+        settings.store.userColorFromRoles ??= {};
     },
 
     getColorInt(userId: string, channelOrGuildId: string) {
@@ -225,5 +244,32 @@ export default definePlugin({
                 {title ?? label} &mdash; {count}
             </span>
         );
-    }, { noop: true })
+    }, { noop: true }),
+
+    getVoiceProps({ user: { id: userId }, guildId }: { user: { id: string; }; guildId: string; }) {
+        return {
+            style: {
+                color: this.getColor(userId, { guildId })
+            }
+        };
+    },
+
+    contextMenus: {
+        "dev-context"(children, { id }: { id: string; }) {
+            const guild = getCurrentGuild();
+            if (!guild) return;
+
+            settings.store.userColorFromRoles[guild.id] ??= [];
+
+            const role = GuildRoleStore.getRole(guild.id, id);
+            if (!role) return;
+
+            children.push(ContextMenu({
+                classFactory: cl,
+                colorsStore: settings.store.userColorFromRoles,
+                roleId: role.id,
+                guild
+            }));
+        }
+    }
 });

--- a/src/plugins/roleColorEverywhere/storeHelper.ts
+++ b/src/plugins/roleColorEverywhere/storeHelper.ts
@@ -1,0 +1,31 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { GuildRoleStore } from "@webpack/common";
+
+// Using plain replaces cause i dont want sanitize regexp
+export function toggleRole(colorsStore: ColorsStore, guildId: string, id: string) {
+    let roles = colorsStore[guildId];
+    const len = roles.length;
+
+    roles = roles.filter(e => e !== id);
+
+    if (len === roles.length) {
+        roles.push(id);
+    }
+
+    colorsStore[guildId] = roles;
+}
+
+export function atLeastOneOverrideAppliesToGuild(overrides: string[], guildId: string) {
+    for (const role of overrides) {
+        if (GuildRoleStore.getRole(guildId, role)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/plugins/roleColorEverywhere/types.ts
+++ b/src/plugins/roleColorEverywhere/types.ts
@@ -1,0 +1,7 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+type ColorsStore = Record<string, string[]>;

--- a/src/plugins/roleColorEverywhere/witchCauldron.ts
+++ b/src/plugins/roleColorEverywhere/witchCauldron.ts
@@ -1,0 +1,37 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { GuildRoleStore } from "@webpack/common";
+
+import { blendColors } from "./blendColors";
+import { atLeastOneOverrideAppliesToGuild } from "./storeHelper";
+
+export function brewUserColor(colorsStore: ColorsStore, roles: string[], guildId: string) {
+    const overrides = colorsStore[guildId];
+    if (!overrides?.length) return null;
+
+    if (atLeastOneOverrideAppliesToGuild(overrides, guildId!)) {
+        const memberRoles = roles.map(role => GuildRoleStore.getRole(guildId!, role)).filter(e => e);
+        const blendColorsFromRoles = memberRoles
+            .filter(role => overrides.includes(role.id))
+            .sort((a, b) => b.color - a.color);
+
+        // if only one override apply, return the first role color
+        if (blendColorsFromRoles.length < 2)
+            return blendColorsFromRoles[0]?.colorString ?? null;
+
+        const color = blendColorsFromRoles
+            .slice(1)
+            .reduce(
+                (p, c) => blendColors(p, c!.colorString!, .5),
+                blendColorsFromRoles[0].colorString!
+            );
+
+        return color;
+    }
+
+    return null;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -669,6 +669,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Davri: {
         name: "Davri",
         id: 457579346282938368n
+    },
+    EnergoStalin: {
+        name: "EnergoStalin",
+        id: 283262118902497281n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
It was sitting in my repo long time soo let's try to get it upstream.

Hit me if some changes required.

This enable automatically blending colors from selected roles on the server.

<details>
<summary>To show highlighted roles on the server.</summary>

![image](https://github.com/user-attachments/assets/739135ca-1656-4ee3-a44c-902a2636232c)

<details>
<summary>This will look like this</summary>

![image](https://github.com/user-attachments/assets/2af22882-d2de-4c5a-887e-1757c1d05c86)

<details>
<summary>Here you can click role circle to remove from the list.</summary>

![image](https://github.com/user-attachments/assets/beb6821c-def3-4342-895e-ea2428782c55)

</details>

As well as just hit **remove from coloring list** button which is togglable so role adding is done via this button too.

</details>

</details>

<details>

<summary>This is how user looks like.</summary>

![image](https://github.com/user-attachments/assets/5ee0f8e2-af44-403b-adc9-556ea748081d)

For users with no roles used in coloring list fallback to default user color.

When only one role matches blending skipped and this role color is used.

</details>
 
This solved problem of being forced to look at user everytime to check out their role or multiple roles.