### PR TITLE
Translate: Add support for DeepLX

### DIFF
--- a/src/plugins/translate/index.tsx
+++ b/src/plugins/translate/index.tsx
@@ -53,8 +53,8 @@ const messageCtxPatch: NavContextMenuPatchCallback = (children, { message }) => 
 
 export default definePlugin({
     name: "Translate",
-    description: "Translate messages with Google Translate or DeepL",
-    authors: [Devs.Ven, Devs.AshtonMemer],
+    description: "Translate messages with Google Translate or DeepL(Free/Pro/X)",
+    authors: [Devs.Ven, Devs.AshtonMemer, Devs.ScarZ],
     dependencies: ["MessageAccessoriesAPI", "MessagePopoverAPI", "MessageEventsAPI", "ChatInputButtonAPI"],
     settings,
     contextMenus: {

--- a/src/plugins/translate/languages.ts
+++ b/src/plugins/translate/languages.ts
@@ -208,6 +208,12 @@ export const DeeplLanguages = {
     "uk": "Ukrainian"
 } as const;
 
+export const DeeplLanguagesWithoutPostfix = {
+    "zh": "Chinese",
+    "en": "English",
+    "pt": "Portuguese",
+} as const;
+
 export function deeplLanguageToGoogleLanguage(language: string) {
     switch (language) {
         case "": return "auto";

--- a/src/plugins/translate/native.ts
+++ b/src/plugins/translate/native.ts
@@ -6,17 +6,19 @@
 
 import { IpcMainInvokeEvent } from "electron";
 
-export async function makeDeeplTranslateRequest(_: IpcMainInvokeEvent, pro: boolean, apiKey: string, payload: string) {
-    const url = pro
-        ? "https://api.deepl.com/v2/translate"
-        : "https://api-free.deepl.com/v2/translate";
+export async function makeDeeplTranslateRequest(_: IpcMainInvokeEvent, service: string, deeplxApiEndpoint: string, apiKey: string, payload: string) {
+    const urls = {
+        "deepl": "https://api-free.deepl.com/v2/translate",
+        "deepl-pro": "https://api.deepl.com/v2/translate",
+        "deepl-x": deeplxApiEndpoint
+    };
 
     try {
-        const res = await fetch(url, {
+        const res = await fetch(urls[service], {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                "Authorization": `DeepL-Auth-Key ${apiKey}`
+                ...(service === "deepl-x" ? {} : { "Authorization": `DeepL-Auth-Key ${apiKey}` })
             },
             body: payload
         });

--- a/src/plugins/translate/settings.ts
+++ b/src/plugins/translate/settings.ts
@@ -57,7 +57,8 @@ export const settings = definePluginSettings({
         options: [
             { label: "Google Translate", value: "google", default: true },
             { label: "DeepL Free", value: "deepl" },
-            { label: "DeepL Pro", value: "deepl-pro" }
+            { label: "DeepL Pro", value: "deepl-pro" },
+            { label: "DeepLX", value: "deepl-x" }
         ] as const,
         onChange: resetLanguageDefaults
     },
@@ -66,6 +67,13 @@ export const settings = definePluginSettings({
         description: "DeepL API key",
         default: "",
         placeholder: "Get your API key from https://deepl.com/your-account",
+        disabled: () => IS_WEB
+    },
+    deeplxApiEndpoint: {
+        type: OptionType.STRING,
+        description: "DeepLX API Endpoint",
+        default: "",
+        placeholder: "Enter custom DeepLX API endpoint, e.g. https://deeplx.example.com/translate",
         disabled: () => IS_WEB
     },
     autoTranslate: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    ScarZ: {
+        name: "ScarZ",
+        id: 0n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
- Main: Add support for DeepLX, a powerful and free DeepL API that does not require token.
- Resolved a previous issue where the source language was not displayed correctly when `src` was the base language.