### PR TITLE
EmoteCloner: Fix a hang when the sticker/original server is deleted

### DIFF
--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -317,6 +317,20 @@ function isGifUrl(url: string) {
     return u.pathname.endsWith(".gif") || u.searchParams.get("animated") === "true";
 }
 
+function buildFakeSticker(sticker: any) {
+    return {
+        id: sticker?.id,
+        name: sticker?.name,
+        format_type: sticker?.format_type,
+        // Discord has a character limit of at least 1 for tags (aka related emoji)
+        tags: " ",
+        description: "",
+        type: "2",
+        available: true,
+        guild_id: 0
+    };
+}
+
 const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
     const { favoriteableId, itemHref, itemSrc, favoriteableType } = props ?? {};
 
@@ -343,27 +357,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
                 // (e.g when using MessageLinkEmkbeds)
                 if (sticker === undefined) return;
 
-                return buildMenuItem("Sticker", async () => {
-                    const fetchedSticker = await fetchSticker(favoriteableId);
-
-                    // Workaround for incase the sticker or the server it's from is deleted.
-                    // Allows the sticker to still be cloned.
-                    if (fetchedSticker === undefined) {
-                        return {
-                            id: sticker?.id,
-                            name: sticker?.name,
-                            format_type: sticker?.format_type,
-                            // Discord has a character limit of at least 1 for tags (aka related emoji)
-                            tags: " ",
-                            description: "",
-                            type: "2",
-                            available: true,
-                            guild_id: 0
-                        };
-                    }
-
-                    return fetchedSticker;
-                });
+                return buildMenuItem("Sticker", () => fetchSticker(favoriteableId).then(s => s ?? buildFakeSticker(sticker)));
         }
     })();
 

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -342,7 +342,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
 
                 // Workaround for cases when it's not available
                 // (e.g when using MessageLinkEmkbeds)
-                if (sticker == undefined) {
+                if (sticker === undefined) {
                     return;
                 }
 
@@ -351,7 +351,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
 
                     // Workaround for incase the sticker or the server it's from is deleted.
                     // Allows the sticker to still be cloned, albeit less accurately.
-                    if (fetchedSticker == undefined) {
+                    if (fetchedSticker === undefined) {
                         return {
                             "id": sticker?.id,
                             "name": sticker?.name,

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -350,13 +350,17 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
                     const fetchedSticker = await fetchSticker(favoriteableId);
 
                     // Workaround for incase the sticker or the server it's from is deleted.
-                    // Allows the sticker to still be cloned, albeit less accurately.
+                    // Allows the sticker to still be cloned.
                     if (fetchedSticker === undefined) {
                         return {
                             "id": sticker?.id,
                             "name": sticker?.name,
                             "format_type": sticker?.format_type,
-                            "tags": sticker?.name,
+                            // Discord has a character limit of at least 1 for tags (aka related emoji)
+                            // for some reason.
+                            // They don't check for spaces.
+                            "tags": " ",
+                            "description": "",
                             "type": "2",
                             "available": true,
                             "guild_id": 0

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -357,8 +357,6 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
                             "name": sticker?.name,
                             "format_type": sticker?.format_type,
                             // Discord has a character limit of at least 1 for tags (aka related emoji)
-                            // for some reason.
-                            // They don't check for spaces.
                             "tags": " ",
                             "description": "",
                             "type": "2",

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -75,7 +75,6 @@ async function fetchSticker(id: string) {
 
         return body as Sticker;
     } catch (err) {
-        return undefined;
     }
 }
 
@@ -342,9 +341,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
 
                 // Workaround for cases when it's not available
                 // (e.g when using MessageLinkEmkbeds)
-                if (sticker === undefined) {
-                    return;
-                }
+                if (sticker === undefined) return;
 
                 return buildMenuItem("Sticker", async () => {
                     const fetchedSticker = await fetchSticker(favoriteableId);
@@ -353,19 +350,19 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
                     // Allows the sticker to still be cloned.
                     if (fetchedSticker === undefined) {
                         return {
-                            "id": sticker?.id,
-                            "name": sticker?.name,
-                            "format_type": sticker?.format_type,
+                            id: sticker?.id,
+                            name: sticker?.name,
+                            format_type: sticker?.format_type,
                             // Discord has a character limit of at least 1 for tags (aka related emoji)
-                            "tags": " ",
-                            "description": "",
-                            "type": "2",
-                            "available": true,
-                            "guild_id": 0
+                            tags: " ",
+                            description: "",
+                            type: "2",
+                            available: true,
+                            guild_id: 0
                         };
-                    } else {
-                        return fetchedSticker;
                     }
+
+                    return fetchedSticker;
                 });
         }
     })();

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -75,6 +75,7 @@ async function fetchSticker(id: string) {
 
         return body as Sticker;
     } catch (err) {
+        return null;
     }
 }
 

--- a/src/plugins/emoteCloner/index.tsx
+++ b/src/plugins/emoteCloner/index.tsx
@@ -318,7 +318,7 @@ function isGifUrl(url: string) {
     return u.pathname.endsWith(".gif") || u.searchParams.get("animated") === "true";
 }
 
-function buildFakeSticker(sticker: any) {
+function buildFakeSticker(sticker: Partial<Sticker>) {
     return {
         id: sticker?.id,
         name: sticker?.name,
@@ -326,7 +326,7 @@ function buildFakeSticker(sticker: any) {
         // Discord has a character limit of at least 1 for tags (aka related emoji)
         tags: " ",
         description: "",
-        type: "2",
+        type: 2,
         available: true,
         guild_id: 0
     };
@@ -351,7 +351,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
                     isAnimated: isGifUrl(itemHref ?? itemSrc)
                 }));
             case "sticker":
-                const sticker = props.message.stickerItems.find(s => s.id === favoriteableId);
+                const sticker: Partial<Sticker> | undefined = props.message.stickerItems.find(s => s.id === favoriteableId);
                 if (sticker?.format_type === 3 /* LOTTIE */) return;
 
                 // Workaround for cases when it's not available


### PR DESCRIPTION
This fixes the modal hanging and infinitely loading in cases where the sticker can't be fetched (e.g when it or the server it's from was deleted, general Discord weirdness, etc). Also allows for the sticker to still be cloned.