### PR TITLE
QuickReply: Prevent caret from moving when selecting message

### DIFF
--- a/src/plugins/quickReply/index.ts
+++ b/src/plugins/quickReply/index.ts
@@ -68,8 +68,12 @@ export default definePlugin({
     },
 
     flux: {
-        DELETE_PENDING_REPLY: () => { replyIdx = -1; },
-        MESSAGE_END_EDIT: () => { editIdx = -1; },
+        DELETE_PENDING_REPLY() {
+            replyIdx = -1;
+        },
+        MESSAGE_END_EDIT() {
+            editIdx = -1;
+        },
         MESSAGE_START_EDIT: onStartEdit,
         CREATE_PENDING_REPLY: onCreatePendingReply
     }

--- a/src/plugins/quickReply/index.ts
+++ b/src/plugins/quickReply/index.ts
@@ -20,7 +20,7 @@ import { definePluginSettings, Settings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
-import { ChannelStore, FluxDispatcher as Dispatcher, MessageStore, PermissionsBits, PermissionStore, SelectedChannelStore, UserStore } from "@webpack/common";
+import { ChannelStore, ComponentDispatch, FluxDispatcher as Dispatcher, MessageStore, PermissionsBits, PermissionStore, SelectedChannelStore, UserStore } from "@webpack/common";
 import { Message } from "discord-types/general";
 
 const Kangaroo = findByPropsLazy("jumpToMessage");
@@ -60,24 +60,20 @@ export default definePlugin({
     settings,
 
     start() {
-        Dispatcher.subscribe("DELETE_PENDING_REPLY", onDeletePendingReply);
-        Dispatcher.subscribe("MESSAGE_END_EDIT", onEndEdit);
-        Dispatcher.subscribe("MESSAGE_START_EDIT", onStartEdit);
-        Dispatcher.subscribe("CREATE_PENDING_REPLY", onCreatePendingReply);
         document.addEventListener("keydown", onKeydown);
     },
 
     stop() {
-        Dispatcher.unsubscribe("DELETE_PENDING_REPLY", onDeletePendingReply);
-        Dispatcher.unsubscribe("MESSAGE_END_EDIT", onEndEdit);
-        Dispatcher.unsubscribe("MESSAGE_START_EDIT", onStartEdit);
-        Dispatcher.unsubscribe("CREATE_PENDING_REPLY", onCreatePendingReply);
         document.removeEventListener("keydown", onKeydown);
     },
-});
 
-const onDeletePendingReply = () => replyIdx = -1;
-const onEndEdit = () => editIdx = -1;
+    flux: {
+        DELETE_PENDING_REPLY: () => { replyIdx = -1; },
+        MESSAGE_END_EDIT: () => { editIdx = -1; },
+        MESSAGE_START_EDIT: onStartEdit,
+        CREATE_PENDING_REPLY: onCreatePendingReply
+    }
+});
 
 function calculateIdx(messages: Message[], id: string) {
     const idx = messages.findIndex(m => m.id === id);
@@ -108,6 +104,8 @@ function onKeydown(e: KeyboardEvent) {
     const isUp = e.key === "ArrowUp";
     if (!isUp && e.key !== "ArrowDown") return;
     if (!isCtrl(e) || isAltOrMeta(e)) return;
+
+    e.preventDefault();
 
     if (e.shiftKey)
         nextEdit(isUp);
@@ -194,9 +192,10 @@ function nextReply(isUp: boolean) {
         channel,
         message,
         shouldMention: shouldMention(message),
-        showMentionToggle: channel.guild_id !== null && message.author.id !== meId,
+        showMentionToggle: channel.isPrivate() && message.author.id !== meId,
         _isQuickReply: true
     });
+    ComponentDispatch.dispatchToLastSubscribed("TEXTAREA_FOCUS");
     jumpIfOffScreen(channel.id, message.id);
 }
 


### PR DESCRIPTION
Fixes Vendicated/Vencord#3085
Additionally this refactors flux listeners to new standard and tries to replicate stock reply button behaviour slightly more accurately