### PR TITLE
Update the prodversion in the extension download URL

### DIFF
--- a/src/main/utils/extensions.ts
+++ b/src/main/utils/extensions.ts
@@ -72,7 +72,7 @@ export async function installExt(id: string) {
             // v4.27 is broken in Electron, see https://github.com/facebook/react/issues/25843
             // Unfortunately, Google does not serve old versions, so this is the only way
             ? "https://raw.githubusercontent.com/Vendicated/random-files/f6f550e4c58ac5f2012095a130406c2ab25b984d/fmkadmapgofadopljbjfkapdkoienihi.zip"
-            : `https://clients2.google.com/service/update2/crx?response=redirect&acceptformat=crx2,crx3&x=id%3D${id}%26uc&prodversion=32`;
+            : `https://clients2.google.com/service/update2/crx?response=redirect&acceptformat=crx2,crx3&x=id%3D${id}%26uc&prodversion=2147483647`;
         const buf = await get(url, {
             headers: {
                 "User-Agent": "Vencord (https://github.com/Vendicated/Vencord)"


### PR DESCRIPTION
The version 32 is too old and cause the request to fail
The 32bit int limit seems to be the max value and should make the request not fail for a few years hopefully
*This change doesn't really matter for Vencord as its only use is to load react dev tools which are not taken from the chrome web store anyway, but it will fix the feature if a userplugin try to load chrome extensions*