### PR TITLE
New Plugin: Message Jumper

### DIFF
--- a/src/plugins/messageJumper/index.ts
+++ b/src/plugins/messageJumper/index.ts
@@ -1,0 +1,108 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { ChannelRouter, ChannelStore, SelectedChannelStore } from "@webpack/common";
+import { Message } from "discord-types/general";
+
+interface IMessageCreate {
+    type: "MESSAGE_CREATE";
+    optimistic: boolean;
+    isPushNotification: boolean;
+    channelId: string;
+    message: Message;
+}
+
+
+const settings = definePluginSettings({
+    whitelistedServers: {
+        type: OptionType.SELECT,
+        description: "Whether to use ID list as blacklist or whitelist",
+        options: [
+            {
+                label: "Blacklist",
+                value: "blacklist",
+                default: true
+            },
+            {
+                label: "Whitelist",
+                value: "whitelist"
+            }
+        ],
+        default: "Blacklist"
+    },
+    servers: {
+        type: OptionType.STRING,
+        description: "Blacklisted/Whitelisted server ids, separated by commas",
+        default: "",
+    },
+    whitelistedChannels: {
+        type: OptionType.SELECT,
+        description: "Whether to use ID list as blacklist or whitelist",
+        options: [
+            {
+                label: "Blacklist",
+                value: "blacklist",
+                default: true
+            },
+            {
+                label: "Whitelist",
+                value: "whitelist"
+            }
+        ],
+        default: "Blacklist"
+    },
+    channels: {
+        type: OptionType.STRING,
+        description: "Blacklisted/Whitelisted channel ids, separated by commas",
+        default: "",
+    },
+});
+
+export default definePlugin({
+    name: "MessageJumper",
+    description: "Auto jumps to channels with new messages",
+    authors: [Devs.may2bee],
+    settings,
+
+    flux: {
+        async MESSAGE_CREATE({ optimistic, type, message, channelId }: IMessageCreate) {
+            if (optimistic || type !== "MESSAGE_CREATE") return;
+            if (SelectedChannelStore.getChannelId() === channelId) return;
+            const channel = ChannelStore.getChannel(channelId);
+            if (ChannelStore.getChannel(SelectedChannelStore.getChannelId())?.guild_id !== channel.guild_id) return;
+            if (document.hasFocus()) return;
+
+            const { whitelistedServers, servers, whitelistedChannels, channels } = settings.store;
+
+            const serverIds = servers.split(",").map(id => id.trim());
+            if (whitelistedServers === "whitelist") {
+                if (!serverIds.includes(channel.guild_id)) {
+                    return;
+                }
+            } else {
+                if (serverIds.includes(channel.guild_id)) {
+                    return;
+                }
+            }
+
+            const channelIds = channels!!.split(",").map(id => id.trim());
+            if (whitelistedChannels === "whitelist") {
+                if (!channelIds.includes(channelId)) {
+                    return;
+                }
+            } else {
+                if (channelIds.includes(channelId)) {
+                    return;
+                }
+            }
+
+            ChannelRouter.transitionToChannel(channelId);
+        },
+    }
+});

--- a/src/plugins/messageJumper/index.ts
+++ b/src/plugins/messageJumper/index.ts
@@ -75,7 +75,6 @@ export default definePlugin({
             if (optimistic || type !== "MESSAGE_CREATE") return;
             if (SelectedChannelStore.getChannelId() === channelId) return;
             const channel = ChannelStore.getChannel(channelId);
-            if (ChannelStore.getChannel(SelectedChannelStore.getChannelId())?.guild_id !== channel.guild_id) return;
             if (document.hasFocus()) return;
 
             const { whitelistedServers, servers, whitelistedChannels, channels } = settings.store;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -579,6 +579,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "jamesbt365",
         id: 158567567487795200n,
     },
+    may2bee: {
+        name: "May2Bee",
+        id: 174929158294470656n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This plugin jumps into the channels that contains new messages, if your discord is not focused.
Convenient for people, that have Discord on second monitor and still want to read all the messages.
Plugin contains whitelist and blacklist for certain servers and channels.