### PR TITLE
SpotifyControls: Setting to restart playing song if playtime >3s

### DIFF
--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -18,6 +18,7 @@
 
 import "./spotifyStyles.css";
 
+import { Settings } from "@api/Settings";
 import { Flex } from "@components/Flex";
 import { ImageIcon, LinkIcon, OpenExternalIcon } from "@components/Icons";
 import { debounce } from "@shared/debounce";
@@ -130,7 +131,9 @@ function Controls() {
             >
                 <Shuffle />
             </Button>
-            <Button onClick={() => SpotifyStore.prev()}>
+            <Button onClick={() => {
+                Settings.plugins.SpotifyControls.previousButtonRestartsTrack && SpotifyStore.position > 3000 ? SpotifyStore.seek(0) : SpotifyStore.prev();
+            }}>
                 <SkipPrev />
             </Button>
             <Button onClick={() => SpotifyStore.setPlaying(!isPlaying)}>

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -44,6 +44,11 @@ export default definePlugin({
             type: OptionType.BOOLEAN,
             description: "Open Spotify URIs instead of Spotify URLs. Will only work if you have Spotify installed and might not work on all platforms",
             default: false
+        },
+        previousButtonRestartsTrack: {
+            type: OptionType.BOOLEAN,
+            description: "Restart currently playing track when pressing the previous button if playtime is >3s",
+            default: true
         }
     },
     patches: [


### PR DESCRIPTION
This makes spotifycontrols behave like every sane media player in history.

If the setting is enabled, and playtime is above 3 seconds, using the previous button will restart the currently playing song instead of going to the previous one