### PR TITLE
sentry-ipc grey screen fix

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -95,7 +95,7 @@ if (IS_VESKTOP || !IS_VANILLA) {
 
                 for (const directive of ["style-src", "connect-src", "img-src", "font-src", "media-src", "worker-src"]) {
                     csp[directive] ??= [];
-                    csp[directive].push("*", "blob:", "data:", "vencord:", "'unsafe-inline'");
+                    csp[directive].push("*", "blob:", "data:", "vencord:", "'unsafe-inline'", "sentry-ipc");
                 }
 
                 // TODO: Restrict this to only imported packages with fixed version.


### PR DESCRIPTION
This fixed the grey screen for me...
The Error was: Refused to connect to 'sentry-ipc://sentry-electron.renderer-start/sentry_key' because it violates the document's Content Security Policy.