### PR TITLE
new plugin: stopAutoUnread

### DIFF
--- a/src/plugins/stopAutoUnread/index.ts
+++ b/src/plugins/stopAutoUnread/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "StopAutoUnread",
+    description: "(new unread system only) Stop Discord from automatically setting a channel's unreads as \"all messages\"",
+    authors: [Devs.Lumap],
+
+    patches: [
+        {
+            find: "}maybeAutoUpgradeChannel(",
+            replacement: {
+                match: /maybeAutoUpgradeChannel\(\i\){/,
+                replace: "$&return !1;"
+            }
+        }
+    ]
+});


### PR DESCRIPTION
<img width="955" alt="image" src="https://github.com/user-attachments/assets/053157f5-60c4-4135-8b3e-8fada255fedb">
stops discord from automatically setting a channel's unread indicator as "all messages" after a while