### PR TITLE
Reverse dm check condition in QuickReply plugin

### DIFF
--- a/src/plugins/quickReply/index.ts
+++ b/src/plugins/quickReply/index.ts
@@ -196,7 +196,7 @@ function nextReply(isUp: boolean) {
         channel,
         message,
         shouldMention: shouldMention(message),
-        showMentionToggle: channel.isPrivate() && message.author.id !== meId,
+        showMentionToggle: !channel.isPrivate() && message.author.id !== meId,
         _isQuickReply: true
     });
     ComponentDispatch.dispatchToLastSubscribed("TEXTAREA_FOCUS");


### PR DESCRIPTION
Yeah turns out this is backwards, currently the code checked if it was in a private channel, which in servers is false, so it never shows up.

This is backwards to discords behaviour, and this change makes the dm toggle appear in servers (and not in dms instead).