### PR TITLE
Add DisableAnimations plugin

### DIFF
--- a/src/plugins/disableAnimations/index.ts
+++ b/src/plugins/disableAnimations/index.ts
@@ -1,0 +1,54 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { findAll } from "@webpack";
+
+export default definePlugin({
+
+    name: "DisableAnimations",
+    description: "Disables most of Discord's animations.",
+    authors: [Devs.seth],
+    start() {
+        this.springs = findAll((mod) => {
+            if (!mod.Globals) return false;
+            return true;
+        });
+
+        for (const spring of this.springs) {
+            spring.Globals.assign({
+                skipAnimation: true,
+            });
+        }
+
+        this.css = document.createElement("style");
+        this.css.innerText = "* { transition: none !important; animation: none !important; }";
+
+        document.head.appendChild(this.css);
+    },
+    stop() {
+        for (const spring of this.springs) {
+            spring.Globals.assign({
+                skipAnimation: false,
+            });
+        }
+
+        if (this.css) this.css.remove();
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    seth: {
+        name: "S€th",
+        id: 1273447359417942128n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Applies the property `skipAnimation` to all react-sprint instances Discord has. 

Also adds basic css `* { transition: none !important; animation: none !important; }`