### PR TITLE
RevealAllSpoilers: Fix error on <C-S-Click>

### DIFF
--- a/src/plugins/revealAllSpoilers/index.ts
+++ b/src/plugins/revealAllSpoilers/index.ts
@@ -21,7 +21,7 @@ import definePlugin from "@utils/types";
 import { findByPropsLazy } from "@webpack";
 
 const SpoilerClasses = findByPropsLazy("spoilerContent");
-const MessagesClasses = findByPropsLazy("messagesWrapper");
+const MessagesClasses = findByPropsLazy("messagesWrapper", "navigationDescription");
 
 export default definePlugin({
     name: "RevealAllSpoilers",


### PR DESCRIPTION
there are two classes for messagesWrapper now, and the second one doesnt
match anything with querySelector