### PR TITLE
TypingTweaks: Fix usernames not being colored

### DIFF
--- a/src/plugins/typingTweaks/index.tsx
+++ b/src/plugins/typingTweaks/index.tsx
@@ -125,7 +125,7 @@ export default definePlugin({
 
     buildSeveralUsers,
 
-    mutateChildren(props: any, users: User[], children: any) {
+    mutateChildren(guildId: any, users: User[], children: any) {
         try {
             if (!Array.isArray(children)) {
                 return children;
@@ -135,7 +135,7 @@ export default definePlugin({
 
             return children.map(c =>
                 c.type === "strong" || (typeof c !== "string" && !React.isValidElement(c))
-                    ? <TypingUser {...props} user={users[element++]} />
+                    ? <TypingUser guildId={guildId} user={users[element++]} />
                     : c
             );
         } catch (e) {


### PR DESCRIPTION
not sure if this was introduced by https://github.com/Vendicated/Vencord/commit/9d3c91e9df7f5168da2ce8b6d1f60e0fd792f935
or if it came from one of discords changes