### PR TITLE
feat(Plugin): NoJoinOnClick

### DIFF
--- a/src/plugins/noJoinOnClick/README.md
+++ b/src/plugins/noJoinOnClick/README.md
@@ -1,0 +1,3 @@
+# NoJoinOnClick
+
+Restores the behavior of clicking voice channels in the Active Now tab without joining

--- a/src/plugins/noJoinOnClick/index.ts
+++ b/src/plugins/noJoinOnClick/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NoJoinOnClick",
+    description: "Restores the behavior of clicking voice channels in the Active Now tab without joining",
+    authors: [Devs.Moritzoni],
+
+    patches: [{
+        find: "h.default.selectVoiceChannel(r.id),",
+        replacement: [
+            {
+                match: "h.default.selectVoiceChannel(r.id),",
+                replace: "h.default.selectChannel(r.id),"
+            }
+        ]
+    }]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    Moritzoni: {
+        name: "Moritzoni",
+        id: 246749186911895553n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Restores the behavior of clicking voice channels in the Active Now tab without joining