### PR TITLE
feat: Disable faulty plugins to prevent unrecoverable loop

### DIFF
--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -85,6 +85,7 @@ async function syncSettings() {
     }
 }
 
+
 async function init() {
     await onceReady;
     startAllPlugins(StartAt.WebpackReady);

--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -85,7 +85,6 @@ async function syncSettings() {
     }
 }
 
-
 async function init() {
     await onceReady;
     startAllPlugins(StartAt.WebpackReady);

--- a/src/plugins/crashHandler/index.ts
+++ b/src/plugins/crashHandler/index.ts
@@ -89,11 +89,11 @@ export default definePlugin({
                 if (!shouldAttemptRecover) {
                     // Disable all non-core plugins (last-ditch effort to prevent a crash loop)
                     try {
-                        CrashHandlerLogger.log("Disabling all non-core plugins...");
+                        CrashHandlerLogger.debug("Disabling all non-core plugins...");
                         const pluginSettings = Settings.plugins;
-                        const disabledPlugins: string[] = [];
+                        const disabledPlugins: string[] = []; // horror
                         for (const pluginName in pluginSettings) {
-                            if (pluginSettings[pluginName].enabled && !pluginSettings[pluginName].required && !pluginSettings[pluginName].hidden) {
+                            if (pluginSettings[pluginName].enabled && !pluginSettings[pluginName].required && !pluginSettings[pluginName].hidden && !pluginName.endsWith("API")) {
                                 pluginSettings[pluginName].enabled = false;
                                 disabledPlugins.push(pluginName);
                                 CrashHandlerLogger.log(`Disabled plugin: ${pluginName}`);

--- a/src/plugins/crashHandler/index.ts
+++ b/src/plugins/crashHandler/index.ts
@@ -24,7 +24,7 @@ import { closeAllModals } from "@utils/modal";
 import definePlugin, { OptionType } from "@utils/types";
 import { maybePromptToUpdate } from "@utils/updater";
 import { filters, findBulk, proxyLazyWebpack } from "@webpack";
-import { DraftType, ExpressionPickerStore, FluxDispatcher, NavigationRouter, SelectedChannelStore } from "@webpack/common";
+import { Clipboard, DraftType, ExpressionPickerStore, FluxDispatcher, NavigationRouter, SelectedChannelStore } from "@webpack/common";
 
 const CrashHandlerLogger = new Logger("CrashHandler");
 
@@ -91,13 +91,21 @@ export default definePlugin({
                     try {
                         CrashHandlerLogger.log("Disabling all non-core plugins...");
                         const pluginSettings = Settings.plugins;
-
+                        const disabledPlugins: string[] = [];
                         for (const pluginName in pluginSettings) {
-                            if (pluginSettings[pluginName].enabled && !pluginSettings[pluginName].required) {
+                            if (pluginSettings[pluginName].enabled && !pluginSettings[pluginName].required && !pluginSettings[pluginName].hidden) {
                                 pluginSettings[pluginName].enabled = false;
+                                disabledPlugins.push(pluginName);
                                 CrashHandlerLogger.log(`Disabled plugin: ${pluginName}`);
                             }
                         }
+                        showNotification({
+                            color: "#eed202",
+                            title: "Plugins Disabled",
+                            body: "All plugins have been disabled to prevent an unrecoverable boot-loop! You can click this notification to copy the list of plugins disabled.",
+                            onClick: () => Clipboard.copy(disabledPlugins.join(", ")),
+                            noPersist: false
+                        });
                     } catch (err) {
                         CrashHandlerLogger.error("Failed to disable all non-core plugins", err);
                     }

--- a/src/plugins/crashHandler/index.ts
+++ b/src/plugins/crashHandler/index.ts
@@ -55,7 +55,7 @@ const settings = definePluginSettings({
 
 let hasCrashedOnce = false;
 let isRecovering = false;
-let shouldAttemptRecover = false;// true;
+let shouldAttemptRecover = true;
 
 export default definePlugin({
     name: "CrashHandler",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -37,6 +37,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Vee",
         id: 343383572805058560n
     },
+    million1156: {
+        name: "million1156",
+        id: 96294210021376000n
+    },
     Arjix: {
         name: "ArjixWasTaken",
         id: 674710789138939916n,


### PR DESCRIPTION
An issue a lot of people have when Discord updates is their plugins break. Sometimes, the update is so significant that Vencord itself is broken (i.e. cannot manually disable plugins). I experienced this issue myself, and so I created a pretty decent solution.

When the user enters an "unrecoverable loop" (this is triggered when Vencord crashes 2x in <1s), we disable all plugins **EXCEPT** for plugins that are API related (i.e. `CommandsAPI`, plugins that are marked as `required` (such as `NoTrack`), or plugins that are already disabled (why would you disable an already disabled plugin?) & create a notification that lets the user copy the plugins that were disabled (so they can go ahead and re-enable them when Vencord is fixed). 

This PR is currently a draft as I could probably make the copying part a bit better, but let me know! :)