### PR TITLE
Add support for onAuxClick on ChatBarButton

### DIFF
--- a/src/api/ChatButtons.tsx
+++ b/src/api/ChatButtons.tsx
@@ -99,7 +99,8 @@ export interface ChatBarButtonProps {
     tooltip: string;
     onClick: MouseEventHandler<HTMLButtonElement>;
     onContextMenu?: MouseEventHandler<HTMLButtonElement>;
-    buttonProps?: Omit<HTMLProps<HTMLButtonElement>, "size" | "onClick" | "onContextMenu">;
+    onAuxClick?: MouseEventHandler<HTMLButtonElement>;
+    buttonProps?: Omit<HTMLProps<HTMLButtonElement>, "size" | "onClick" | "onContextMenu" | "onAuxClick">;
 }
 export const ChatBarButton = ErrorBoundary.wrap((props: ChatBarButtonProps) => {
     return (
@@ -115,6 +116,7 @@ export const ChatBarButton = ErrorBoundary.wrap((props: ChatBarButtonProps) => {
                         innerClassName={`${ButtonWrapperClasses.button} ${ChannelTextAreaClasses?.button}`}
                         onClick={props.onClick}
                         onContextMenu={props.onContextMenu}
+                        onAuxClick={props.onAuxClick}
                         {...props.buttonProps}
                     >
                         <div className={ButtonWrapperClasses.buttonWrapper}>


### PR DESCRIPTION
This adds support for the [auxclick event](https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event) which triggers when any non-primary mouse button is pressed. This means it will allow for detecting middle clicks on chat bar buttons, although it will *also* trigger for right clicks but that can be avoided by checking the event button when utilizing the auxclick event.