### PR TITLE
ShowHiddenThings: Allow opening mod view on yourself

### DIFF
--- a/src/plugins/showHiddenThings/index.ts
+++ b/src/plugins/showHiddenThings/index.ts
@@ -40,7 +40,7 @@ export default definePlugin({
     name: "ShowHiddenThings",
     tags: ["ShowTimeouts", "ShowInvitesPaused", "ShowModView", "DisableDiscoveryFilters"],
     description: "Displays various hidden & moderator-only things regardless of permissions.",
-    authors: [Devs.Dolfies, Devs.sadan],
+    authors: [Devs.Dolfies],
     patches: [
         {
             find: "showCommunicationDisabledStyles",
@@ -75,9 +75,9 @@ export default definePlugin({
                 replace: "$1$2arguments[0].member.highestRoleId]",
             }
         },
-        // Allows you to open mod view on yourself
+        // allows you to open mod view on yourself
         {
-            find: ':"PRESS_MOD_VIEW",',
+            find: ".MEMBER_SAFETY,{modViewPanel:",
             predicate: () => settings.store.showModView,
             replacement: {
                 match: /\i(?=\?null)/,

--- a/src/plugins/showHiddenThings/index.ts
+++ b/src/plugins/showHiddenThings/index.ts
@@ -40,7 +40,7 @@ export default definePlugin({
     name: "ShowHiddenThings",
     tags: ["ShowTimeouts", "ShowInvitesPaused", "ShowModView", "DisableDiscoveryFilters"],
     description: "Displays various hidden & moderator-only things regardless of permissions.",
-    authors: [Devs.Dolfies],
+    authors: [Devs.Dolfies, Devs.sadan],
     patches: [
         {
             find: "showCommunicationDisabledStyles",
@@ -73,6 +73,15 @@ export default definePlugin({
             replacement: {
                 match: /(role:)\i(?=,guildId.{0,100}role:(\i\[))/,
                 replace: "$1$2arguments[0].member.highestRoleId]",
+            }
+        },
+        // Allows you to open mod view on yourself
+        {
+            find: ':"PRESS_MOD_VIEW",',
+            predicate: () => settings.store.showModView,
+            replacement: {
+                match: /\i(?=\?null)/,
+                replace: "false"
             }
         },
         {


### PR DESCRIPTION
Mod view has a lot of useful information in one place. there have been several time where I have wanted to open it on myself, but have not been able to. This fixes that. 

I'm not sure if this should be hidden behind the Show Mod View setting, but it made the most sense to me.