### PR TITLE
RoleColorEverywhere: Embed/Time/Pronouns support

### DIFF
--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import "./messageColors.css";
+
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { makeRange } from "@components/PluginSettings/components";
@@ -153,13 +155,14 @@ export default definePlugin({
         },
         // Messages
         {
-            find: "#{intl::MESSAGE_EDITED}",
-            replacement: {
-                match: /(?<=isUnsupported\]:(\i)\.isUnsupported\}\),)(?=children:\[)/,
-                replace: "style:$self.useMessageColorsStyle($1),"
-            },
+            find: "Message must not be a thread starter message",
+            replacement: [{
+                match: /\i\.messageListItem/,
+                replace: "$&+' '+$self.useMessageColorsStyle(arguments[0].message)?.class," +
+                    "style:$self.useMessageColorsStyle(arguments[0].message)?.styles"
+            }],
             predicate: () => settings.store.colorChatMessages
-        }
+        },
     ],
 
     getColorString(userId: string, channelOrGuildId: string) {
@@ -194,12 +197,11 @@ export default definePlugin({
             const author = useMessageAuthor(message);
 
             if (author.colorString != null && messageSaturation !== 0) {
-                const value = `color-mix(in oklab, ${author.colorString} ${messageSaturation}%, var({DEFAULT}))`;
-
                 return {
-                    color: value.replace("{DEFAULT}", "--text-normal"),
-                    "--header-primary": value.replace("{DEFAULT}", "--header-primary"),
-                    "--text-muted": value.replace("{DEFAULT}", "--text-muted")
+                    styles: {
+                        "--role-color": author.colorString,
+                        "--saturation": messageSaturation + "%",
+                    }, class: "vc-role-color-wrapper"
                 };
             }
         } catch (e) {

--- a/src/plugins/roleColorEverywhere/messageColors.css
+++ b/src/plugins/roleColorEverywhere/messageColors.css
@@ -1,0 +1,29 @@
+.vc-role-color-wrapper {
+    --muted: var(--text-muted);
+    --normal: var(--text-normal);
+    --header: var(--header-primary);
+    --e-title: var(--embed-title);
+}
+
+.vc-role-color-wrapper div {
+    --text-muted: color-mix(
+        in oklab,
+        var(--role-color) var(--saturation),
+        var(--muted)
+    );
+    --text-normal: color-mix(
+        in oklab,
+        var(--role-color) var(--saturation),
+        var(--normal)
+    );
+    --header-primary: color-mix(
+        in oklab,
+        var(--role-color) var(--saturation),
+        var(--header)
+    );
+    --embed-title: color-mix(
+        in oklab,
+        var(--role-color) var(--saturation),
+        var(--e-title)
+    );
+}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/b6b61c00-9f92-4131-bd4b-0bab93935dd5)

After:
![image](https://github.com/user-attachments/assets/4fd03ca4-50d0-4375-a934-930c11d820a1)

Screenshots are made with 70% saturation.

So turns out my last PR https://github.com/Vendicated/Vencord/pull/3036 was kinda **broken**

When trying to re-assign a css var with itself css can't find it!
```css
--text-muted: var(--text-muted) 
```
will resolve in a black color because of circular dependency, but because we're using color-mix it just mixed our role color with black :)

That's why i'm doing this weird stuff in css, so we don't have circular dependency and colors will resolve as intended

### Why changing patch location?
Previous patch was on a too "deep" level of a message, so it could be applied to a normal text, but text inside of embeds will be ignored.
So i've moved it to a message item itself, where MessageLogger and ThemeAtribbutes also have patches

So with both these changes we have:
1. headers/"muted" text are now properly getting colors
2. text inside of embeds also have new colors!
3. As a side effect of moving patch on a upper level it gets applied to a timestamp of a message and for pronouns ( if pronouns db is enabled or how is it called now )


### Why use take className from a function call and not apply it imminently
With this approach i'm getting a bug
1. When user doesn't have role/left the server they can't be resolved, so no `--saturation` and no `--role-color` which will result it a #000 text!
2. When having potato pc/poor internet connection it can't resolve colors imminently, which also result in a black color for a few ms. Theme-based colors are preferred, so it's better use them while loading


The only thing I don't like is how i'm calling the same function twice, but i have no idea how to reduce it in this example