### PR TITLE
moreUserTags: attempt to rewrite

### DIFF
--- a/src/plugins/moreUserTags/consts.ts
+++ b/src/plugins/moreUserTags/consts.ts
@@ -1,0 +1,56 @@
+import { RC } from "@webpack/types";
+import type { ITag } from "./types";
+import { findByCodeLazy, findLazy } from "@webpack";
+import { GuildStore } from "@webpack/common";
+import { Channel, Guild, Message, User } from "discord-types/general";
+
+export const isWebhook = (message: Message, user: User) => !!message?.webhookId && user.isNonUserBot();
+export const tags: ITag[] = [
+    {
+        name: "WEBHOOK",
+        displayName: "Webhook",
+        description: "Messages sent by webhooks",
+        condition: isWebhook
+    }, {
+        name: "OWNER",
+        displayName: "Owner",
+        description: "Owns the server",
+        condition: (_, user, channel) => GuildStore.getGuild(channel?.guild_id)?.ownerId === user.id
+    }, {
+        name: "ADMINISTRATOR",
+        displayName: "Admin",
+        description: "Has the administrator permission",
+        permissions: ["ADMINISTRATOR"]
+    }, {
+        name: "MODERATOR_STAFF",
+        displayName: "Staff",
+        description: "Can manage the server, channels or roles",
+        permissions: ["MANAGE_GUILD", "MANAGE_CHANNELS", "MANAGE_ROLES"]
+    }, {
+        name: "MODERATOR",
+        displayName: "Mod",
+        description: "Can manage messages or kick/ban people",
+        permissions: ["MANAGE_MESSAGES", "KICK_MEMBERS", "BAN_MEMBERS"]
+    }, {
+        name: "VOICE_MODERATOR",
+        displayName: "VC Mod",
+        description: "Can manage voice chats",
+        permissions: ["MOVE_MEMBERS", "MUTE_MEMBERS", "DEAFEN_MEMBERS"]
+    }, {
+        name: "CHAT_MODERATOR",
+        displayName: "Chat Mod",
+        description: "Can timeout people",
+        permissions: ["MODERATE_MEMBERS"]
+    }
+];
+
+export const Tag = findLazy(m => m.Types?.[0] === "BOT") as RC<{ type?: number, className?: string, useRemSizes?: boolean; }> & { Types: Record<string, number>; };
+
+// PermissionStore.computePermissions will not work here since it only gets permissions for the current user
+export const computePermissions: (options: {
+    user?: { id: string; } | string | null;
+    context?: Guild | Channel | null;
+    overwrites?: Channel["permissionOverwrites"] | null;
+    checkElevated?: boolean /* = true */;
+    excludeGuildPermissions?: boolean /* = false */;
+}) => bigint = findByCodeLazy(".getCurrentUser()", ".computeLurkerPermissionsAllowList()");

--- a/src/plugins/moreUserTags/index.tsx
+++ b/src/plugins/moreUserTags/index.tsx
@@ -1,0 +1,147 @@
+import definePlugin from "@utils/types";
+import { Devs } from "@utils/constants";
+import { settings } from './settings';
+import { computePermissions, isWebhook, Tag, tags } from "./consts";
+import { getIntlMessage } from "@utils/discord";
+import { ChannelStore, GuildStore, PermissionsBits } from "@webpack/common";
+import { Channel, Message, User } from "discord-types/general";
+import { tag } from "type-fest/source/opaque";
+
+
+export default definePlugin({
+    name: "MoreUserTags",
+    description: "Adds tags for webhooks and moderative roles (owner, admin, etc.)",
+    authors: [Devs.Cyn, Devs.TheSun, Devs.RyanCaoDev, Devs.LordElias, Devs.AutumnVN],
+    settings,
+    patches: [
+        // Add tags
+        {
+            find: '.ORIGINAL_POSTER=',
+            replacement: {
+                match: /function\(\i\){(?=.{1,30}.BOT)/,
+                replace: "$&$self.genTagTypes(arguments[0]);"
+            }
+        },
+        // Render Tags in messages
+        {
+            find: '.Types.ORIGINAL_POSTER',
+            replacement: {
+                match: /(?<=let (\i).{1,200}children:\i}=\i;.{0,100}.isSystemDM.{0,350}),null==\i\)(?=.{1,30}?null:)/,
+                replace: ',($1=$self.getTag({...arguments[0],location:"chat",origType:$1}))$&'
+            }
+        },
+        {
+            find: '.STAFF_ONLY_DM:',
+            replacement: {
+                match: /(?<=type:(\i).{10,1000}.REMIX.{10,100})default:(\i)=/,
+                replace: "default:$2=$self.tagObj[$1];"
+            }
+        }
+    ],
+    tagObj: {},
+
+    genTagTypes(obj) {
+        let i = 100;
+
+        for (const { name } of tags) {
+            obj[name] = ++i;
+            obj[i] = name;
+            obj[`${name}-BOT`] = ++i;
+            obj[i] = `${name}-BOT`;
+            obj[`${name}-OP`] = ++i;
+            obj[i] = `${name}-OP`;
+        }
+
+        this.tagObj = obj;
+    },
+
+    getTagText(passedTagName: string, originalText: string) {
+        try {
+            if (!passedTagName) return getIntlMessage("APP_TAG");
+            const [tagName, variant] = passedTagName.split("-");
+
+            const tag = tags.find(({ name }) => tagName === name);
+            if (!tag) return getIntlMessage("APP_TAG");
+
+            if (variant === "BOT" && tagName !== "WEBHOOK" && this.settings.store.dontShowForBots) return getIntlMessage("APP_TAG");
+
+            const tagText = settings.store.tagSettings?.[tag.name]?.text || tag.displayName;
+            switch (variant) {
+                case "OP":
+                    return `${getIntlMessage("BOT_TAG_FORUM_ORIGINAL_POSTER")} • ${tagText}`;
+                case "BOT":
+                    return `${getIntlMessage("APP_TAG")} • ${tagText}`;
+                default:
+                    return tagText;
+            }
+        } catch {
+            return originalText;
+        }
+    },
+
+    getTag({
+        message, user, channelId, origType, location, channel
+    }: {
+        message?: Message,
+        user: User & { isClyde(): boolean; },
+        channel?: Channel & { isForumPost(): boolean; isMediaPost(): boolean; },
+        channelId?: string;
+        origType?: number;
+        location: "chat" | "not-chat";
+    }): number | null {
+        if (!user)
+            return null;
+        if (location === "chat" && user.id === "1")
+            return Tag.Types.OFFICIAL;
+        if (user.isClyde())
+            return Tag.Types.AI;
+
+        let type = typeof origType === "number" ? origType : null;
+
+        channel ??= ChannelStore.getChannel(channelId!) as any;
+        if (!channel) return type;
+
+        const settings = this.settings.store;
+        const perms = this.getPermissions(user, channel);
+
+        for (const tag of tags) {
+            if (location === "chat" && !settings.tagSettings[tag.name].showInChat) continue;
+            if (location === "not-chat" && !settings.tagSettings[tag.name].showInNotChat) continue;
+
+            // If the owner tag is disabled, and the user is the owner of the guild,
+            // avoid adding other tags because the owner will always match the condition for them
+            if (
+                tag.name !== "OWNER" &&
+                GuildStore.getGuild(channel?.guild_id)?.ownerId === user.id &&
+                (location === "chat" && !settings.tagSettings.OWNER.showInChat) ||
+                (location === "not-chat" && !settings.tagSettings.OWNER.showInNotChat)
+            ) continue;
+
+            if (
+                tag.permissions?.some(perm => perms.includes(perm)) ||
+                (tag.condition?.(message!, user, channel))
+            ) {
+                if ((channel.isForumPost() || channel.isMediaPost()) && channel.ownerId === user.id)
+                    type = Tag.Types[`${tag.name}-OP`];
+                else if (user.bot && !isWebhook(message!, user) && !settings.dontShowBotTag)
+                    type = Tag.Types[`${tag.name}-BOT`];
+                else
+                    type = Tag.Types[tag.name];
+                break;
+            }
+        }
+        return type;
+    },
+    getPermissions(user: User, channel: Channel): string[] {
+        const guild = GuildStore.getGuild(channel?.guild_id);
+        if (!guild) return [];
+
+        const permissions = computePermissions({ user, context: guild, overwrites: channel.permissionOverwrites });
+        return Object.entries(PermissionsBits)
+            .map(([perm, permInt]) =>
+                permissions & permInt ? perm : ""
+            )
+            .filter(Boolean);
+    },
+});
+

--- a/src/plugins/moreUserTags/settings.tsx
+++ b/src/plugins/moreUserTags/settings.tsx
@@ -1,0 +1,76 @@
+import { definePluginSettings } from "@api/Settings";
+import { Margins } from "@utils/margins";
+import { OptionType } from "@utils/types";
+import { Card, Flex, Forms, Switch, TextInput, Tooltip } from "@webpack/common";
+import { TagSettings } from "./types";
+import { Tag, tags } from "./consts";
+
+
+const defaultSettings = Object.fromEntries(
+    tags.map(({ name, displayName }) => [name, { text: displayName, showInChat: true, showInNotChat: true }])
+) as TagSettings;
+
+function SettingsComponent() {
+    const tagSettings = settings.store.tagSettings ??= defaultSettings;
+
+    return (
+        <Flex flexDirection="column">
+            {tags.map(t => (
+                <Card key={t.name} style={{ padding: "1em 1em 0" }}>
+                    <Forms.FormTitle style={{ width: "fit-content" }}>
+                        <Tooltip text={t.description}>
+                            {({ onMouseEnter, onMouseLeave }) => (
+                                <div
+                                    onMouseEnter={onMouseEnter}
+                                    onMouseLeave={onMouseLeave}
+                                >
+                                    {t.displayName} Tag <Tag type={Tag.Types[t.name]} />
+                                </div>
+                            )}
+                        </Tooltip>
+                    </Forms.FormTitle>
+
+                    <TextInput
+                        type="text"
+                        value={tagSettings[t.name]?.text ?? t.displayName}
+                        placeholder={`Text on tag (default: ${t.displayName})`}
+                        onChange={v => tagSettings[t.name].text = v}
+                        className={Margins.bottom16}
+                    />
+
+                    <Switch
+                        value={tagSettings[t.name]?.showInChat ?? true}
+                        onChange={v => tagSettings[t.name].showInChat = v}
+                        hideBorder
+                    >
+                        Show in messages
+                    </Switch>
+
+                    <Switch
+                        value={tagSettings[t.name]?.showInNotChat ?? true}
+                        onChange={v => tagSettings[t.name].showInNotChat = v}
+                        hideBorder
+                    >
+                        Show in member list and profiles
+                    </Switch>
+                </Card>
+            ))}
+        </Flex>
+    );
+}
+
+export const settings = definePluginSettings({
+    dontShowForBots: {
+        description: "Don't show extra tags for bots (excluding webhooks)",
+        type: OptionType.BOOLEAN
+    },
+    dontShowBotTag: {
+        description: "Only show extra tags for bots / Hide [BOT] text",
+        type: OptionType.BOOLEAN
+    },
+    tagSettings: {
+        type: OptionType.COMPONENT,
+        component: SettingsComponent,
+        description: "fill me"
+    }
+});

--- a/src/plugins/moreUserTags/types.ts
+++ b/src/plugins/moreUserTags/types.ts
@@ -1,0 +1,28 @@
+import type { Channel, Message, User } from "discord-types/general";
+import type { Permissions } from "@webpack/types";
+
+export interface ITag {
+    // name used for identifying, must be alphanumeric + underscores
+    name: string;
+    // name shown on the tag itself, can be anything probably; automatically uppercase'd
+    displayName: string;
+    description: string;
+    permissions?: Permissions[];
+    condition?(message: Message | null, user: User, channel: Channel): boolean;
+}
+
+export interface TagSetting {
+    text: string;
+    showInChat: boolean;
+    showInNotChat: boolean;
+}
+export interface TagSettings {
+    WEBHOOK: TagSetting,
+    OWNER: TagSetting,
+    ADMINISTRATOR: TagSetting,
+    MODERATOR_STAFF: TagSetting,
+    MODERATOR: TagSetting,
+    VOICE_MODERATOR: TagSetting,
+    TRIAL_MODERATOR: TagSetting,
+    [k: string]: TagSetting;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    hen: {
+        id: 279266228151779329n,
+        name: "Hen"
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Reason:
![image](https://github.com/user-attachments/assets/952d9256-70ba-4414-926a-17211e0eafaf)

While discord hasn't pushed to stable i'm trying to rewrite patches, so they work both on canary and stable

Currently I've got tags working in messages:
![image](https://github.com/user-attachments/assets/57696071-8a31-4de5-aaf3-e5ea12b8a0d2)