### PR TITLE
Fix top level settings notifying global listeners

### DIFF
--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -169,6 +169,7 @@ export class SettingsStore<T extends object> {
             this.pathListeners.get(settingPathStr)?.forEach(cb => cb(settingValue));
         }
 
+        this.globalListeners.forEach(cb => cb(root, pathStr));
         this.pathListeners.get(pathStr)?.forEach(cb => cb(value));
     }
 

--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -167,9 +167,10 @@ export class SettingsStore<T extends object> {
 
             this.globalListeners.forEach(cb => cb(root, settingPathStr));
             this.pathListeners.get(settingPathStr)?.forEach(cb => cb(settingValue));
+        } else {
+            this.globalListeners.forEach(cb => cb(root, pathStr));
         }
 
-        this.globalListeners.forEach(cb => cb(root, pathStr));
         this.pathListeners.get(pathStr)?.forEach(cb => cb(value));
     }
 


### PR DESCRIPTION
Fix the settings in the Vencord tab not notifying listeners, so switches don't work and changes aren't saved

![9xllw](https://github.com/user-attachments/assets/173b6090-4705-4854-86ad-cc3ca815b2d8)
