### PR TITLE
feat(plugin): SpoilerReveal

### DIFF
--- a/src/plugins/spoilerReveal/index.tsx
+++ b/src/plugins/spoilerReveal/index.tsx
@@ -1,0 +1,72 @@
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { React } from "@webpack/common";
+import { definePluginSettings } from "@api/Settings";
+
+const settings = definePluginSettings({
+    enableHoverReveal: {
+        type: OptionType.BOOLEAN,
+        description: "Enable spoiler reveal on hover",
+        default: true,
+    },
+});
+
+export default definePlugin({
+    name: "SpoilerReveal",
+    description: "Reveal spoilers on hover, ctrl+click to hide them again",
+    authors: [Devs.rushy],
+    settings,
+
+    patches: [
+        {
+            find: ".removeObscurity,",
+            replacement: {
+                match: /super\(\.\.\.e\),/,
+                replace: 'super(...e),Vencord.Plugins.plugins.SpoilerReveal.createHoverWrapper(this),'
+            }
+        }
+    ],
+
+    createHoverWrapper(component: any) {
+        const originalRenderObscuredText = component.renderObscuredText;
+
+        component.renderObscuredText = function () {
+            const result = originalRenderObscuredText.call(this);
+            if (!settings.store.enableHoverReveal) {
+                return result;
+            }
+
+            const handleSpoilerClick = (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+                if (event.ctrlKey && this.state.visible && this._wasClickRevealed) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    this._wasClickRevealed = false;
+                    this.setState({ visible: false });
+                    return;
+                }
+
+                if (!this._wasClickRevealed) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    this._wasClickRevealed = true;
+                    this.setState({ visible: true });
+                    return;
+                }
+            };
+
+            return React.createElement("span", {
+                onMouseEnter: () => {
+                    if (!this.state.visible) {
+                        this.setState({ visible: true });
+                    }
+                },
+                onMouseLeave: () => {
+                    if (this.state.visible && !this._wasClickRevealed) {
+                        this.setState({ visible: false });
+                    }
+                },
+                onClick: handleSpoilerClick.bind(this)
+            }, result);
+        };
+    }
+});

--- a/src/plugins/spoilerReveal/index.tsx
+++ b/src/plugins/spoilerReveal/index.tsx
@@ -1,3 +1,9 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { React } from "@webpack/common";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    rushy: {
+        name: "Rushy",
+        id: 812421218740994068n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Allows spoilers to be revealed on hover, with ctrl+click to hide them again.

![kziKEwQ6l3fVNwmaZp9q9jJqYLaGmIg](https://github.com/user-attachments/assets/44b0e811-9fe2-4ff4-aa97-eb5e83b740b6)