### PR TITLE
ConsoleShortcuts: Add openModal and openModalLazy

### DIFF
--- a/src/plugins/consoleShortcuts/index.ts
+++ b/src/plugins/consoleShortcuts/index.ts
@@ -20,6 +20,7 @@ import { Devs } from "@utils/constants";
 import { getCurrentChannel, getCurrentGuild } from "@utils/discord";
 import { runtimeHashMessageKey } from "@utils/intlHash";
 import { SYM_LAZY_CACHED, SYM_LAZY_GET } from "@utils/lazy";
+import { ModalAPI } from "@utils/modal";
 import { relaunch } from "@utils/native";
 import { canonicalizeMatch, canonicalizeReplace, canonicalizeReplacement } from "@utils/patches";
 import definePlugin, { PluginNative, StartAt } from "@utils/types";
@@ -144,8 +145,8 @@ function makeShortcuts() {
         me: { getter: () => Common.UserStore.getCurrentUser(), preload: false },
         meId: { getter: () => Common.UserStore.getCurrentUser().id, preload: false },
         messages: { getter: () => Common.MessageStore.getMessages(Common.SelectedChannelStore.getChannelId()), preload: false },
-        openModal: { getter: () => Webpack.findByProps("openModalLazy").openModal },
-        openModalLazy: { getter: () => Webpack.findByProps("openModalLazy").openModalLazy },
+        openModal: { getter: () => ModalAPI.openModal },
+        openModalLazy: { getter: () => ModalAPI.openModalLazy },
 
         Stores: {
             getter: () => Object.fromEntries(

--- a/src/plugins/consoleShortcuts/index.ts
+++ b/src/plugins/consoleShortcuts/index.ts
@@ -144,6 +144,8 @@ function makeShortcuts() {
         me: { getter: () => Common.UserStore.getCurrentUser(), preload: false },
         meId: { getter: () => Common.UserStore.getCurrentUser().id, preload: false },
         messages: { getter: () => Common.MessageStore.getMessages(Common.SelectedChannelStore.getChannelId()), preload: false },
+        openModal: { getter: () => Webpack.findByProps("openModalLazy").openModal },
+        openModalLazy: { getter: () => Webpack.findByProps("openModalLazy").openModalLazy },
 
         Stores: {
             getter: () => Object.fromEntries(

--- a/src/utils/modal.tsx
+++ b/src/utils/modal.tsx
@@ -148,28 +148,25 @@ export const ModalAPI = findByPropsLazy("openModalLazy");
  * This is equivalent to render().then(openModal)
  * You should use the Modal components exported by this file
  */
-export function openModalLazy(render: () => Promise<RenderFunction>, options?: ModalOptions & { contextKey?: string; }): Promise<string> {
-    return ModalAPI.openModalLazy(render, options);
-}
+export const openModalLazy: (render: () => Promise<RenderFunction>, options?: ModalOptions & { contextKey?: string; }) => Promise<string>
+    = proxyLazyWebpack(() => ModalAPI.openModalLazy);
 
 /**
  * Open a Modal with the given render function.
  * You should use the Modal components exported by this file
  */
-export function openModal(render: RenderFunction, options?: ModalOptions, contextKey?: string): string {
-    return ModalAPI.openModal(render, options, contextKey);
-}
+export const openModal: (render: RenderFunction, options?: ModalOptions, contextKey?: string) => string
+    = proxyLazyWebpack(() => ModalAPI.openModal);
 
 /**
  * Close a modal by its key
  */
-export function closeModal(modalKey: string, contextKey?: string): void {
-    return ModalAPI.closeModal(modalKey, contextKey);
-}
+export const closeModal: (modalKey: string, contextKey?: string) => void
+    = proxyLazyWebpack(() => ModalAPI.closeModal);
 
 /**
  * Close all open modals
  */
-export function closeAllModals(): void {
-    return ModalAPI.closeAllModals();
-}
+export const closeAllModals: () => void
+    = proxyLazyWebpack(() => ModalAPI.closeAllModals);
+

--- a/src/utils/modal.tsx
+++ b/src/utils/modal.tsx
@@ -141,7 +141,7 @@ export const ModalContent = LazyComponent(() => Modals.ModalContent);
 export const ModalFooter = LazyComponent(() => Modals.ModalFooter);
 export const ModalCloseButton = LazyComponent(() => Modals.ModalCloseButton);
 
-const ModalAPI = findByPropsLazy("openModalLazy");
+export const ModalAPI = findByPropsLazy("openModalLazy");
 
 /**
  * Wait for the render promise to resolve, then open a modal with it.


### PR DESCRIPTION
they're useful for adding breakpoints to find out where a modal is
opened from, and annoying to find