### PR TITLE
New Plugin: NoJoinPermission

### DIFF
--- a/src/plugins/noJoinPermission/index.ts
+++ b/src/plugins/noJoinPermission/index.ts
@@ -15,8 +15,8 @@ export default definePlugin({
         {
             find: "No integration type was selected.",
             replacement: {
-                match: /(.includes\(\i\)\);)(return{requestedScopes:\i,accountScopes:\i})/,
-                replace: "$1$self.handleScopes(t, n);$2"
+                match: /(.includes\(\i\)\);)(return{requestedScopes:(\i),accountScopes:(\i)})/,
+                replace: "$1$self.handleScopes($3, $4);$2"
             }
         }
     ],

--- a/src/plugins/noJoinPermission/index.ts
+++ b/src/plugins/noJoinPermission/index.ts
@@ -1,0 +1,39 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NoJoinPermission",
+    description: "Removes the annoying 'Join Servers For You' scope from all authorization links (May cause some apps to break)",
+    authors: [Devs.Pixeluted],
+    patches: [
+        {
+            find: "No integration type was selected.",
+            replacement: {
+                match: /(.includes\(\i\)\);)(return{requestedScopes:\i,accountScopes:\i})/,
+                replace: "$1$self.handleScopes(t, n);$2"
+            }
+        }
+    ],
+
+    handleScopes(requestedScopes, accountScopes) {
+        for (let i = requestedScopes.length - 1; i >= 0; i--) {
+            const scopeName = requestedScopes[i];
+            if (scopeName === "guilds.join") {
+                requestedScopes.splice(i, 1);
+            }
+        }
+
+        for (let i = accountScopes.length - 1; i >= 0; i--) {
+            const scopeName = accountScopes[i];
+            if (scopeName === "guilds.join") {
+                accountScopes.splice(i, 1);
+            }
+        }
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    Pixeluted: {
+        name: "Pixeluted",
+        id: 1057760003701882890n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This plugins automatically detects the 'Join Servers For You' scope in all authorization links you click in your desktop client and strips it out. Effectively not granting that scope to the application.

This plugin can break some apps if they check the scopes you granted them, but that can be easily fixable by just disabling the plugin for little while.

Here is little showcase how it works:
https://github.com/user-attachments/assets/b21965f1-4e9d-4e1a-b1ef-bd413f0c52ef

