### PR TITLE
ConsoleShortcuts: Patch Symbol.toStringTag on FluxStore to be the store name

### DIFF
--- a/src/plugins/consoleShortcuts/index.ts
+++ b/src/plugins/consoleShortcuts/index.ts
@@ -179,6 +179,16 @@ export default definePlugin({
     description: "Adds shorter Aliases for many things on the window. Run `shortcutList` for a list.",
     authors: [Devs.Ven],
 
+    patches: [
+        {
+            find: 'this,"_changeCallbacks",',
+            replacement: {
+                match: /\i\(this,"_changeCallbacks",/,
+                replace: "Reflect.defineProperty(this,Symbol.toStringTag,{value:this.getName(),configurable:!0,writable:!0,enumerable:!1}),$&"
+            }
+        }
+    ],
+
     startAt: StartAt.Init,
     start() {
         const shortcuts = makeShortcuts();
@@ -229,15 +239,5 @@ export default definePlugin({
         for (const key in makeShortcuts()) {
             delete window[key];
         }
-    },
-
-    patches: [
-        {
-            find: 'this,"_changeCallbacks",',
-            replacement: {
-                match: /\i\(this,"_changeCallbacks",/,
-                replace: "Object.defineProperty(this,Symbol.toStringTag,{value:this.getName()}),$&"
-            }
-        }
-    ]
+    }
 });

--- a/src/plugins/consoleShortcuts/index.ts
+++ b/src/plugins/consoleShortcuts/index.ts
@@ -229,5 +229,15 @@ export default definePlugin({
         for (const key in makeShortcuts()) {
             delete window[key];
         }
-    }
+    },
+
+    patches: [
+        {
+            find: 'this,"_changeCallbacks",',
+            replacement: {
+                match: /\i\(this,"_changeCallbacks",/,
+                replace: "Object.defineProperty(this,Symbol.toStringTag,{value:this.getName()}),$&"
+            }
+        }
+    ]
 });


### PR DESCRIPTION
![Debugger showing a tooltip with the title "MediaEngineStore" when hovering over a variable](https://github.com/user-attachments/assets/fcfa7863-e210-4c44-b6be-74d4fa201da2)
