### PR TITLE
CommandsAPI: Fix spread overwriting omitted subcommand options

### DIFF
--- a/src/api/Commands/index.ts
+++ b/src/api/Commands/index.ts
@@ -110,6 +110,7 @@ function registerSubCommands(cmd: Command, plugin: string) {
         const subCmd = {
             ...cmd,
             ...o,
+            options: o.options !== undefined ? o.options : undefined,
             type: ApplicationCommandType.CHAT_INPUT,
             name: `${cmd.name} ${o.name}`,
             id: `${o.name}-${cmd.id}`,


### PR DESCRIPTION
If you omit options from a subcommand as you are allowed to do, the options argument will be filled in with the parent's options creating a recursive loop ending in `RangeError: Maximum call stack size exceeded`. This resets the options to `undefined` if they were intentionally left out.