### PR TITLE
feat(translate): preserve emojis and add original text option

### DIFF
--- a/src/plugins/translate/settings.ts
+++ b/src/plugins/translate/settings.ts
@@ -78,6 +78,11 @@ export const settings = definePluginSettings({
         description: "Show a tooltip on the ChatBar button whenever a message is automatically translated",
         default: true
     },
+    includeOriginalText: {
+        type: OptionType.BOOLEAN,
+        description: "Include the original message content in the translated message",
+        default: false
+    }
 }).withPrivateSettings<{
     showAutoTranslateAlert: boolean;
 }>();


### PR DESCRIPTION
Hey team! 👋  

This PR fixes an issue where the auto-translate plugin was trying to translate emojis and adds a new option to include the original text in the translated message.

#### **What's New?**
1. **Emojis Are Safe Now**
   - The plugin no longer tries to translate emojis (which was breaking things).  
   - Emojis stay exactly where they should be in the message.  

2. **New Setting: Include Original Text**
   - Added a toggle to optionally show the original message below the translation.  
   - Perfect for when you want to double-check the translation!

#### **What Was Fixed?**
Before, if a message had emojis, the plugin would freak out and break. For example:
- **Input**: `Hello <:smile:123456789> world!`  
- **Broken Output**: The translation would fail or look weird because of the emoji.

Now, it works like a charm:
- **Input**: `Hello <:smile:123456789> world!`  
- **Fixed Output**: `Hola <:smile:123456789> mundo!`  

#### **Examples**
Here are some examples to show how it works now:
1. **Simple Message with Emoji**:
   - **Input**: `Hello <:smile:123456789> world!`  
   - **Output**: `Hola <:smile:123456789> mundo!`  

2. **Message with Multiple Emojis**:
   - **Input**: `Hello <:smile:123456789> world! <:wave:987654321> How are you?`  
   - **Output**: `Hola <:smile:123456789> mundo! <:wave:987654321> ¿Cómo estás?`  

3. **With Original Text Enabled**:
   - **Input**: `Hello <:smile:123456789> world!`  
   - **Output**:
     ```
     Hola <:smile:123456789> mundo!
     -# Hello <:smile:123456789> world!
     ```

#### **Why This Matters**
This makes the plugin way more reliable and user-friendly. No more broken messages because of emojis, and the new setting gives users more control over how translations are displayed. Win-win!

---

### **Testing**
I tested it with:
- Messages with emojis at the start, middle, and end.
- Messages with no emojis.
- The new `includeOriginalText` setting.

Everything works as expected!