### PR TITLE
New plugin: Keybinds

### DIFF
--- a/src/plugins/index.tsx
+++ b/src/plugins/index.tsx
@@ -1,0 +1,77 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import definePlugin, { OptionType } from "@utils/types";
+
+import { keybinds } from "./components/keybinds";
+import { SettingsView } from "./components/SettingsView";
+
+const defaultSettings = {};
+for (const keybind in keybinds) {
+    defaultSettings[keybind] = {
+        type: OptionType.CUSTOM,
+        default: keybinds[keybind].default,
+    };
+}
+
+const settings = definePluginSettings({
+    keybinds: {
+        type: OptionType.COMPONENT,
+        component: () => {
+            return (
+                <SettingsView settings={settings} />
+            );
+        }
+    },
+    ...defaultSettings,
+});
+
+export default definePlugin({
+    name: "Keybinds",
+    description: "Bind keys to commands.",
+    authors: [
+        {
+            name: "Ryfter",
+            id: 0n,
+        }
+    ],
+    settings,
+    start() {
+        document.addEventListener("keydown", this.event);
+    },
+    stop() {
+        document.removeEventListener("keydown", this.event);
+    },
+    event(e: KeyboardEvent) {
+        for (const keybind in keybinds) {
+            const {
+                enabled,
+                key,
+                ctrl,
+                alt,
+                shift,
+            } = settings.store[keybind];
+            const str: string = "e";
+            if (
+                enabled &&
+                alt === e.altKey &&
+                ctrl === e.ctrlKey &&
+                shift === e.shiftKey &&
+                key.toUpperCase() === e.key
+            ) keybinds[keybind].action();
+            console.log(keybinds[keybind]);
+        }
+    },
+});
+
+


### PR DESCRIPTION
A unified plugin to regroup most of the single use plugins, such as F8Break. 
 - Settings to change each plugin's keybind easily
 - Easy to add a keybind, eg: Add this to the keybinds.tsx file.
 ```tsx
    restart: {
        name: "Restart",
        desc: "Restarts your discord client",
        default: {
            enabled: false,
            key: "R",
            ctrl: true,
            shift: true,
            alt: false,
        },
        action: () => {
            relaunch();
        }
    }
```
### TODO:
- Add more keybinds, suggest some here
- Allow config directly from client (Optional, if there is demand)
