### PR TITLE
New Plugin: fixupLinks

### DIFF
--- a/src/plugins/fixupLinks/index.ts
+++ b/src/plugins/fixupLinks/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { addPreSendListener, MessageObject, removePreSendListener } from "@api/MessageEvents";
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    matches: {
+        type: OptionType.STRING,
+        description: "Domains to replace. Semicolon seperated pairs of urls to replace from and to",
+        default: "x.com fxtwitter.com;twitter.com fxtwitter.com",
+    }
+});
+
+export default definePlugin({
+    name: "Fixup links",
+    description: "Replaces domains with (configurable) fixup domains for prettier discord embeds",
+    authors: [Devs.kodenamekrak],
+
+    settings: settings,
+
+    onMessagePresend(message: MessageObject) {
+        const replaces = settings.store.matches.split(";").map(s => s.trim()).filter(s => s.length > 0);
+        for(const pair of replaces) {
+            const [from, to] = pair.split(" ");
+            if(!from || !to)
+                return;
+
+            message.content = message.content.replace(`https://${from}`, `https://${to}`);
+        }
+    },
+
+    start() {
+        this.presendListener = addPreSendListener((channelId, message) => this.onMessagePresend(message));
+    },
+
+    stop() {
+        removePreSendListener(this.presendListener);
+    },
+});
+

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    kodenamekrak: {
+        name: "kodenamekrak",
+        id: 430459328852656148n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Adds configurable domain replacement in messages, primarily intended for easier use of fixup websites such as fxtwitter that provide prettier discord embeds