### PR TITLE
Add plugin ForceOwner

### DIFF
--- a/src/plugins/forceOwner/README.md
+++ b/src/plugins/forceOwner/README.md
@@ -1,0 +1,4 @@
+## ForceAdmin
+Makes your client remove permissions checks.
+Your client will send a lot of `403 Forbidden` requests, which might get flagged by discord.
+### Use at your own risk

--- a/src/plugins/forceOwner/index.ts
+++ b/src/plugins/forceOwner/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+
+
+let ownerClass;
+let originalIsOwner;
+
+export default definePlugin({
+    name: "ForceOwner",
+    description: "Makes your client disable permissions checks, may cause bugs.",
+    authors: [Devs.ryfterwastaken],
+
+
+    start() {
+        ownerClass = findByPropsLazy("isOwner");
+        originalIsOwner = ownerClass.__proto__.isOwner;
+        ownerClass.__proto__.isOwner = () => true;
+    },
+    stop() {
+        ownerClass.__proto__.isOwner = originalIsOwner;
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    ryfterwastaken: {
+        name: "Ryfter",
+        id: 898619112350183445n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Makes the client think the user is the owner of all the servers, allows access to see most of the settings of a server, as well as to see all members (through role settings).