### PR TITLE
Settings API: add support for custom objects / arrays

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,7 +105,13 @@ export default tseslint.config(
             "no-invalid-regexp": "error",
             "no-constant-condition": ["error", { "checkLoops": false }],
             "no-duplicate-imports": "error",
-            "dot-notation": "error",
+            "@typescript-eslint/dot-notation": [
+                "error",
+                {
+                    "allowPrivateClassPropertyAccess": true,
+                    "allowProtectedClassPropertyAccess": true
+                }
+            ],
             "no-useless-escape": [
                 "error",
                 {

--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -132,8 +132,6 @@ export default function PluginModal({ plugin, onRestartNeeded, onClose, transiti
             pluginSettings[key] = value;
 
             if (option.type === OptionType.CUSTOM) continue;
-
-            option?.onChange?.(value);
             if (option?.restartNeeded) restartNeeded = true;
         }
         if (restartNeeded) onRestartNeeded();

--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -81,7 +81,9 @@ const Components: Record<OptionType, React.ComponentType<ISettingElementProps<an
     [OptionType.BOOLEAN]: SettingBooleanComponent,
     [OptionType.SELECT]: SettingSelectComponent,
     [OptionType.SLIDER]: SettingSliderComponent,
-    [OptionType.COMPONENT]: SettingCustomComponent
+    [OptionType.COMPONENT]: SettingCustomComponent,
+    // TODO: Add UI for Array settings
+    [OptionType.ARRAY]: () => null,
 };
 
 export default function PluginModal({ plugin, onRestartNeeded, onClose, transitionState }: PluginModalProps) {

--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -143,7 +143,7 @@ export default function PluginModal({ plugin, onRestartNeeded, onClose, transiti
             return <Forms.FormText>There are no settings for this plugin.</Forms.FormText>;
         } else {
             const options = Object.entries(plugin.options).map(([key, setting]) => {
-                if (setting.type !== OptionType.CUSTOM && setting.hidden) return null;
+                if (setting.type === OptionType.CUSTOM || setting.hidden) return null;
 
                 function onChange(newValue: any) {
                     setTempSettings(s => ({ ...s, [key]: newValue }));

--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -82,8 +82,7 @@ const Components: Record<OptionType, React.ComponentType<ISettingElementProps<an
     [OptionType.SELECT]: SettingSelectComponent,
     [OptionType.SLIDER]: SettingSliderComponent,
     [OptionType.COMPONENT]: SettingCustomComponent,
-    // TODO: Add UI for Array settings
-    [OptionType.ARRAY]: () => null,
+    [OptionType.CUSTOM]: () => null,
 };
 
 export default function PluginModal({ plugin, onRestartNeeded, onClose, transitionState }: PluginModalProps) {
@@ -131,6 +130,9 @@ export default function PluginModal({ plugin, onRestartNeeded, onClose, transiti
         for (const [key, value] of Object.entries(tempSettings)) {
             const option = plugin.options[key];
             pluginSettings[key] = value;
+
+            if (option.type === OptionType.CUSTOM) continue;
+
             option?.onChange?.(value);
             if (option?.restartNeeded) restartNeeded = true;
         }
@@ -143,7 +145,7 @@ export default function PluginModal({ plugin, onRestartNeeded, onClose, transiti
             return <Forms.FormText>There are no settings for this plugin.</Forms.FormText>;
         } else {
             const options = Object.entries(plugin.options).map(([key, setting]) => {
-                if (setting.hidden) return null;
+                if (setting.type !== OptionType.CUSTOM && setting.hidden) return null;
 
                 function onChange(newValue: any) {
                     setTempSettings(s => ({ ...s, [key]: newValue }));

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -200,7 +200,7 @@ const settings = definePluginSettings({
     ignoreWatching: {
         type: OptionType.BOOLEAN,
         description: "Ignore all watching activities",
-        default: undefined,
+        default: false,
         onChange: recalculateActivities
     },
     ignoreCompeting: {

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import * as DataStore from "@api/DataStore";
 import { definePluginSettings, Settings } from "@api/Settings";
 import { getUserSettingLazy } from "@api/UserSettings";
 import ErrorBoundary from "@components/ErrorBoundary";
@@ -71,9 +70,9 @@ function ToggleActivityComponent(activity: IgnoredActivity, isPlaying = false) {
 function handleActivityToggle(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, activity: IgnoredActivity) {
     e.stopPropagation();
 
-    const ignoredActivityIndex = getIgnoredActivities().findIndex(act => act.id === activity.id);
-    if (ignoredActivityIndex === -1) settings.store.ignoredActivities = getIgnoredActivities().concat(activity);
-    else settings.store.ignoredActivities = getIgnoredActivities().filter((_, index) => index !== ignoredActivityIndex);
+    const ignoredActivityIndex = settings.store.ignoredActivities.findIndex(act => act.id === activity.id);
+    if (ignoredActivityIndex === -1) settings.store.ignoredActivities.push(activity);
+    else settings.store.ignoredActivities.splice(ignoredActivityIndex, 1);
 
     recalculateActivities();
 }
@@ -201,7 +200,7 @@ const settings = definePluginSettings({
     ignoreWatching: {
         type: OptionType.BOOLEAN,
         description: "Ignore all watching activities",
-        default: false,
+        default: undefined,
         onChange: recalculateActivities
     },
     ignoreCompeting: {
@@ -209,14 +208,15 @@ const settings = definePluginSettings({
         description: "Ignore all competing activities (These are normally special game activities)",
         default: false,
         onChange: recalculateActivities
+    },
+    ignoredActivities: {
+        type: OptionType.ARRAY,
+        description: "",
+        hidden: true,
+        default: [] as IgnoredActivity[],
+        onChange: recalculateActivities
     }
-}).withPrivateSettings<{
-    ignoredActivities: IgnoredActivity[];
-}>();
-
-function getIgnoredActivities() {
-    return settings.store.ignoredActivities ??= [];
-}
+});
 
 function isActivityTypeIgnored(type: number, id?: string) {
     if (id && settings.store.idsList.includes(id)) {
@@ -284,29 +284,14 @@ export default definePlugin({
     ],
 
     async start() {
-        // Migrate allowedIds
-        if (Settings.plugins.IgnoreActivities.allowedIds) {
-            settings.store.idsList = Settings.plugins.IgnoreActivities.allowedIds;
-            delete Settings.plugins.IgnoreActivities.allowedIds; // Remove allowedIds
-        }
-
-        const oldIgnoredActivitiesData = await DataStore.get<Map<IgnoredActivity["id"], IgnoredActivity>>("IgnoreActivities_ignoredActivities");
-
-        if (oldIgnoredActivitiesData != null) {
-            settings.store.ignoredActivities = Array.from(oldIgnoredActivitiesData.values())
-                .map(activity => ({ ...activity, name: "Unknown Name" }));
-
-            DataStore.del("IgnoreActivities_ignoredActivities");
-        }
-
-        if (getIgnoredActivities().length !== 0) {
+        if (settings.store.ignoredActivities.length !== 0) {
             const gamesSeen = RunningGameStore.getGamesSeen() as { id?: string; exePath: string; }[];
 
-            for (const [index, ignoredActivity] of getIgnoredActivities().entries()) {
+            for (const [index, ignoredActivity] of settings.store.ignoredActivities.entries()) {
                 if (ignoredActivity.type !== ActivitiesTypes.Game) continue;
 
                 if (!gamesSeen.some(game => game.id === ignoredActivity.id || game.exePath === ignoredActivity.id)) {
-                    getIgnoredActivities().splice(index, 1);
+                    settings.store.ignoredActivities.splice(index, 1);
                 }
             }
         }
@@ -316,11 +301,11 @@ export default definePlugin({
         if (isActivityTypeIgnored(props.type, props.application_id)) return false;
 
         if (props.application_id != null) {
-            return !getIgnoredActivities().some(activity => activity.id === props.application_id) || (settings.store.listMode === FilterMode.Whitelist && settings.store.idsList.includes(props.application_id));
+            return !settings.store.ignoredActivities.some(activity => activity.id === props.application_id) || (settings.store.listMode === FilterMode.Whitelist && settings.store.idsList.includes(props.application_id));
         } else {
             const exePath = RunningGameStore.getRunningGames().find(game => game.name === props.name)?.exePath;
             if (exePath) {
-                return !getIgnoredActivities().some(activity => activity.id === exePath);
+                return !settings.store.ignoredActivities.some(activity => activity.id === exePath);
             }
         }
 

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -61,7 +61,7 @@ const ToggleIconOff = (activity: IgnoredActivity, fill: string) => ToggleIcon(ac
 
 function ToggleActivityComponent(activity: IgnoredActivity, isPlaying = false) {
     const s = settings.use(["ignoredActivities"]);
-    const { ignoredActivities = [] } = s;
+    const { ignoredActivities } = s;
 
     if (ignoredActivities.some(act => act.id === activity.id)) return ToggleIconOff(activity, "var(--status-danger)");
     return ToggleIconOn(activity, isPlaying ? "var(--green-300)" : "var(--primary-400)");

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -213,8 +213,7 @@ const settings = definePluginSettings({
         type: OptionType.ARRAY,
         description: "",
         hidden: true,
-        default: [] as IgnoredActivity[],
-        onChange: recalculateActivities
+        default: [] as IgnoredActivity[]
     }
 });
 
@@ -287,12 +286,18 @@ export default definePlugin({
         if (settings.store.ignoredActivities.length !== 0) {
             const gamesSeen = RunningGameStore.getGamesSeen() as { id?: string; exePath: string; }[];
 
+            let hasChanges = false;
             for (const [index, ignoredActivity] of settings.store.ignoredActivities.entries()) {
                 if (ignoredActivity.type !== ActivitiesTypes.Game) continue;
 
                 if (!gamesSeen.some(game => game.id === ignoredActivity.id || game.exePath === ignoredActivity.id)) {
                     settings.store.ignoredActivities.splice(index, 1);
+                    hasChanges = true;
                 }
+            }
+
+            if (hasChanges) {
+                recalculateActivities();
             }
         }
     },

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -210,10 +210,8 @@ const settings = definePluginSettings({
         onChange: recalculateActivities
     },
     ignoredActivities: {
-        type: OptionType.ARRAY,
-        description: "",
-        hidden: true,
-        default: [] as IgnoredActivity[]
+        type: OptionType.CUSTOM,
+        default: [] as IgnoredActivity[],
     }
 });
 

--- a/src/plugins/ignoreActivities/index.tsx
+++ b/src/plugins/ignoreActivities/index.tsx
@@ -212,6 +212,7 @@ const settings = definePluginSettings({
     ignoredActivities: {
         type: OptionType.CUSTOM,
         default: [] as IgnoredActivity[],
+        onChange: recalculateActivities
     }
 });
 
@@ -284,18 +285,12 @@ export default definePlugin({
         if (settings.store.ignoredActivities.length !== 0) {
             const gamesSeen = RunningGameStore.getGamesSeen() as { id?: string; exePath: string; }[];
 
-            let hasChanges = false;
             for (const [index, ignoredActivity] of settings.store.ignoredActivities.entries()) {
                 if (ignoredActivity.type !== ActivitiesTypes.Game) continue;
 
                 if (!gamesSeen.some(game => game.id === ignoredActivity.id || game.exePath === ignoredActivity.id)) {
                     settings.store.ignoredActivities.splice(index, 1);
-                    hasChanges = true;
                 }
-            }
-
-            if (hasChanges) {
-                recalculateActivities();
             }
         }
     },

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -21,7 +21,7 @@ import { addContextMenuPatch, removeContextMenuPatch } from "@api/ContextMenu";
 import { Settings } from "@api/Settings";
 import { Logger } from "@utils/Logger";
 import { canonicalizeFind } from "@utils/patches";
-import { Patch, Plugin, ReporterTestable, StartAt } from "@utils/types";
+import { OptionType, Patch, Plugin, ReporterTestable, StartAt } from "@utils/types";
 import { FluxDispatcher } from "@webpack/common";
 import { FluxEvents } from "@webpack/types";
 
@@ -119,6 +119,11 @@ for (const p of pluginsValues) {
         for (const [name, def] of Object.entries(p.settings.def)) {
             const checks = p.settings.checks?.[name];
             p.options[name] = { ...def, ...checks };
+
+            // TODO: Remove this once Array settings have an UI implementation
+            if (p.options[name].type === OptionType.ARRAY) {
+                p.options[name].hidden = true;
+            }
         }
     }
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -21,7 +21,7 @@ import { addContextMenuPatch, removeContextMenuPatch } from "@api/ContextMenu";
 import { Settings } from "@api/Settings";
 import { Logger } from "@utils/Logger";
 import { canonicalizeFind } from "@utils/patches";
-import { OptionType, Patch, Plugin, ReporterTestable, StartAt } from "@utils/types";
+import { Patch, Plugin, ReporterTestable, StartAt } from "@utils/types";
 import { FluxDispatcher } from "@webpack/common";
 import { FluxEvents } from "@webpack/types";
 
@@ -119,11 +119,6 @@ for (const p of pluginsValues) {
         for (const [name, def] of Object.entries(p.settings.def)) {
             const checks = p.settings.checks?.[name];
             p.options[name] = { ...def, ...checks };
-
-            // TODO: Remove this once Array settings have an UI implementation
-            if (p.options[name].type === OptionType.ARRAY) {
-                p.options[name].hidden = true;
-            }
         }
     }
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -18,7 +18,7 @@
 
 import { registerCommand, unregisterCommand } from "@api/Commands";
 import { addContextMenuPatch, removeContextMenuPatch } from "@api/ContextMenu";
-import { Settings } from "@api/Settings";
+import { Settings, SettingsStore } from "@api/Settings";
 import { Logger } from "@utils/Logger";
 import { canonicalizeFind } from "@utils/patches";
 import { Patch, Plugin, ReporterTestable, StartAt } from "@utils/types";
@@ -119,6 +119,10 @@ for (const p of pluginsValues) {
         for (const [name, def] of Object.entries(p.settings.def)) {
             const checks = p.settings.checks?.[name];
             p.options[name] = { ...def, ...checks };
+
+            if (def.onChange != null) {
+                SettingsStore.addChangeListener(`plugins.${p.name}.${name}`, def.onChange);
+            }
         }
     }
 

--- a/src/plugins/messageTags/index.ts
+++ b/src/plugins/messageTags/index.ts
@@ -37,18 +37,15 @@ function getTags() {
 }
 
 function getTag(name: string) {
-    return settings.store.tagsList.find(tag => tag.name === name) ?? null;
+    return settings.store.tagsList[name] ?? null;
 }
 
 function addTag(tag: Tag) {
-    settings.store.tagsList.push(tag);
+    settings.store.tagsList[tag.name] = tag;
 }
 
 function removeTag(name: string) {
-    const index = settings.store.tagsList.findIndex(tag => tag.name === name);
-    if (index === -1) return;
-
-    settings.store.tagsList.splice(index, 1);
+    delete settings.store.tagsList[name];
 }
 
 function createTagCommand(tag: Tag) {
@@ -81,10 +78,8 @@ const settings = definePluginSettings({
         default: true
     },
     tagsList: {
-        type: OptionType.ARRAY,
-        description: "",
-        hidden: true,
-        default: [] as Tag[],
+        type: OptionType.CUSTOM,
+        default: {} as Record<string, Tag>,
     }
 });
 
@@ -105,7 +100,7 @@ export default definePlugin({
         // TODO: Remove DataStore tags migration once enough time has passed
         const oldTags = await DataStore.get<Tag[]>(DATA_KEY);
         if (oldTags != null) {
-            settings.store.tagsList = oldTags;
+            settings.store.tagsList = Object.fromEntries(oldTags.map(oldTag => [oldTag.name, oldTag]));
             await DataStore.del(DATA_KEY);
         }
 

--- a/src/plugins/messageTags/index.ts
+++ b/src/plugins/messageTags/index.ts
@@ -32,6 +32,10 @@ interface Tag {
     enabled: boolean;
 }
 
+function getTags() {
+    return settings.store.tagsList;
+}
+
 function getTag(name: string) {
     return settings.store.tagsList.find(tag => tag.name === name) ?? null;
 }
@@ -81,7 +85,6 @@ const settings = definePluginSettings({
     }
 });
 
-
 export default definePlugin({
     name: "MessageTags",
     description: "Allows you to save messages and to use them with a simple command.",
@@ -103,7 +106,7 @@ export default definePlugin({
             await DataStore.del(DATA_KEY);
         }
 
-        for (const tag of settings.store.tagsList) {
+        for (const tag of getTags()) {
             createTagCommand(tag);
         }
     },
@@ -216,7 +219,7 @@ export default definePlugin({
                                     // @ts-ignore
                                     title: "All Tags:",
                                     // @ts-ignore
-                                    description: settings.store.tagsList
+                                    description: getTags()
                                         .map(tag => `\`${tag.name}\`: ${tag.message.slice(0, 72).replaceAll("\\n", " ")}${tag.message.length > 72 ? "..." : ""}`)
                                         .join("\n") || `${EMOTE} Woops! There are no tags yet, use \`/tags create\` to create one!`,
                                     // @ts-ignore

--- a/src/plugins/messageTags/index.ts
+++ b/src/plugins/messageTags/index.ts
@@ -99,7 +99,7 @@ export default definePlugin({
     },
 
     async start() {
-        // TODO: Remove DataStore tags migrations once enough time has passed
+        // TODO: Remove DataStore tags migration once enough time has passed
         const oldTags = await DataStore.get<Tag[]>(DATA_KEY);
         if (oldTags != null) {
             settings.store.tagsList = oldTags;

--- a/src/plugins/messageTags/index.ts
+++ b/src/plugins/messageTags/index.ts
@@ -45,7 +45,10 @@ function addTag(tag: Tag) {
 }
 
 function removeTag(name: string) {
-    settings.store.tagsList = settings.store.tagsList.filter(tag => tag.name !== name);
+    const index = settings.store.tagsList.findIndex(tag => tag.name === name);
+    if (index === -1) return;
+
+    settings.store.tagsList.splice(index, 1);
 }
 
 function createTagCommand(tag: Tag) {

--- a/src/plugins/messageTags/index.ts
+++ b/src/plugins/messageTags/index.ts
@@ -18,7 +18,7 @@
 
 import { ApplicationCommandInputType, ApplicationCommandOptionType, findOption, registerCommand, sendBotMessage, unregisterCommand } from "@api/Commands";
 import * as DataStore from "@api/DataStore";
-import { definePluginSettings, Settings } from "@api/Settings";
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
@@ -61,7 +61,7 @@ function createTagCommand(tag: Tag) {
                 return { content: `/${tag.name}` };
             }
 
-            if (Settings.plugins.MessageTags.clyde) sendBotMessage(ctx.channel.id, {
+            if (settings.store.clyde) sendBotMessage(ctx.channel.id, {
                 content: `${EMOTE} The tag **${tag.name}** has been sent!`
             });
             return { content: tag.message.replaceAll("\\n", "\n") };
@@ -104,8 +104,9 @@ export default definePlugin({
             await DataStore.del(DATA_KEY);
         }
 
-        for (const tag of getTags()) {
-            createTagCommand(tag);
+        const tags = getTags();
+        for (const tagName in tags) {
+            createTagCommand(tags[tagName]);
         }
     },
 
@@ -217,7 +218,7 @@ export default definePlugin({
                                     // @ts-ignore
                                     title: "All Tags:",
                                     // @ts-ignore
-                                    description: getTags()
+                                    description: Object.values(getTags())
                                         .map(tag => `\`${tag.name}\`: ${tag.message.slice(0, 72).replaceAll("\\n", " ")}${tag.message.length > 72 ? "..." : ""}`)
                                         .join("\n") || `${EMOTE} Woops! There are no tags yet, use \`/tags create\` to create one!`,
                                     // @ts-ignore

--- a/src/plugins/pinDms/components/CreateCategoryModal.tsx
+++ b/src/plugins/pinDms/components/CreateCategoryModal.tsx
@@ -10,8 +10,7 @@ import { extractAndLoadChunksLazy, findComponentByCodeLazy, findExportedComponen
 import { Button, Forms, Text, TextInput, Toasts, useEffect, useState } from "@webpack/common";
 
 import { DEFAULT_COLOR, SWATCHES } from "../constants";
-import { categories, Category, createCategory, getCategory, updateCategory } from "../data";
-import { forceUpdate } from "../index";
+import { Category, categoryLen, createCategory, getCategory, updateCategory } from "../data";
 
 interface ColorPickerProps {
     color: number | null;
@@ -52,7 +51,7 @@ function useCategory(categoryId: string | null, initalChannelId: string | null) 
         else if (initalChannelId)
             setCategory({
                 id: Toasts.genId(),
-                name: `Pin Category ${categories.length + 1}`,
+                name: `Pin Category ${categoryLen() + 1}`,
                 color: DEFAULT_COLOR,
                 collapsed: false,
                 channels: [initalChannelId]
@@ -70,14 +69,13 @@ export function NewCategoryModal({ categoryId, modalProps, initalChannelId }: Pr
 
     if (!category) return null;
 
-    const onSave = async (e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    const onSave = (e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
         e.preventDefault();
         if (!categoryId)
-            await createCategory(category);
+            createCategory(category);
         else
-            await updateCategory(category);
+            updateCategory(category);
 
-        forceUpdate();
         modalProps.onClose();
     };
 

--- a/src/plugins/pinDms/components/CreateCategoryModal.tsx
+++ b/src/plugins/pinDms/components/CreateCategoryModal.tsx
@@ -7,10 +7,10 @@
 import { classNameFactory } from "@api/Styles";
 import { ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, openModalLazy } from "@utils/modal";
 import { extractAndLoadChunksLazy, findComponentByCodeLazy, findExportedComponentLazy } from "@webpack";
-import { Button, Forms, Text, TextInput, Toasts, useEffect, useState } from "@webpack/common";
+import { Button, Forms, Text, TextInput, Toasts, useMemo, useState } from "@webpack/common";
 
 import { DEFAULT_COLOR, SWATCHES } from "../constants";
-import { Category, categoryLen, createCategory, getCategory, updateCategory } from "../data";
+import { categoryLen, createCategory, getCategory } from "../data";
 
 interface ColorPickerProps {
     color: number | null;
@@ -38,43 +38,44 @@ const cl = classNameFactory("vc-pindms-modal-");
 
 interface Props {
     categoryId: string | null;
-    initalChannelId: string | null;
+    initialChannelId: string | null;
     modalProps: ModalProps;
 }
 
 function useCategory(categoryId: string | null, initalChannelId: string | null) {
-    const [category, setCategory] = useState<Category | null>(null);
-
-    useEffect(() => {
-        if (categoryId)
-            setCategory(getCategory(categoryId)!);
-        else if (initalChannelId)
-            setCategory({
+    const category = useMemo(() => {
+        if (categoryId) {
+            return getCategory(categoryId);
+        } else if (initalChannelId) {
+            return {
                 id: Toasts.genId(),
                 name: `Pin Category ${categoryLen() + 1}`,
                 color: DEFAULT_COLOR,
                 collapsed: false,
                 channels: [initalChannelId]
-            });
+            };
+        }
     }, [categoryId, initalChannelId]);
 
-    return {
-        category,
-        setCategory
-    };
+    return category;
 }
 
-export function NewCategoryModal({ categoryId, modalProps, initalChannelId }: Props) {
-    const { category, setCategory } = useCategory(categoryId, initalChannelId);
-
+export function NewCategoryModal({ categoryId, modalProps, initialChannelId }: Props) {
+    const category = useCategory(categoryId, initialChannelId);
     if (!category) return null;
+
+    const [name, setName] = useState(category.name);
+    const [color, setColor] = useState(category.color);
 
     const onSave = (e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
         e.preventDefault();
-        if (!categoryId)
+
+        category.name = name;
+        category.color = color;
+
+        if (!categoryId) {
             createCategory(category);
-        else
-            updateCategory(category);
+        }
 
         modalProps.onClose();
     };
@@ -91,25 +92,25 @@ export function NewCategoryModal({ categoryId, modalProps, initalChannelId }: Pr
                     <Forms.FormSection>
                         <Forms.FormTitle>Name</Forms.FormTitle>
                         <TextInput
-                            value={category.name}
-                            onChange={e => setCategory({ ...category, name: e })}
+                            value={name}
+                            onChange={e => setName(e)}
                         />
                     </Forms.FormSection>
                     <Forms.FormDivider />
                     <Forms.FormSection>
                         <Forms.FormTitle>Color</Forms.FormTitle>
                         <ColorPickerWithSwatches
-                            key={category.name}
+                            key={category.id}
                             defaultColor={DEFAULT_COLOR}
                             colors={SWATCHES}
-                            onChange={c => setCategory({ ...category, color: c! })}
-                            value={category.color}
+                            onChange={c => setColor(c!)}
+                            value={color}
                             renderDefaultButton={() => null}
                             renderCustomButton={() => (
                                 <ColorPicker
-                                    color={category.color}
-                                    onChange={c => setCategory({ ...category, color: c! })}
-                                    key={category.name}
+                                    color={color}
+                                    onChange={c => setColor(c!)}
+                                    key={category.id}
                                     showEyeDropper={false}
                                 />
                             )}
@@ -117,7 +118,7 @@ export function NewCategoryModal({ categoryId, modalProps, initalChannelId }: Pr
                     </Forms.FormSection>
                 </ModalContent>
                 <ModalFooter>
-                    <Button type="submit" onClick={onSave} disabled={!category.name}>{categoryId ? "Save" : "Create"}</Button>
+                    <Button type="submit" onClick={onSave} disabled={!name}>{categoryId ? "Save" : "Create"}</Button>
                 </ModalFooter>
             </form>
         </ModalRoot>
@@ -127,6 +128,6 @@ export function NewCategoryModal({ categoryId, modalProps, initalChannelId }: Pr
 export const openCategoryModal = (categoryId: string | null, channelId: string | null) =>
     openModalLazy(async () => {
         await requireSettingsMenu();
-        return modalProps => <NewCategoryModal categoryId={categoryId} modalProps={modalProps} initalChannelId={channelId} />;
+        return modalProps => <NewCategoryModal categoryId={categoryId} modalProps={modalProps} initialChannelId={channelId} />;
     });
 

--- a/src/plugins/pinDms/components/contextMenu.tsx
+++ b/src/plugins/pinDms/components/contextMenu.tsx
@@ -7,8 +7,8 @@
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Menu } from "@webpack/common";
 
-import { addChannelToCategory, canMoveChannelInDirection, categories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
-import { forceUpdate, PinOrder, settings } from "../index";
+import { addChannelToCategory, canMoveChannelInDirection, currentUserCategories, isPinned, moveChannel, removeChannelFromCategory } from "../data";
+import { PinOrder, settings } from "../index";
 import { openCategoryModal } from "./CreateCategoryModal";
 
 function createPinMenuItem(channelId: string) {
@@ -31,12 +31,12 @@ function createPinMenuItem(channelId: string) {
                     <Menu.MenuSeparator />
 
                     {
-                        categories.map(category => (
+                        currentUserCategories.map(category => (
                             <Menu.MenuItem
                                 key={category.id}
                                 id={`pin-category-${category.id}`}
                                 label={category.name}
-                                action={() => addChannelToCategory(channelId, category.id).then(forceUpdate)}
+                                action={() => addChannelToCategory(channelId, category.id)}
                             />
                         ))
                     }
@@ -49,7 +49,7 @@ function createPinMenuItem(channelId: string) {
                         id="unpin-dm"
                         label="Unpin DM"
                         color="danger"
-                        action={() => removeChannelFromCategory(channelId).then(forceUpdate)}
+                        action={() => removeChannelFromCategory(channelId)}
                     />
 
                     {
@@ -57,7 +57,7 @@ function createPinMenuItem(channelId: string) {
                             <Menu.MenuItem
                                 id="move-up"
                                 label="Move Up"
-                                action={() => moveChannel(channelId, -1).then(forceUpdate)}
+                                action={() => moveChannel(channelId, -1)}
                             />
                         )
                     }
@@ -67,7 +67,7 @@ function createPinMenuItem(channelId: string) {
                             <Menu.MenuItem
                                 id="move-down"
                                 label="Move Down"
-                                action={() => moveChannel(channelId, 1).then(forceUpdate)}
+                                action={() => moveChannel(channelId, 1)}
                             />
                         )
                     }

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -5,6 +5,7 @@
  */
 
 import * as DataStore from "@api/DataStore";
+import { Settings } from "@api/Settings";
 import { UserStore } from "@webpack/common";
 
 import { forceUpdate, PinOrder, PrivateChannelSortStore, settings } from "./index";
@@ -46,7 +47,7 @@ export function initCategories(userId: string) {
         currentUserCategories = settings.store.userBasedCategoryList[currentUserCategoriesIndex].categories;
     } else {
         currentUserCategoriesIndex = categoriesIndex;
-        currentUserCategories = settings.store.userBasedCategoryList[currentUserCategoriesIndex].categories;
+        currentUserCategories = settings.store.userBasedCategoryList[categoriesIndex].categories;
     }
 }
 
@@ -187,9 +188,9 @@ export function moveChannel(channelId: string, direction: -1 | 1) {
 
 // TODO: Remove DataStore PinnedDms migration once enough time has passed
 async function migrateData() {
-    if (Vencord.Settings.plugins.PinDMs.dmSectioncollapsed != null) {
-        settings.store.dmSectionCollapsed = Vencord.Settings.plugins.PinDMs.dmSectioncollapsed;
-        delete Vencord.Settings.plugins.PinDMs.dmSectioncollapsed;
+    if (Settings.plugins.PinDMs.dmSectioncollapsed != null) {
+        settings.store.dmSectionCollapsed = Settings.plugins.PinDMs.dmSectioncollapsed;
+        delete Settings.plugins.PinDMs.dmSectioncollapsed;
     }
 
     const dataStoreKeys = await DataStore.keys();
@@ -207,7 +208,5 @@ async function migrateData() {
         await DataStore.del(pinDmsKey);
     }
 
-    await DataStore.del(CATEGORY_MIGRATED_PINDMS_KEY);
-    await DataStore.del(CATEGORY_MIGRATED_KEY);
-    await DataStore.del(OLD_CATEGORY_KEY);
+    await Promise.all([DataStore.del(CATEGORY_MIGRATED_PINDMS_KEY), DataStore.del(CATEGORY_MIGRATED_KEY), DataStore.del(OLD_CATEGORY_KEY)]);
 }

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -195,6 +195,8 @@ async function migrateData() {
     const dataStoreKeys = await DataStore.keys();
     const pinDmsKeys = dataStoreKeys.map(key => String(key)).filter(key => key.startsWith(CATEGORY_BASE_KEY));
 
+    if (pinDmsKeys.length === 0) return;
+
     for (const pinDmsKey of pinDmsKeys) {
         const categories = await DataStore.get<Category[]>(pinDmsKey);
         if (categories == null) continue;

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -37,7 +37,7 @@ export async function init() {
 
 export function usePinnedDms() {
     forceUpdateDms = useForceUpdater();
-    settings.use(["pinOrder", "dmSectionCollapsed", "userBasedCategoryList"]);
+    settings.use(["pinOrder", "canCollapseDmSection", "dmSectionCollapsed", "userBasedCategoryList"]);
 }
 
 export let currentUserCategories: Category[] = [];

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { DataStore } from "@api/index";
+import * as DataStore from "@api/DataStore";
 import { UserStore } from "@webpack/common";
 
 import { forceUpdate, PinOrder, PrivateChannelSortStore, settings } from "./index";

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -25,13 +25,15 @@ const CATEGORY_MIGRATED_KEY = "PinDMsMigratedOldCategories";
 const OLD_CATEGORY_KEY = "BetterPinDMsCategories-";
 
 let forceUpdateDms: (() => void) | undefined = undefined;
+export let currentUserCategories: Category[] = [];
 
 export async function init() {
     await migrateData();
 
     const userId = UserStore.getCurrentUser()?.id;
-    currentUserCategories = settings.store.userBasedCategoryList[userId] ??= [];
+    if (userId == null) return;
 
+    currentUserCategories = settings.store.userBasedCategoryList[userId] ??= [];
     forceUpdateDms?.();
 }
 
@@ -39,8 +41,6 @@ export function usePinnedDms() {
     forceUpdateDms = useForceUpdater();
     settings.use(["pinOrder", "canCollapseDmSection", "dmSectionCollapsed", "userBasedCategoryList"]);
 }
-
-export let currentUserCategories: Category[] = [];
 
 export function getCategory(id: string) {
     return currentUserCategories.find(c => c.id === id);

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -12,7 +12,7 @@ import { Devs } from "@utils/constants";
 import { classes } from "@utils/misc";
 import definePlugin, { OptionType, StartAt } from "@utils/types";
 import { findByPropsLazy, findStoreLazy } from "@webpack";
-import { ContextMenuApi, FluxDispatcher, Menu, React } from "@webpack/common";
+import { Clickable, ContextMenuApi, FluxDispatcher, Menu, React } from "@webpack/common";
 import { Channel } from "discord-types/general";
 
 import { contextMenus } from "./components/contextMenu";
@@ -48,7 +48,7 @@ export const settings = definePluginSettings({
     },
     canCollapseDmSection: {
         type: OptionType.BOOLEAN,
-        description: "Allow DMs section to be collapsable",
+        description: "Allow uncategorised DMs section to be collapsable",
         default: false
     },
     dmSectionCollapsed: {
@@ -163,9 +163,9 @@ export default definePlugin({
     },
 
     startAt: StartAt.WebpackReady,
-    start: () => init(),
+    start: init,
     flux: {
-        CONNECTION_OPEN: () => init(),
+        CONNECTION_OPEN: init,
     },
 
     usePinnedDms,
@@ -259,66 +259,69 @@ export default definePlugin({
         if (!category) return null;
 
         return (
-            <h2
-                className={classes(headerClasses.privateChannelsHeaderContainer, "vc-pindms-section-container", category.collapsed ? "vc-pindms-collapsed" : "")}
-                style={{ color: `#${category.color.toString(16).padStart(6, "0")}` }}
+            <Clickable
                 onClick={() => collapseCategory(category.id, !category.collapsed)}
-                onContextMenu={e => {
-                    ContextMenuApi.openContextMenu(e, () => (
-                        <Menu.Menu
-                            navId="vc-pindms-header-menu"
-                            onClose={() => FluxDispatcher.dispatch({ type: "CONTEXT_MENU_CLOSE" })}
-                            color="danger"
-                            aria-label="Pin DMs Category Menu"
-                        >
-                            <Menu.MenuItem
-                                id="vc-pindms-edit-category"
-                                label="Edit Category"
-                                action={() => openCategoryModal(category.id, null)}
-                            />
-
-                            {
-                                canMoveCategory(category.id) && (
-                                    <>
-                                        {
-                                            canMoveCategoryInDirection(category.id, -1) && <Menu.MenuItem
-                                                id="vc-pindms-move-category-up"
-                                                label="Move Up"
-                                                action={() => moveCategory(category.id, -1)}
-                                            />
-                                        }
-                                        {
-                                            canMoveCategoryInDirection(category.id, 1) && <Menu.MenuItem
-                                                id="vc-pindms-move-category-down"
-                                                label="Move Down"
-                                                action={() => moveCategory(category.id, 1)}
-                                            />
-                                        }
-                                    </>
-
-                                )
-                            }
-
-                            <Menu.MenuSeparator />
-                            <Menu.MenuItem
-                                id="vc-pindms-delete-category"
-                                color="danger"
-                                label="Delete Category"
-                                action={() => removeCategory(category.id)}
-                            />
-
-
-                        </Menu.Menu>
-                    ));
-                }}
             >
-                <span className={headerClasses.headerText}>
-                    {category?.name ?? "uh oh"}
-                </span>
-                <svg className="vc-pindms-collapse-icon" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-                    <path fill="currentColor" d="M9.3 5.3a1 1 0 0 0 0 1.4l5.29 5.3-5.3 5.3a1 1 0 1 0 1.42 1.4l6-6a1 1 0 0 0 0-1.4l-6-6a1 1 0 0 0-1.42 0Z"></path>
-                </svg>
-            </h2>
+                <h2
+                    className={classes(headerClasses.privateChannelsHeaderContainer, "vc-pindms-section-container", category.collapsed ? "vc-pindms-collapsed" : "")}
+                    style={{ color: `#${category.color.toString(16).padStart(6, "0")}` }}
+                    onContextMenu={e => {
+                        ContextMenuApi.openContextMenu(e, () => (
+                            <Menu.Menu
+                                navId="vc-pindms-header-menu"
+                                onClose={() => FluxDispatcher.dispatch({ type: "CONTEXT_MENU_CLOSE" })}
+                                color="danger"
+                                aria-label="Pin DMs Category Menu"
+                            >
+                                <Menu.MenuItem
+                                    id="vc-pindms-edit-category"
+                                    label="Edit Category"
+                                    action={() => openCategoryModal(category.id, null)}
+                                />
+
+                                {
+                                    canMoveCategory(category.id) && (
+                                        <>
+                                            {
+                                                canMoveCategoryInDirection(category.id, -1) && <Menu.MenuItem
+                                                    id="vc-pindms-move-category-up"
+                                                    label="Move Up"
+                                                    action={() => moveCategory(category.id, -1)}
+                                                />
+                                            }
+                                            {
+                                                canMoveCategoryInDirection(category.id, 1) && <Menu.MenuItem
+                                                    id="vc-pindms-move-category-down"
+                                                    label="Move Down"
+                                                    action={() => moveCategory(category.id, 1)}
+                                                />
+                                            }
+                                        </>
+
+                                    )
+                                }
+
+                                <Menu.MenuSeparator />
+                                <Menu.MenuItem
+                                    id="vc-pindms-delete-category"
+                                    color="danger"
+                                    label="Delete Category"
+                                    action={() => removeCategory(category.id)}
+                                />
+
+
+                            </Menu.Menu>
+                        ));
+                    }}
+                >
+                    <span className={headerClasses.headerText}>
+                        {category?.name ?? "uh oh"}
+                    </span>
+                    <svg className="vc-pindms-collapse-icon" aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                        <path fill="currentColor" d="M9.3 5.3a1 1 0 0 0 0 1.4l5.29 5.3-5.3 5.3a1 1 0 1 0 1.42 1.4l6-6a1 1 0 0 0 0-1.4l-6-6a1 1 0 0 0-1.42 0Z"></path>
+                    </svg>
+                </h2>
+            </Clickable>
         );
     }, { noop: true }),
 

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -261,58 +261,58 @@ export default definePlugin({
         return (
             <Clickable
                 onClick={() => collapseCategory(category.id, !category.collapsed)}
+                onContextMenu={e => {
+                    ContextMenuApi.openContextMenu(e, () => (
+                        <Menu.Menu
+                            navId="vc-pindms-header-menu"
+                            onClose={() => FluxDispatcher.dispatch({ type: "CONTEXT_MENU_CLOSE" })}
+                            color="danger"
+                            aria-label="Pin DMs Category Menu"
+                        >
+                            <Menu.MenuItem
+                                id="vc-pindms-edit-category"
+                                label="Edit Category"
+                                action={() => openCategoryModal(category.id, null)}
+                            />
+
+                            {
+                                canMoveCategory(category.id) && (
+                                    <>
+                                        {
+                                            canMoveCategoryInDirection(category.id, -1) && <Menu.MenuItem
+                                                id="vc-pindms-move-category-up"
+                                                label="Move Up"
+                                                action={() => moveCategory(category.id, -1)}
+                                            />
+                                        }
+                                        {
+                                            canMoveCategoryInDirection(category.id, 1) && <Menu.MenuItem
+                                                id="vc-pindms-move-category-down"
+                                                label="Move Down"
+                                                action={() => moveCategory(category.id, 1)}
+                                            />
+                                        }
+                                    </>
+
+                                )
+                            }
+
+                            <Menu.MenuSeparator />
+                            <Menu.MenuItem
+                                id="vc-pindms-delete-category"
+                                color="danger"
+                                label="Delete Category"
+                                action={() => removeCategory(category.id)}
+                            />
+
+
+                        </Menu.Menu>
+                    ));
+                }}
             >
                 <h2
                     className={classes(headerClasses.privateChannelsHeaderContainer, "vc-pindms-section-container", category.collapsed ? "vc-pindms-collapsed" : "")}
                     style={{ color: `#${category.color.toString(16).padStart(6, "0")}` }}
-                    onContextMenu={e => {
-                        ContextMenuApi.openContextMenu(e, () => (
-                            <Menu.Menu
-                                navId="vc-pindms-header-menu"
-                                onClose={() => FluxDispatcher.dispatch({ type: "CONTEXT_MENU_CLOSE" })}
-                                color="danger"
-                                aria-label="Pin DMs Category Menu"
-                            >
-                                <Menu.MenuItem
-                                    id="vc-pindms-edit-category"
-                                    label="Edit Category"
-                                    action={() => openCategoryModal(category.id, null)}
-                                />
-
-                                {
-                                    canMoveCategory(category.id) && (
-                                        <>
-                                            {
-                                                canMoveCategoryInDirection(category.id, -1) && <Menu.MenuItem
-                                                    id="vc-pindms-move-category-up"
-                                                    label="Move Up"
-                                                    action={() => moveCategory(category.id, -1)}
-                                                />
-                                            }
-                                            {
-                                                canMoveCategoryInDirection(category.id, 1) && <Menu.MenuItem
-                                                    id="vc-pindms-move-category-down"
-                                                    label="Move Down"
-                                                    action={() => moveCategory(category.id, 1)}
-                                                />
-                                            }
-                                        </>
-
-                                    )
-                                }
-
-                                <Menu.MenuSeparator />
-                                <Menu.MenuItem
-                                    id="vc-pindms-delete-category"
-                                    color="danger"
-                                    label="Delete Category"
-                                    action={() => removeCategory(category.id)}
-                                />
-
-
-                            </Menu.Menu>
-                        ));
-                    }}
                 >
                     <span className={headerClasses.headerText}>
                         {category?.name ?? "uh oh"}

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -18,7 +18,7 @@ import { Channel } from "discord-types/general";
 import { contextMenus } from "./components/contextMenu";
 import { openCategoryModal, requireSettingsMenu } from "./components/CreateCategoryModal";
 import { DEFAULT_CHUNK_SIZE } from "./constants";
-import { canMoveCategory, canMoveCategoryInDirection, Category, categoryLen, collapseCategory, getAllUncollapsedChannels, getCategoryByIndex, getSections, init, isPinned, moveCategory, removeCategory } from "./data";
+import { canMoveCategory, canMoveCategoryInDirection, Category, categoryLen, collapseCategory, getAllUncollapsedChannels, getCategoryByIndex, getSections, init, isPinned, moveCategory, removeCategory, usePinnedDms } from "./data";
 
 interface ChannelComponentProps {
     children: React.ReactNode,
@@ -31,7 +31,6 @@ const headerClasses = findByPropsLazy("privateChannelsHeaderContainer");
 export const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as { getPrivateChannelIds: () => string[]; };
 
 export let instance: any;
-export const forceUpdate = () => instance?.props?._forceUpdate?.();
 
 export const enum PinOrder {
     LastMessage,
@@ -45,14 +44,12 @@ export const settings = definePluginSettings({
         options: [
             { label: "Most recent message", value: PinOrder.LastMessage, default: true },
             { label: "Custom (right click channels to reorder)", value: PinOrder.Custom }
-        ],
-        onChange: () => forceUpdate()
+        ]
     },
     dmSectionCollapsed: {
         type: OptionType.BOOLEAN,
         description: "Collapse DM sections",
-        default: false,
-        onChange: () => forceUpdate()
+        default: false
     },
     userBasedCategoryList: {
         type: OptionType.CUSTOM,
@@ -126,8 +123,8 @@ export default definePlugin({
         {
             find: ".FRIENDS},\"friends\"",
             replacement: {
-                match: /let{showLibrary:\i,.+?showDMHeader:.+?,/,
-                replace: "let forceUpdate = Vencord.Util.useForceUpdater();$&_forceUpdate:forceUpdate,"
+                match: /let{showLibrary:\i,/,
+                replace: "$self.usePinnedDms();$&"
             }
         },
 
@@ -151,6 +148,7 @@ export default definePlugin({
             }
         },
     ],
+
     sections: null as number[] | null,
 
     set _instance(i: any) {
@@ -164,6 +162,7 @@ export default definePlugin({
         CONNECTION_OPEN: () => init(),
     },
 
+    usePinnedDms,
     isPinned,
     categoryLen,
     getSections,

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -18,7 +18,7 @@ import { Channel } from "discord-types/general";
 import { contextMenus } from "./components/contextMenu";
 import { openCategoryModal, requireSettingsMenu } from "./components/CreateCategoryModal";
 import { DEFAULT_CHUNK_SIZE } from "./constants";
-import { canMoveCategory, canMoveCategoryInDirection, Category, categoryLen, collapseCategory, getAllUncollapsedChannels, getCategoryByIndex, getSections, init, isPinned, moveCategory, removeCategory, UserBasedCategoryList } from "./data";
+import { canMoveCategory, canMoveCategoryInDirection, Category, categoryLen, collapseCategory, getAllUncollapsedChannels, getCategoryByIndex, getSections, init, isPinned, moveCategory, removeCategory } from "./data";
 
 interface ChannelComponentProps {
     children: React.ReactNode,
@@ -55,10 +55,8 @@ export const settings = definePluginSettings({
         onChange: () => forceUpdate()
     },
     userBasedCategoryList: {
-        type: OptionType.ARRAY,
-        description: "",
-        hidden: true,
-        default: [] as UserBasedCategoryList[]
+        type: OptionType.CUSTOM,
+        default: {} as Record<string, Category[]>
     }
 });
 

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -46,10 +46,16 @@ export const settings = definePluginSettings({
             { label: "Custom (right click channels to reorder)", value: PinOrder.Custom }
         ]
     },
+    canCollapseDmSection: {
+        type: OptionType.BOOLEAN,
+        description: "Allow DMs section to be collapsable",
+        default: false
+    },
     dmSectionCollapsed: {
         type: OptionType.BOOLEAN,
-        description: "Collapse DM sections",
-        default: false
+        description: "Collapse DM section",
+        default: false,
+        hidden: true
     },
     userBasedCategoryList: {
         type: OptionType.CUSTOM,
@@ -187,11 +193,11 @@ export default definePlugin({
     },
 
     makeSpanProps() {
-        return {
+        return settings.store.canCollapseDmSection ? {
             onClick: () => this.collapseDMList(),
             role: "button",
             style: { cursor: "pointer" }
-        };
+        } : undefined;
     },
 
     getChunkSize() {
@@ -211,16 +217,12 @@ export default definePlugin({
     },
 
     isChannelIndex(sectionIndex: number, channelIndex: number) {
-        if (settings.store.dmSectionCollapsed && sectionIndex !== 0) {
+        if (settings.store.canCollapseDmSection && settings.store.dmSectionCollapsed && sectionIndex !== 0) {
             return true;
         }
 
         const category = getCategoryByIndex(sectionIndex - 1);
         return this.isCategoryIndex(sectionIndex) && (category?.channels?.length === 0 || category?.channels[channelIndex]);
-    },
-
-    isDMSectioncollapsed() {
-        return settings.store.dmSectionCollapsed;
     },
 
     collapseDMList() {
@@ -230,7 +232,7 @@ export default definePlugin({
     isChannelHidden(categoryIndex: number, channelIndex: number) {
         if (categoryIndex === 0) return false;
 
-        if (settings.store.dmSectionCollapsed && this.getSections().length + 1 === categoryIndex)
+        if (settings.store.canCollapseDmSection && settings.store.dmSectionCollapsed && this.getSections().length + 1 === categoryIndex)
             return true;
 
         if (!this.instance || !this.isChannelIndex(categoryIndex, channelIndex)) return false;

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -64,7 +64,7 @@ export const settings = definePluginSettings({
 
 export default definePlugin({
     name: "PinDMs",
-    description: "Allows you to pin private channels to the top of your DM list. To pin/unpin or reorder pins, right click DMs",
+    description: "Allows you to pin private channels to the top of your DM list. To pin/unpin or re-order pins, right click DMs",
     authors: [Devs.Ven, Devs.Aria],
     settings,
     contextMenus,

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -203,8 +203,9 @@ function TextReplaceTesting() {
 }
 
 function applyRules(content: string): string {
-    if (content.length === 0)
+    if (content.length === 0) {
         return content;
+    }
 
     for (const rule of settings.store.stringRules) {
         if (!rule.find) continue;

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -66,15 +66,11 @@ const settings = definePluginSettings({
         }
     },
     stringRules: {
-        type: OptionType.ARRAY,
-        description: "",
-        hidden: true,
+        type: OptionType.CUSTOM,
         default: makeEmptyRuleArray(),
     },
     regexRules: {
-        type: OptionType.ARRAY,
-        description: "",
-        hidden: true,
+        type: OptionType.CUSTOM,
         default: makeEmptyRuleArray(),
     }
 });

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -132,10 +132,7 @@ function TextReplace({ title, rulesArray }: TextReplaceProps) {
             rulesArray.push(makeEmptyRule());
         }
 
-        rulesArray[index] = {
-            ...rulesArray[index],
-            [key]: e
-        };
+        rulesArray[index][key] = e;
 
         if (rulesArray[index].find === "" && rulesArray[index].replace === "" && rulesArray[index].onlyIfIncludes === "" && index !== rulesArray.length - 1) {
             rulesArray.splice(index, 1);

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -23,7 +23,6 @@ import { Flex } from "@components/Flex";
 import { DeleteIcon } from "@components/Icons";
 import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
-import { useForceUpdater } from "@utils/react";
 import definePlugin, { OptionType } from "@utils/types";
 import { Button, Forms, React, TextInput, useState } from "@webpack/common";
 
@@ -35,8 +34,6 @@ type Rule = Record<"find" | "replace" | "onlyIfIncludes", string>;
 interface TextReplaceProps {
     title: string;
     rulesArray: Rule[];
-    rulesKey: string;
-    update: () => void;
 }
 
 const makeEmptyRule: () => Rule = () => ({
@@ -46,34 +43,40 @@ const makeEmptyRule: () => Rule = () => ({
 });
 const makeEmptyRuleArray = () => [makeEmptyRule()];
 
-let stringRules = makeEmptyRuleArray();
-let regexRules = makeEmptyRuleArray();
-
 const settings = definePluginSettings({
     replace: {
         type: OptionType.COMPONENT,
         description: "",
         component: () => {
-            const update = useForceUpdater();
+            const { stringRules, regexRules } = settings.use(["stringRules", "regexRules"]);
+
             return (
                 <>
                     <TextReplace
                         title="Using String"
                         rulesArray={stringRules}
-                        rulesKey={STRING_RULES_KEY}
-                        update={update}
                     />
                     <TextReplace
                         title="Using Regex"
                         rulesArray={regexRules}
-                        rulesKey={REGEX_RULES_KEY}
-                        update={update}
                     />
                     <TextReplaceTesting />
                 </>
             );
         }
     },
+    stringRules: {
+        type: OptionType.ARRAY,
+        description: "",
+        hidden: true,
+        default: makeEmptyRuleArray(),
+    },
+    regexRules: {
+        type: OptionType.ARRAY,
+        description: "",
+        hidden: true,
+        default: makeEmptyRuleArray(),
+    }
 });
 
 function stringToRegex(str: string) {
@@ -120,28 +123,27 @@ function Input({ initialValue, onChange, placeholder }: {
     );
 }
 
-function TextReplace({ title, rulesArray, rulesKey, update }: TextReplaceProps) {
+function TextReplace({ title, rulesArray }: TextReplaceProps) {
     const isRegexRules = title === "Using Regex";
 
     async function onClickRemove(index: number) {
         if (index === rulesArray.length - 1) return;
         rulesArray.splice(index, 1);
-
-        await DataStore.set(rulesKey, rulesArray);
-        update();
     }
 
     async function onChange(e: string, index: number, key: string) {
-        if (index === rulesArray.length - 1)
+        if (index === rulesArray.length - 1) {
             rulesArray.push(makeEmptyRule());
+        }
 
-        rulesArray[index][key] = e;
+        rulesArray[index] = {
+            ...rulesArray[index],
+            [key]: e
+        };
 
-        if (rulesArray[index].find === "" && rulesArray[index].replace === "" && rulesArray[index].onlyIfIncludes === "" && index !== rulesArray.length - 1)
+        if (rulesArray[index].find === "" && rulesArray[index].replace === "" && rulesArray[index].onlyIfIncludes === "" && index !== rulesArray.length - 1) {
             rulesArray.splice(index, 1);
-
-        await DataStore.set(rulesKey, rulesArray);
-        update();
+        }
     }
 
     return (
@@ -211,26 +213,22 @@ function applyRules(content: string): string {
     if (content.length === 0)
         return content;
 
-    if (stringRules) {
-        for (const rule of stringRules) {
-            if (!rule.find) continue;
-            if (rule.onlyIfIncludes && !content.includes(rule.onlyIfIncludes)) continue;
+    for (const rule of settings.store.stringRules) {
+        if (!rule.find) continue;
+        if (rule.onlyIfIncludes && !content.includes(rule.onlyIfIncludes)) continue;
 
-            content = ` ${content} `.replaceAll(rule.find, rule.replace.replaceAll("\\n", "\n")).replace(/^\s|\s$/g, "");
-        }
+        content = ` ${content} `.replaceAll(rule.find, rule.replace.replaceAll("\\n", "\n")).replace(/^\s|\s$/g, "");
     }
 
-    if (regexRules) {
-        for (const rule of regexRules) {
-            if (!rule.find) continue;
-            if (rule.onlyIfIncludes && !content.includes(rule.onlyIfIncludes)) continue;
+    for (const rule of settings.store.regexRules) {
+        if (!rule.find) continue;
+        if (rule.onlyIfIncludes && !content.includes(rule.onlyIfIncludes)) continue;
 
-            try {
-                const regex = stringToRegex(rule.find);
-                content = content.replace(regex, rule.replace.replaceAll("\\n", "\n"));
-            } catch (e) {
-                new Logger("TextReplace").error(`Invalid regex: ${rule.find}`);
-            }
+        try {
+            const regex = stringToRegex(rule.find);
+            content = content.replace(regex, rule.replace.replaceAll("\\n", "\n"));
+        } catch (e) {
+            new Logger("TextReplace").error(`Invalid regex: ${rule.find}`);
         }
     }
 
@@ -249,8 +247,18 @@ export default definePlugin({
     settings,
 
     async start() {
-        stringRules = await DataStore.get(STRING_RULES_KEY) ?? makeEmptyRuleArray();
-        regexRules = await DataStore.get(REGEX_RULES_KEY) ?? makeEmptyRuleArray();
+        // TODO: Remove DataStore rules migrations once enough time has passed
+        const oldStringRules = await DataStore.get<Rule[]>(STRING_RULES_KEY);
+        if (oldStringRules != null) {
+            settings.store.stringRules = oldStringRules;
+            await DataStore.del(STRING_RULES_KEY);
+        }
+
+        const oldRegexRules = await DataStore.get<Rule[]>(REGEX_RULES_KEY);
+        if (oldRegexRules != null) {
+            settings.store.regexRules = oldRegexRules;
+            await DataStore.del(REGEX_RULES_KEY);
+        }
 
         this.preSend = addPreSendListener((channelId, msg) => {
             // Channel used for sharing rules, applying rules here would be messy

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -31,9 +31,9 @@ interface SettingsStoreOptions {
 // merges the SettingsStoreOptions type into the class
 export interface SettingsStore<T extends object> extends SettingsStoreOptions { }
 
-interface ProxyContext {
-    settingsStore: SettingsStore<any>;
-    root: any;
+interface ProxyContext<T extends object = any> {
+    settingsStore: SettingsStore<T>;
+    root: T;
     path: string;
 }
 

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -79,10 +79,16 @@ export class SettingsStore<T extends object> {
                 if (target[key] === value) return true;
 
                 Reflect.set(target, key, value);
-                const setPath = `${path}${path && "."}${key}`;
 
-                self.globalListeners.forEach(cb => cb(root, setPath));
+                const setPath = `${path}${path && "."}${key}`;
                 self.pathListeners.get(setPath)?.forEach(cb => cb(value));
+
+                if (Array.isArray(target)) {
+                    self.globalListeners.forEach(cb => cb(root, path));
+                    self.pathListeners.get(path)?.forEach(cb => cb(target));
+                } else {
+                    self.globalListeners.forEach(cb => cb(root, setPath));
+                }
 
                 return true;
             },
@@ -90,9 +96,14 @@ export class SettingsStore<T extends object> {
                 Reflect.deleteProperty(target, key);
 
                 const setPath = `${path}${path && "."}${key}`;
-
-                self.globalListeners.forEach(cb => cb(root, setPath));
                 self.pathListeners.get(setPath)?.forEach(cb => cb(undefined));
+
+                if (Array.isArray(target)) {
+                    self.globalListeners.forEach(cb => cb(root, path));
+                    self.pathListeners.get(path)?.forEach(cb => cb(target));
+                } else {
+                    self.globalListeners.forEach(cb => cb(root, setPath));
+                }
 
                 return true;
             }

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -89,6 +89,16 @@ export class SettingsStore<T extends object> {
                 self.pathListeners.get(setPath)?.forEach(cb => cb(value));
 
                 return true;
+            },
+            deleteProperty(target, key: string) {
+                Reflect.deleteProperty(target, key);
+
+                const setPath = `${path}${path && "."}${key}`;
+
+                self.globalListeners.forEach(cb => cb(undefined, setPath));
+                self.pathListeners.get(setPath)?.forEach(cb => cb(undefined));
+
+                return true;
             }
         });
     }

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -111,8 +111,8 @@ const proxyHandler: ProxyHandler<any> = {
 
         const { settingsStore, root, path } = proxyContext;
 
-        const deletPath = `${path}${path && "."}${key}`;
-        settingsStore["notifyListeners"](deletPath, undefined, root);
+        const deletePath = `${path}${path && "."}${key}`;
+        settingsStore["notifyListeners"](deletePath, undefined, root);
 
         return true;
     }

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -92,7 +92,17 @@ export class SettingsStore<T extends object> {
                 }
 
                 const setPath = `${path}${path && "."}${key}`;
-                self.globalListeners.forEach(cb => cb(root, setPath));
+                const paths = setPath.split(".");
+
+                if (paths.length > 2 && paths[0] === "plugins") {
+                    const settingPath = paths.slice(0, 3);
+                    const settingPathStr = settingPath.join(".");
+                    const settingValue = settingPath.reduce((acc, curr) => acc[curr], root);
+
+                    self.globalListeners.forEach(cb => cb(root, settingPathStr));
+                    self.pathListeners.get(settingPathStr)?.forEach(cb => cb(settingValue));
+                }
+
                 self.pathListeners.get(setPath)?.forEach(cb => cb(value));
 
                 return true;
@@ -103,7 +113,14 @@ export class SettingsStore<T extends object> {
                 }
 
                 const setPath = `${path}${path && "."}${key}`;
-                self.globalListeners.forEach(cb => cb(root, setPath));
+                const paths = setPath.split(".");
+
+                if (paths.length > 2 && paths[0] === "plugins") {
+                    const settingPathStr = paths.slice(0, 3).join(".");
+                    self.globalListeners.forEach(cb => cb(root, settingPathStr));
+                    self.pathListeners.get(settingPathStr)?.forEach(cb => cb(undefined));
+                }
+
                 self.pathListeners.get(setPath)?.forEach(cb => cb(undefined));
 
                 return true;
@@ -168,9 +185,19 @@ export class SettingsStore<T extends object> {
                     return false;
                 }
 
-                self.globalListeners.forEach(cb => cb(root, path));
-                self.pathListeners.get(path)?.forEach(cb => cb(target));
-                self.pathListeners.get(`${path}${path && "."}${key}`)?.forEach(cb => cb(value));
+                const setPath = `${path}${path && "."}${key}`;
+                const paths = setPath.split(".");
+
+                if (paths.length > 2 && paths[0] === "plugins") {
+                    const settingPath = paths.slice(0, 3);
+                    const settingPathStr = settingPath.join(".");
+                    const settingValue = settingPath.reduce((acc, curr) => acc[curr], root);
+
+                    self.globalListeners.forEach(cb => cb(root, settingPathStr));
+                    self.pathListeners.get(settingPathStr)?.forEach(cb => cb(settingValue));
+                }
+
+                self.pathListeners.get(setPath)?.forEach(cb => cb(value));
 
                 return true;
             },
@@ -179,10 +206,14 @@ export class SettingsStore<T extends object> {
                     return false;
                 }
 
-                self.globalListeners.forEach(cb => cb(root, path));
-                self.pathListeners.get(path)?.forEach(cb => cb(target));
-                self.pathListeners.get(`${path}${path && "."}${key}`)?.forEach(cb => cb(undefined));
+                const setPath = `${path}${path && "."}${key}`;
+                const paths = setPath.split(".");
 
+                if (paths.length > 2 && paths[0] === "plugins") {
+                    const settingPathStr = paths.slice(0, 3).join(".");
+                    self.globalListeners.forEach(cb => cb(root, settingPathStr));
+                    self.pathListeners.get(settingPathStr)?.forEach(cb => cb(undefined));
+                }
 
                 return true;
             }

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -68,8 +68,8 @@ const proxyHandler: ProxyHandler<any> = {
         }
 
         if (typeof v === "object" && v !== null && !v[SYM_IS_PROXY]) {
-            const settingsPath = `${path}${path && "."}${key}`;
-            return settingsStore["makeProxy"](v, root, settingsPath);
+            const getPath = `${path}${path && "."}${key}`;
+            return settingsStore["makeProxy"](v, root, getPath);
         }
 
         return v;
@@ -111,8 +111,8 @@ const proxyHandler: ProxyHandler<any> = {
 
         const { settingsStore, root, path } = proxyContext;
 
-        const setPath = `${path}${path && "."}${key}`;
-        settingsStore["notifyListeners"](setPath, undefined, root);
+        const deletPath = `${path}${path && "."}${key}`;
+        settingsStore["notifyListeners"](deletPath, undefined, root);
 
         return true;
     }

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -67,6 +67,10 @@ export class SettingsStore<T extends object> {
                     });
                 }
 
+                if (Array.isArray(target)) {
+                    return v;
+                }
+
                 const settingsPath = `${path}${path && "."}${key}`;
 
                 if (typeof v === "object" && v != null) {

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -94,6 +94,11 @@ export class SettingsStore<T extends object> {
                 const setPath = `${path}${path && "."}${key}`;
                 const paths = setPath.split(".");
 
+                // Because we support any type of settings with OptionType.CUSTOM, and those objects get proxied recursively,
+                // the path ends up including all the nested paths (plugins.pluginName.settingName.example.one).
+                // So, we need to extract the top-level setting path (plugins.pluginName.settingName),
+                // to be able to notify globalListeners and top-level setting name listeners (let { settingName } = settings.use(["settingName"]),
+                // with the new value
                 if (paths.length > 2 && paths[0] === "plugins") {
                     const settingPath = paths.slice(0, 3);
                     const settingPathStr = settingPath.join(".");
@@ -188,6 +193,11 @@ export class SettingsStore<T extends object> {
                 const setPath = `${path}${path && "."}${key}`;
                 const paths = setPath.split(".");
 
+                // Because we support any type of settings with OptionType.CUSTOM, and those objects get proxied recursively,
+                // the path ends up including all the nested paths (plugins.pluginName.settingName.example.one).
+                // So, we need to extract the top-level setting path (plugins.pluginName.settingName),
+                // to be able to notify globalListeners and top-level setting name listeners (let { settingName } = settings.use(["settingName"]),
+                // with the new value
                 if (paths.length > 2 && paths[0] === "plugins") {
                     const settingPath = paths.slice(0, 3);
                     const settingPathStr = settingPath.join(".");

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -6,8 +6,8 @@
 
 import { LiteralUnion } from "type-fest";
 
-const SYM_IS_PROXY = Symbol("SettingsStore.isProxy");
-const SYM_GET_RAW_TARGET = Symbol("SettingsStore.getRawTarget");
+export const SYM_IS_PROXY = Symbol("SettingsStore.isProxy");
+export const SYM_GET_RAW_TARGET = Symbol("SettingsStore.getRawTarget");
 
 // Resolves a possibly nested prop in the form of "some.nested.prop" to type of T.some.nested.prop
 type ResolvePropDeep<T, P> = P extends `${infer Pre}.${infer Suf}`

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -177,7 +177,7 @@ export type SettingsChecks<D extends SettingsDefinition> = {
     (IsDisabled<DefinedSettings<D>> & IsValid<PluginSettingType<D[K]>, DefinedSettings<D>>);
 };
 
-export type PluginSettingDef = PluginSettingCustomDef | ((
+export type PluginSettingDef = ((
     | PluginSettingStringDef
     | PluginSettingNumberDef
     | PluginSettingBooleanDef
@@ -185,7 +185,7 @@ export type PluginSettingDef = PluginSettingCustomDef | ((
     | PluginSettingSliderDef
     | PluginSettingComponentDef
     | PluginSettingBigIntDef
-) & PluginSettingCommon);
+) & PluginSettingCommon) | (PluginSettingCustomDef & Partial<PluginSettingCommon>);
 
 export interface PluginSettingCommon {
     description: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -20,7 +20,7 @@ import { Command } from "@api/Commands";
 import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { FluxEvents } from "@webpack/types";
 import { JSX } from "react";
-import { IsAny, Promisable } from "type-fest";
+import { Promisable } from "type-fest";
 
 // exists to export default definePlugin({...})
 export default function definePlugin<P extends PluginDef>(p: P & Record<string, any>) {
@@ -300,7 +300,7 @@ type PluginSettingType<O extends PluginSettingDef> = O extends PluginSettingStri
     O extends PluginSettingSelectDef ? O["options"][number]["value"] :
     O extends PluginSettingSliderDef ? number :
     O extends PluginSettingComponentDef ? any :
-    O extends PluginSettingCustomDef ? IsAny<O["default"]> extends true ? O["default"] : any :
+    O extends PluginSettingCustomDef ? O extends { default: infer Default; } ? Default : any :
     never;
 
 type PluginSettingDefaultType<O extends PluginSettingDef> = O extends PluginSettingSelectDef ? (

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -168,6 +168,7 @@ export const enum OptionType {
     SELECT,
     SLIDER,
     COMPONENT,
+    ARRAY
 }
 
 export type SettingsDefinition = Record<string, PluginSettingDef>;
@@ -184,6 +185,7 @@ export type PluginSettingDef = (
     | PluginSettingSliderDef
     | PluginSettingComponentDef
     | PluginSettingBigIntDef
+    | PluginSettingArrayDef
 ) & PluginSettingCommon;
 
 export interface PluginSettingCommon {
@@ -238,10 +240,16 @@ export interface PluginSettingSelectDef {
     type: OptionType.SELECT;
     options: readonly PluginSettingSelectOption[];
 }
+
 export interface PluginSettingSelectOption {
     label: string;
     value: string | number | boolean;
     default?: boolean;
+}
+
+export interface PluginSettingArrayDef {
+    type: OptionType.ARRAY;
+    default?: any[];
 }
 
 export interface PluginSettingSliderDef {
@@ -293,7 +301,9 @@ type PluginSettingType<O extends PluginSettingDef> = O extends PluginSettingStri
     O extends PluginSettingSelectDef ? O["options"][number]["value"] :
     O extends PluginSettingSliderDef ? number :
     O extends PluginSettingComponentDef ? any :
+    O extends PluginSettingArrayDef ? O["default"] extends any[] ? O["default"] : any[] :
     never;
+
 type PluginSettingDefaultType<O extends PluginSettingDef> = O extends PluginSettingSelectDef ? (
     O["options"] extends { default?: boolean; }[] ? O["options"][number]["value"] : undefined
 ) : O extends { default: infer T; } ? T : undefined;
@@ -345,13 +355,15 @@ export type PluginOptionsItem =
     | PluginOptionBoolean
     | PluginOptionSelect
     | PluginOptionSlider
-    | PluginOptionComponent;
+    | PluginOptionComponent
+    | PluginOptionArray;
 export type PluginOptionString = PluginSettingStringDef & PluginSettingCommon & IsDisabled & IsValid<string>;
 export type PluginOptionNumber = (PluginSettingNumberDef | PluginSettingBigIntDef) & PluginSettingCommon & IsDisabled & IsValid<number | BigInt>;
 export type PluginOptionBoolean = PluginSettingBooleanDef & PluginSettingCommon & IsDisabled & IsValid<boolean>;
 export type PluginOptionSelect = PluginSettingSelectDef & PluginSettingCommon & IsDisabled & IsValid<PluginSettingSelectOption>;
 export type PluginOptionSlider = PluginSettingSliderDef & PluginSettingCommon & IsDisabled & IsValid<number>;
 export type PluginOptionComponent = PluginSettingComponentDef & PluginSettingCommon;
+export type PluginOptionArray = PluginSettingArrayDef & PluginSettingCommon;
 
 export type PluginNative<PluginExports extends Record<string, (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any>> = {
     [key in keyof PluginExports]:

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -250,6 +250,8 @@ export interface PluginSettingSelectOption {
 export interface PluginSettingArrayDef {
     type: OptionType.ARRAY;
     default?: any[];
+    // TODO: Remove this once Array settings have an UI implementation
+    hidden: true;
 }
 
 export interface PluginSettingSliderDef {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -177,7 +177,7 @@ export type SettingsChecks<D extends SettingsDefinition> = {
     (IsDisabled<DefinedSettings<D>> & IsValid<PluginSettingType<D[K]>, DefinedSettings<D>>);
 };
 
-export type PluginSettingDef = ((
+export type PluginSettingDef = PluginSettingCustomDef | ((
     | PluginSettingStringDef
     | PluginSettingNumberDef
     | PluginSettingBooleanDef
@@ -185,7 +185,7 @@ export type PluginSettingDef = ((
     | PluginSettingSliderDef
     | PluginSettingComponentDef
     | PluginSettingBigIntDef
-) & PluginSettingCommon) | (PluginSettingCustomDef & Partial<PluginSettingCommon>);
+) & PluginSettingCommon);
 
 export interface PluginSettingCommon {
     description: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -177,7 +177,7 @@ export type SettingsChecks<D extends SettingsDefinition> = {
     (IsDisabled<DefinedSettings<D>> & IsValid<PluginSettingType<D[K]>, DefinedSettings<D>>);
 };
 
-export type PluginSettingDef = PluginSettingCustomDef | ((
+export type PluginSettingDef = (PluginSettingCustomDef & Pick<PluginSettingCommon, "onChange">) | ((
     | PluginSettingStringDef
     | PluginSettingNumberDef
     | PluginSettingBooleanDef
@@ -362,7 +362,7 @@ export type PluginOptionBoolean = PluginSettingBooleanDef & PluginSettingCommon 
 export type PluginOptionSelect = PluginSettingSelectDef & PluginSettingCommon & IsDisabled & IsValid<PluginSettingSelectOption>;
 export type PluginOptionSlider = PluginSettingSliderDef & PluginSettingCommon & IsDisabled & IsValid<number>;
 export type PluginOptionComponent = PluginSettingComponentDef & PluginSettingCommon;
-export type PluginOptionCustom = PluginSettingCustomDef;
+export type PluginOptionCustom = PluginSettingCustomDef & Pick<PluginSettingCommon, "onChange">;
 
 export type PluginNative<PluginExports extends Record<string, (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any>> = {
     [key in keyof PluginExports]:

--- a/src/webpack/common/types/components.d.ts
+++ b/src/webpack/common/types/components.d.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import type { ComponentType, CSSProperties, FunctionComponent, HtmlHTMLAttributes, HTMLProps, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
+import type { ComponentPropsWithRef, ComponentType, CSSProperties, FunctionComponent, HtmlHTMLAttributes, HTMLProps, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
 
 import { IconNames } from "./iconNames";
 
@@ -471,15 +471,7 @@ export type ScrollerThin = ComponentType<PropsWithChildren<{
     onScroll?(): void;
 }>>;
 
-export type Clickable = ComponentType<PropsWithChildren<{
-    className?: string;
-
-    href?: string;
-    ignoreKeyPress?: boolean;
-
-    onClick?(): void;
-    onKeyPress?(): void;
-}>>;
+export type Clickable = ComponentType<PropsWithChildren<ComponentPropsWithRef<"div">>>;
 
 export type Avatar = ComponentType<PropsWithChildren<{
     className?: string;

--- a/src/webpack/common/types/components.d.ts
+++ b/src/webpack/common/types/components.d.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import type { ComponentPropsWithRef, ComponentType, CSSProperties, ElementType, FunctionComponent, HtmlHTMLAttributes, HTMLProps, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
+import type { ComponentType, CSSProperties, FunctionComponent, HtmlHTMLAttributes, HTMLProps, JSX, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
 
 import { IconNames } from "./iconNames";
 
@@ -471,9 +471,9 @@ export type ScrollerThin = ComponentType<PropsWithChildren<{
     onScroll?(): void;
 }>>;
 
-export type Clickable<T extends ElementType = "div"> = ComponentType<PropsWithChildren<ComponentPropsWithRef<T>> & {
+export type Clickable = <T extends keyof JSX.IntrinsicElements = "div">(props: PropsWithChildren<JSX.IntrinsicElements[T]> & {
     tag?: T;
-}>;
+}) => ReactNode;
 
 export type Avatar = ComponentType<PropsWithChildren<{
     className?: string;

--- a/src/webpack/common/types/components.d.ts
+++ b/src/webpack/common/types/components.d.ts
@@ -471,7 +471,7 @@ export type ScrollerThin = ComponentType<PropsWithChildren<{
     onScroll?(): void;
 }>>;
 
-export type Clickable = <T extends keyof JSX.IntrinsicElements = "div">(props: PropsWithChildren<JSX.IntrinsicElements[T]> & {
+export type Clickable = <T extends "a" | "div" | "span" | "li" = "div">(props: PropsWithChildren<JSX.IntrinsicElements[T]> & {
     tag?: T;
 }) => ReactNode;
 

--- a/src/webpack/common/types/components.d.ts
+++ b/src/webpack/common/types/components.d.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import type { ComponentPropsWithRef, ComponentType, CSSProperties, FunctionComponent, HtmlHTMLAttributes, HTMLProps, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
+import type { ComponentPropsWithRef, ComponentType, CSSProperties, ElementType, FunctionComponent, HtmlHTMLAttributes, HTMLProps, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
 
 import { IconNames } from "./iconNames";
 
@@ -471,7 +471,9 @@ export type ScrollerThin = ComponentType<PropsWithChildren<{
     onScroll?(): void;
 }>>;
 
-export type Clickable = ComponentType<PropsWithChildren<ComponentPropsWithRef<"div">>>;
+export type Clickable<T extends ElementType = "div"> = ComponentType<PropsWithChildren<ComponentPropsWithRef<T>> & {
+    tag?: T;
+}>;
 
 export type Avatar = ComponentType<PropsWithChildren<{
     className?: string;

--- a/src/webpack/common/types/components.d.ts
+++ b/src/webpack/common/types/components.d.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import type { ComponentType, CSSProperties, FunctionComponent, HtmlHTMLAttributes, HTMLProps, JSX, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
+import type { ComponentPropsWithRef, ComponentType, CSSProperties, FunctionComponent, HtmlHTMLAttributes, HTMLProps, JSX, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
 
 import { IconNames } from "./iconNames";
 
@@ -471,7 +471,7 @@ export type ScrollerThin = ComponentType<PropsWithChildren<{
     onScroll?(): void;
 }>>;
 
-export type Clickable = <T extends "a" | "div" | "span" | "li" = "div">(props: PropsWithChildren<JSX.IntrinsicElements[T]> & {
+export type Clickable = <T extends "a" | "div" | "span" | "li" = "div">(props: PropsWithChildren<ComponentPropsWithRef<T>> & {
     tag?: T;
 }) => ReactNode;
 


### PR DESCRIPTION
Adds support for using objects/array settings which sync whenever they are modified, however they have no UI implementation and are always hidden.

This should be used for saving data which is handled by its own UI, like PinDMs. The difference of using this from DataStore is that the data gets cloud synced.