### PR TITLE
New Plugin NeverAnimate

### DIFF
--- a/src/plugins/DisableAnimations/index.ts
+++ b/src/plugins/DisableAnimations/index.ts
@@ -1,0 +1,44 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NeverAnimate",
+    description: "Freezes profile and server-centric that can be animated, but leaves embeded gifs untouched.",
+    authors: [Devs.Rylie],
+
+    patches: [
+        {
+            find: "canAnimate:",
+            all: true,
+            noWarn: true,
+            replacement: {
+                match: /canAnimate:.+?([,}].*?\))/g,
+                replace: (m, rest) => {
+                    const destructuringMatch = rest.match(/}=.+/);
+                    if (destructuringMatch == null) return `canAnimate:!1${rest}`;
+                    return m;
+                }
+            }
+        },
+        {
+            find: "#{intl::GUILD_OWNER}",
+            replacement: {
+                match: /(?<=\.activityEmoji,.+?animate:)\i/,
+                replace: "!1"
+            }
+        },
+        {
+            find: ".animatedBannerHoverLayer,onMouseEnter:",
+            replacement: {
+                match: /(?<=guildBanner:\i,animate:)\i(?=}\))/,
+                replace: "!1"
+            }
+        }
+    ]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    Rylie: {
+        name: "Rylie",
+        id: 95705726327992320n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Plugin simply disables all animations from profiles/servers/avatars instead of forcing them all on either on load or on hover (always on is already a plugin); I amended the AlwaysAnimate plugin to suit folks like myself with epilepsy, seizure risks, et al - as Discords response to updating their accessibility features functionally neutered this.