### PR TITLE
Implement partial support for Array Settings

### DIFF
--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -81,7 +81,9 @@ const Components: Record<OptionType, React.ComponentType<ISettingElementProps<an
     [OptionType.BOOLEAN]: SettingBooleanComponent,
     [OptionType.SELECT]: SettingSelectComponent,
     [OptionType.SLIDER]: SettingSliderComponent,
-    [OptionType.COMPONENT]: SettingCustomComponent
+    [OptionType.COMPONENT]: SettingCustomComponent,
+    // TODO: Add UI for Array settings
+    [OptionType.ARRAY]: () => null,
 };
 
 export default function PluginModal({ plugin, onRestartNeeded, onClose, transitionState }: PluginModalProps) {

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -200,7 +200,7 @@ const settings = definePluginSettings({
     ignoreWatching: {
         type: OptionType.BOOLEAN,
         description: "Ignore all watching activities",
-        default: undefined,
+        default: false,
         onChange: recalculateActivities
     },
     ignoreCompeting: {

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import * as DataStore from "@api/DataStore";
 import { definePluginSettings, Settings } from "@api/Settings";
 import { getUserSettingLazy } from "@api/UserSettings";
 import ErrorBoundary from "@components/ErrorBoundary";
@@ -71,9 +70,9 @@ function ToggleActivityComponent(activity: IgnoredActivity, isPlaying = false) {
 function handleActivityToggle(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, activity: IgnoredActivity) {
     e.stopPropagation();
 
-    const ignoredActivityIndex = getIgnoredActivities().findIndex(act => act.id === activity.id);
-    if (ignoredActivityIndex === -1) settings.store.ignoredActivities = getIgnoredActivities().concat(activity);
-    else settings.store.ignoredActivities = getIgnoredActivities().filter((_, index) => index !== ignoredActivityIndex);
+    const ignoredActivityIndex = settings.store.ignoredActivities.findIndex(act => act.id === activity.id);
+    if (ignoredActivityIndex === -1) settings.store.ignoredActivities.push(activity);
+    else settings.store.ignoredActivities.splice(ignoredActivityIndex, 1);
 
     recalculateActivities();
 }
@@ -201,7 +200,7 @@ const settings = definePluginSettings({
     ignoreWatching: {
         type: OptionType.BOOLEAN,
         description: "Ignore all watching activities",
-        default: false,
+        default: undefined,
         onChange: recalculateActivities
     },
     ignoreCompeting: {
@@ -209,14 +208,15 @@ const settings = definePluginSettings({
         description: "Ignore all competing activities (These are normally special game activities)",
         default: false,
         onChange: recalculateActivities
+    },
+    ignoredActivities: {
+        type: OptionType.ARRAY,
+        description: "",
+        hidden: true,
+        default: [] as IgnoredActivity[],
+        onChange: recalculateActivities
     }
-}).withPrivateSettings<{
-    ignoredActivities: IgnoredActivity[];
-}>();
-
-function getIgnoredActivities() {
-    return settings.store.ignoredActivities ??= [];
-}
+});
 
 function isActivityTypeIgnored(type: number, id?: string) {
     if (id && settings.store.idsList.includes(id)) {
@@ -284,29 +284,14 @@ export default definePlugin({
     ],
 
     async start() {
-        // Migrate allowedIds
-        if (Settings.plugins.IgnoreActivities.allowedIds) {
-            settings.store.idsList = Settings.plugins.IgnoreActivities.allowedIds;
-            delete Settings.plugins.IgnoreActivities.allowedIds; // Remove allowedIds
-        }
-
-        const oldIgnoredActivitiesData = await DataStore.get<Map<IgnoredActivity["id"], IgnoredActivity>>("IgnoreActivities_ignoredActivities");
-
-        if (oldIgnoredActivitiesData != null) {
-            settings.store.ignoredActivities = Array.from(oldIgnoredActivitiesData.values())
-                .map(activity => ({ ...activity, name: "Unknown Name" }));
-
-            DataStore.del("IgnoreActivities_ignoredActivities");
-        }
-
-        if (getIgnoredActivities().length !== 0) {
+        if (settings.store.ignoredActivities.length !== 0) {
             const gamesSeen = RunningGameStore.getGamesSeen() as { id?: string; exePath: string; }[];
 
-            for (const [index, ignoredActivity] of getIgnoredActivities().entries()) {
+            for (const [index, ignoredActivity] of settings.store.ignoredActivities.entries()) {
                 if (ignoredActivity.type !== ActivitiesTypes.Game) continue;
 
                 if (!gamesSeen.some(game => game.id === ignoredActivity.id || game.exePath === ignoredActivity.id)) {
-                    getIgnoredActivities().splice(index, 1);
+                    settings.store.ignoredActivities.splice(index, 1);
                 }
             }
         }
@@ -316,11 +301,11 @@ export default definePlugin({
         if (isActivityTypeIgnored(props.type, props.application_id)) return false;
 
         if (props.application_id != null) {
-            return !getIgnoredActivities().some(activity => activity.id === props.application_id) || (settings.store.listMode === FilterMode.Whitelist && settings.store.idsList.includes(props.application_id));
+            return !settings.store.ignoredActivities.some(activity => activity.id === props.application_id) || (settings.store.listMode === FilterMode.Whitelist && settings.store.idsList.includes(props.application_id));
         } else {
             const exePath = RunningGameStore.getRunningGames().find(game => game.name === props.name)?.exePath;
             if (exePath) {
-                return !getIgnoredActivities().some(activity => activity.id === exePath);
+                return !settings.store.ignoredActivities.some(activity => activity.id === exePath);
             }
         }
 

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -213,8 +213,7 @@ const settings = definePluginSettings({
         type: OptionType.ARRAY,
         description: "",
         hidden: true,
-        default: [] as IgnoredActivity[],
-        onChange: recalculateActivities
+        default: [] as IgnoredActivity[]
     }
 });
 
@@ -287,12 +286,18 @@ export default definePlugin({
         if (settings.store.ignoredActivities.length !== 0) {
             const gamesSeen = RunningGameStore.getGamesSeen() as { id?: string; exePath: string; }[];
 
+            let hasChanges = false;
             for (const [index, ignoredActivity] of settings.store.ignoredActivities.entries()) {
                 if (ignoredActivity.type !== ActivitiesTypes.Game) continue;
 
                 if (!gamesSeen.some(game => game.id === ignoredActivity.id || game.exePath === ignoredActivity.id)) {
                     settings.store.ignoredActivities.splice(index, 1);
+                    hasChanges = true;
                 }
+            }
+
+            if (hasChanges) {
+                recalculateActivities();
             }
         }
     },

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -21,7 +21,7 @@ import { addContextMenuPatch, removeContextMenuPatch } from "@api/ContextMenu";
 import { Settings } from "@api/Settings";
 import { Logger } from "@utils/Logger";
 import { canonicalizeFind } from "@utils/patches";
-import { Patch, Plugin, ReporterTestable, StartAt } from "@utils/types";
+import { OptionType, Patch, Plugin, ReporterTestable, StartAt } from "@utils/types";
 import { FluxDispatcher } from "@webpack/common";
 import { FluxEvents } from "@webpack/types";
 
@@ -119,6 +119,11 @@ for (const p of pluginsValues) {
         for (const [name, def] of Object.entries(p.settings.def)) {
             const checks = p.settings.checks?.[name];
             p.options[name] = { ...def, ...checks };
+
+            // TODO: Remove this once Array settings have an UI implementation
+            if (p.options[name].type === OptionType.ARRAY) {
+                p.options[name].hidden = true;
+            }
         }
     }
 

--- a/src/plugins/messageTags/index.ts
+++ b/src/plugins/messageTags/index.ts
@@ -32,6 +32,10 @@ interface Tag {
     enabled: boolean;
 }
 
+function getTags() {
+    return settings.store.tagsList;
+}
+
 function getTag(name: string) {
     return settings.store.tagsList.find(tag => tag.name === name) ?? null;
 }
@@ -81,7 +85,6 @@ const settings = definePluginSettings({
     }
 });
 
-
 export default definePlugin({
     name: "MessageTags",
     description: "Allows you to save messages and to use them with a simple command.",
@@ -103,7 +106,7 @@ export default definePlugin({
             await DataStore.del(DATA_KEY);
         }
 
-        for (const tag of settings.store.tagsList) {
+        for (const tag of getTags()) {
             createTagCommand(tag);
         }
     },
@@ -216,7 +219,7 @@ export default definePlugin({
                                     // @ts-ignore
                                     title: "All Tags:",
                                     // @ts-ignore
-                                    description: settings.store.tagsList
+                                    description: getTags()
                                         .map(tag => `\`${tag.name}\`: ${tag.message.slice(0, 72).replaceAll("\\n", " ")}${tag.message.length > 72 ? "..." : ""}`)
                                         .join("\n") || `${EMOTE} Woops! There are no tags yet, use \`/tags create\` to create one!`,
                                     // @ts-ignore

--- a/src/plugins/messageTags/index.ts
+++ b/src/plugins/messageTags/index.ts
@@ -99,7 +99,7 @@ export default definePlugin({
     },
 
     async start() {
-        // TODO: Remove DataStore tags migrations once enough time has passed
+        // TODO: Remove DataStore tags migration once enough time has passed
         const oldTags = await DataStore.get<Tag[]>(DATA_KEY);
         if (oldTags != null) {
             settings.store.tagsList = oldTags;

--- a/src/plugins/pinDms/components/CreateCategoryModal.tsx
+++ b/src/plugins/pinDms/components/CreateCategoryModal.tsx
@@ -10,8 +10,7 @@ import { extractAndLoadChunksLazy, findComponentByCodeLazy, findExportedComponen
 import { Button, Forms, Text, TextInput, Toasts, useEffect, useState } from "@webpack/common";
 
 import { DEFAULT_COLOR, SWATCHES } from "../constants";
-import { categories, Category, createCategory, getCategory, updateCategory } from "../data";
-import { forceUpdate } from "../index";
+import { Category, categoryLen, createCategory, getCategory, updateCategory } from "../data";
 
 interface ColorPickerProps {
     color: number | null;
@@ -52,7 +51,7 @@ function useCategory(categoryId: string | null, initalChannelId: string | null) 
         else if (initalChannelId)
             setCategory({
                 id: Toasts.genId(),
-                name: `Pin Category ${categories.length + 1}`,
+                name: `Pin Category ${categoryLen() + 1}`,
                 color: DEFAULT_COLOR,
                 collapsed: false,
                 channels: [initalChannelId]
@@ -70,14 +69,13 @@ export function NewCategoryModal({ categoryId, modalProps, initalChannelId }: Pr
 
     if (!category) return null;
 
-    const onSave = async (e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    const onSave = (e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
         e.preventDefault();
         if (!categoryId)
-            await createCategory(category);
+            createCategory(category);
         else
-            await updateCategory(category);
+            updateCategory(category);
 
-        forceUpdate();
         modalProps.onClose();
     };
 

--- a/src/plugins/pinDms/components/contextMenu.tsx
+++ b/src/plugins/pinDms/components/contextMenu.tsx
@@ -7,8 +7,8 @@
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Menu } from "@webpack/common";
 
-import { addChannelToCategory, canMoveChannelInDirection, categories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
-import { forceUpdate, PinOrder, settings } from "../index";
+import { addChannelToCategory, canMoveChannelInDirection, currentUserCategories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
+import { PinOrder, settings } from "../index";
 import { openCategoryModal } from "./CreateCategoryModal";
 
 function createPinMenuItem(channelId: string) {
@@ -31,12 +31,12 @@ function createPinMenuItem(channelId: string) {
                     <Menu.MenuSeparator />
 
                     {
-                        categories.map(category => (
+                        currentUserCategories.map(category => (
                             <Menu.MenuItem
                                 key={category.id}
                                 id={`pin-category-${category.id}`}
                                 label={category.name}
-                                action={() => addChannelToCategory(channelId, category.id).then(forceUpdate)}
+                                action={() => addChannelToCategory(channelId, category.id)}
                             />
                         ))
                     }
@@ -49,7 +49,7 @@ function createPinMenuItem(channelId: string) {
                         id="unpin-dm"
                         label="Unpin DM"
                         color="danger"
-                        action={() => removeChannelFromCategory(channelId).then(forceUpdate)}
+                        action={() => removeChannelFromCategory(channelId)}
                     />
 
                     {
@@ -57,7 +57,7 @@ function createPinMenuItem(channelId: string) {
                             <Menu.MenuItem
                                 id="move-up"
                                 label="Move Up"
-                                action={() => moveChannel(channelId, -1).then(forceUpdate)}
+                                action={() => moveChannel(channelId, -1)}
                             />
                         )
                     }
@@ -67,7 +67,7 @@ function createPinMenuItem(channelId: string) {
                             <Menu.MenuItem
                                 id="move-down"
                                 label="Move Down"
-                                action={() => moveChannel(channelId, 1).then(forceUpdate)}
+                                action={() => moveChannel(channelId, 1)}
                             />
                         )
                     }

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -5,6 +5,7 @@
  */
 
 import * as DataStore from "@api/DataStore";
+import { Settings } from "@api/Settings";
 import { UserStore } from "@webpack/common";
 
 import { forceUpdate, PinOrder, PrivateChannelSortStore, settings } from "./index";
@@ -46,7 +47,7 @@ export function initCategories(userId: string) {
         currentUserCategories = settings.store.userBasedCategoryList[currentUserCategoriesIndex].categories;
     } else {
         currentUserCategoriesIndex = categoriesIndex;
-        currentUserCategories = settings.store.userBasedCategoryList[currentUserCategoriesIndex].categories;
+        currentUserCategories = settings.store.userBasedCategoryList[categoriesIndex].categories;
     }
 }
 
@@ -187,9 +188,9 @@ export function moveChannel(channelId: string, direction: -1 | 1) {
 
 // TODO: Remove DataStore PinnedDms migration once enough time has passed
 async function migrateData() {
-    if (Vencord.Settings.plugins.PinDMs.dmSectioncollapsed != null) {
-        settings.store.dmSectionCollapsed = Vencord.Settings.plugins.PinDMs.dmSectioncollapsed;
-        delete Vencord.Settings.plugins.PinDMs.dmSectioncollapsed;
+    if (Settings.plugins.PinDMs.dmSectioncollapsed != null) {
+        settings.store.dmSectionCollapsed = Settings.plugins.PinDMs.dmSectioncollapsed;
+        delete Settings.plugins.PinDMs.dmSectioncollapsed;
     }
 
     const dataStoreKeys = await DataStore.keys();
@@ -207,7 +208,5 @@ async function migrateData() {
         await DataStore.del(pinDmsKey);
     }
 
-    await DataStore.del(CATEGORY_MIGRATED_PINDMS_KEY);
-    await DataStore.del(CATEGORY_MIGRATED_KEY);
-    await DataStore.del(OLD_CATEGORY_KEY);
+    await Promise.all([DataStore.del(CATEGORY_MIGRATED_PINDMS_KEY), DataStore.del(CATEGORY_MIGRATED_KEY), DataStore.del(OLD_CATEGORY_KEY)]);
 }

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -195,6 +195,8 @@ async function migrateData() {
     const dataStoreKeys = await DataStore.keys();
     const pinDmsKeys = dataStoreKeys.map(key => String(key)).filter(key => key.startsWith(CATEGORY_BASE_KEY));
 
+    if (pinDmsKeys.length === 0) return;
+
     for (const pinDmsKey of pinDmsKeys) {
         const categories = await DataStore.get<Category[]>(pinDmsKey);
         if (categories == null) continue;

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { DataStore } from "@api/index";
+import * as DataStore from "@api/DataStore";
 import { UserStore } from "@webpack/common";
 
 import { forceUpdate, PinOrder, PrivateChannelSortStore, settings } from "./index";

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -64,7 +64,7 @@ export const settings = definePluginSettings({
 
 export default definePlugin({
     name: "PinDMs",
-    description: "Allows you to pin private channels to the top of your DM list. To pin/unpin or reorder pins, right click DMs",
+    description: "Allows you to pin private channels to the top of your DM list. To pin/unpin or re-order pins, right click DMs",
     authors: [Devs.Ven, Devs.Aria],
     settings,
     contextMenus,

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -23,7 +23,6 @@ import { Flex } from "@components/Flex";
 import { DeleteIcon } from "@components/Icons";
 import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
-import { useForceUpdater } from "@utils/react";
 import definePlugin, { OptionType } from "@utils/types";
 import { Button, Forms, React, TextInput, useState } from "@webpack/common";
 
@@ -35,8 +34,6 @@ type Rule = Record<"find" | "replace" | "onlyIfIncludes", string>;
 interface TextReplaceProps {
     title: string;
     rulesArray: Rule[];
-    rulesKey: string;
-    update: () => void;
 }
 
 const makeEmptyRule: () => Rule = () => ({
@@ -46,34 +43,40 @@ const makeEmptyRule: () => Rule = () => ({
 });
 const makeEmptyRuleArray = () => [makeEmptyRule()];
 
-let stringRules = makeEmptyRuleArray();
-let regexRules = makeEmptyRuleArray();
-
 const settings = definePluginSettings({
     replace: {
         type: OptionType.COMPONENT,
         description: "",
         component: () => {
-            const update = useForceUpdater();
+            const { stringRules, regexRules } = settings.use(["stringRules", "regexRules"]);
+
             return (
                 <>
                     <TextReplace
                         title="Using String"
                         rulesArray={stringRules}
-                        rulesKey={STRING_RULES_KEY}
-                        update={update}
                     />
                     <TextReplace
                         title="Using Regex"
                         rulesArray={regexRules}
-                        rulesKey={REGEX_RULES_KEY}
-                        update={update}
                     />
                     <TextReplaceTesting />
                 </>
             );
         }
     },
+    stringRules: {
+        type: OptionType.ARRAY,
+        description: "",
+        hidden: true,
+        default: makeEmptyRuleArray(),
+    },
+    regexRules: {
+        type: OptionType.ARRAY,
+        description: "",
+        hidden: true,
+        default: makeEmptyRuleArray(),
+    }
 });
 
 function stringToRegex(str: string) {
@@ -120,28 +123,27 @@ function Input({ initialValue, onChange, placeholder }: {
     );
 }
 
-function TextReplace({ title, rulesArray, rulesKey, update }: TextReplaceProps) {
+function TextReplace({ title, rulesArray }: TextReplaceProps) {
     const isRegexRules = title === "Using Regex";
 
     async function onClickRemove(index: number) {
         if (index === rulesArray.length - 1) return;
         rulesArray.splice(index, 1);
-
-        await DataStore.set(rulesKey, rulesArray);
-        update();
     }
 
     async function onChange(e: string, index: number, key: string) {
-        if (index === rulesArray.length - 1)
+        if (index === rulesArray.length - 1) {
             rulesArray.push(makeEmptyRule());
+        }
 
-        rulesArray[index][key] = e;
+        rulesArray[index] = {
+            ...rulesArray[index],
+            [key]: e
+        };
 
-        if (rulesArray[index].find === "" && rulesArray[index].replace === "" && rulesArray[index].onlyIfIncludes === "" && index !== rulesArray.length - 1)
+        if (rulesArray[index].find === "" && rulesArray[index].replace === "" && rulesArray[index].onlyIfIncludes === "" && index !== rulesArray.length - 1) {
             rulesArray.splice(index, 1);
-
-        await DataStore.set(rulesKey, rulesArray);
-        update();
+        }
     }
 
     return (
@@ -211,26 +213,22 @@ function applyRules(content: string): string {
     if (content.length === 0)
         return content;
 
-    if (stringRules) {
-        for (const rule of stringRules) {
-            if (!rule.find) continue;
-            if (rule.onlyIfIncludes && !content.includes(rule.onlyIfIncludes)) continue;
+    for (const rule of settings.store.stringRules) {
+        if (!rule.find) continue;
+        if (rule.onlyIfIncludes && !content.includes(rule.onlyIfIncludes)) continue;
 
-            content = ` ${content} `.replaceAll(rule.find, rule.replace.replaceAll("\\n", "\n")).replace(/^\s|\s$/g, "");
-        }
+        content = ` ${content} `.replaceAll(rule.find, rule.replace.replaceAll("\\n", "\n")).replace(/^\s|\s$/g, "");
     }
 
-    if (regexRules) {
-        for (const rule of regexRules) {
-            if (!rule.find) continue;
-            if (rule.onlyIfIncludes && !content.includes(rule.onlyIfIncludes)) continue;
+    for (const rule of settings.store.regexRules) {
+        if (!rule.find) continue;
+        if (rule.onlyIfIncludes && !content.includes(rule.onlyIfIncludes)) continue;
 
-            try {
-                const regex = stringToRegex(rule.find);
-                content = content.replace(regex, rule.replace.replaceAll("\\n", "\n"));
-            } catch (e) {
-                new Logger("TextReplace").error(`Invalid regex: ${rule.find}`);
-            }
+        try {
+            const regex = stringToRegex(rule.find);
+            content = content.replace(regex, rule.replace.replaceAll("\\n", "\n"));
+        } catch (e) {
+            new Logger("TextReplace").error(`Invalid regex: ${rule.find}`);
         }
     }
 
@@ -249,8 +247,18 @@ export default definePlugin({
     settings,
 
     async start() {
-        stringRules = await DataStore.get(STRING_RULES_KEY) ?? makeEmptyRuleArray();
-        regexRules = await DataStore.get(REGEX_RULES_KEY) ?? makeEmptyRuleArray();
+        // TODO: Remove DataStore rules migrations once enough time has passed
+        const oldStringRules = await DataStore.get<Rule[]>(STRING_RULES_KEY);
+        if (oldStringRules != null) {
+            settings.store.stringRules = oldStringRules;
+            await DataStore.del(STRING_RULES_KEY);
+        }
+
+        const oldRegexRules = await DataStore.get<Rule[]>(REGEX_RULES_KEY);
+        if (oldRegexRules != null) {
+            settings.store.regexRules = oldRegexRules;
+            await DataStore.del(REGEX_RULES_KEY);
+        }
 
         this.preSend = addPreSendListener((channelId, msg) => {
             // Channel used for sharing rules, applying rules here would be messy

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -168,6 +168,7 @@ export const enum OptionType {
     SELECT,
     SLIDER,
     COMPONENT,
+    ARRAY
 }
 
 export type SettingsDefinition = Record<string, PluginSettingDef>;
@@ -184,6 +185,7 @@ export type PluginSettingDef = (
     | PluginSettingSliderDef
     | PluginSettingComponentDef
     | PluginSettingBigIntDef
+    | PluginSettingArrayDef
 ) & PluginSettingCommon;
 
 export interface PluginSettingCommon {
@@ -238,10 +240,16 @@ export interface PluginSettingSelectDef {
     type: OptionType.SELECT;
     options: readonly PluginSettingSelectOption[];
 }
+
 export interface PluginSettingSelectOption {
     label: string;
     value: string | number | boolean;
     default?: boolean;
+}
+
+export interface PluginSettingArrayDef {
+    type: OptionType.ARRAY;
+    default?: any[];
 }
 
 export interface PluginSettingSliderDef {
@@ -293,7 +301,9 @@ type PluginSettingType<O extends PluginSettingDef> = O extends PluginSettingStri
     O extends PluginSettingSelectDef ? O["options"][number]["value"] :
     O extends PluginSettingSliderDef ? number :
     O extends PluginSettingComponentDef ? any :
+    O extends PluginSettingArrayDef ? O["default"] extends any[] ? O["default"] : any[] :
     never;
+
 type PluginSettingDefaultType<O extends PluginSettingDef> = O extends PluginSettingSelectDef ? (
     O["options"] extends { default?: boolean; }[] ? O["options"][number]["value"] : undefined
 ) : O extends { default: infer T; } ? T : undefined;
@@ -345,13 +355,15 @@ export type PluginOptionsItem =
     | PluginOptionBoolean
     | PluginOptionSelect
     | PluginOptionSlider
-    | PluginOptionComponent;
+    | PluginOptionComponent
+    | PluginOptionArray;
 export type PluginOptionString = PluginSettingStringDef & PluginSettingCommon & IsDisabled & IsValid<string>;
 export type PluginOptionNumber = (PluginSettingNumberDef | PluginSettingBigIntDef) & PluginSettingCommon & IsDisabled & IsValid<number | BigInt>;
 export type PluginOptionBoolean = PluginSettingBooleanDef & PluginSettingCommon & IsDisabled & IsValid<boolean>;
 export type PluginOptionSelect = PluginSettingSelectDef & PluginSettingCommon & IsDisabled & IsValid<PluginSettingSelectOption>;
 export type PluginOptionSlider = PluginSettingSliderDef & PluginSettingCommon & IsDisabled & IsValid<number>;
 export type PluginOptionComponent = PluginSettingComponentDef & PluginSettingCommon;
+export type PluginOptionArray = PluginSettingArrayDef & PluginSettingCommon;
 
 export type PluginNative<PluginExports extends Record<string, (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any>> = {
     [key in keyof PluginExports]:


### PR DESCRIPTION
Adds support for using Array Settings which sync whenever the array is modified, however they currently have no UI implementation and are always hidden.

This should be used for saving data which is handled by its own UI, like PinDMs. The difference of using this from DataStore is that the data gets cloud synced.