### PR TITLE
WebpackPatcher: Use way less closures

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,7 +134,7 @@ export default tseslint.config(
             "no-unsafe-optional-chaining": "error",
             "no-useless-backreference": "error",
             "use-isnan": "error",
-            "prefer-const": "error",
+            "prefer-const": ["error", { destructuring: "all" }],
             "prefer-spread": "error",
 
             // Plugin Rules

--- a/scripts/generateReport.ts
+++ b/scripts/generateReport.ts
@@ -16,11 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-/* eslint-disable no-fallthrough */
-
-// eslint-disable-next-line spaced-comment
 /// <reference types="../src/globals" />
-// eslint-disable-next-line spaced-comment
 /// <reference types="../src/modules" />
 
 import { createHmac } from "crypto";

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -140,8 +140,8 @@ export async function loadLazyChunks() {
         }
 
         Webpack.factoryListeners.add(factoryListener);
-        for (const factoryId in wreq.m) {
-            factoryListener(factoryId, wreq.m[factoryId]);
+        for (const moduleId in wreq.m) {
+            factoryListener(moduleId, wreq.m[moduleId]);
         }
 
         await chunksSearchingDone;

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -8,7 +8,7 @@ import { Logger } from "@utils/Logger";
 import { canonicalizeMatch } from "@utils/patches";
 import * as Webpack from "@webpack";
 import { wreq } from "@webpack";
-import { AnyModuleFactory, ModuleFactory } from "webpack";
+import { AnyModuleFactory, ModuleFactory } from "@webpack/wreq.d";
 
 export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -130,7 +130,7 @@ export async function loadLazyChunks() {
             }, 0);
         }
 
-        function factoryListener(_moduleId: PropertyKey, factory: AnyModuleFactory | ModuleFactory) {
+        function factoryListener(factory: AnyModuleFactory | ModuleFactory) {
             let isResolved = false;
             searchAndLoadLazyChunks(String(factory))
                 .then(() => isResolved = true)
@@ -141,7 +141,7 @@ export async function loadLazyChunks() {
 
         Webpack.factoryListeners.add(factoryListener);
         for (const moduleId in wreq.m) {
-            factoryListener(moduleId, wreq.m[moduleId]);
+            factoryListener(wreq.m[moduleId]);
         }
 
         await chunksSearchingDone;

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -130,7 +130,7 @@ export async function loadLazyChunks() {
             }, 0);
         }
 
-        function factoryListener(factory: AnyModuleFactory | ModuleFactory) {
+        function factoryListener(_moduleId: PropertyKey, factory: AnyModuleFactory | ModuleFactory) {
             let isResolved = false;
             searchAndLoadLazyChunks(String(factory))
                 .then(() => isResolved = true)
@@ -141,7 +141,7 @@ export async function loadLazyChunks() {
 
         Webpack.factoryListeners.add(factoryListener);
         for (const factoryId in wreq.m) {
-            factoryListener(wreq.m[factoryId]);
+            factoryListener(factoryId, wreq.m[factoryId]);
         }
 
         await chunksSearchingDone;

--- a/src/debug/runReporter.ts
+++ b/src/debug/runReporter.ts
@@ -6,9 +6,9 @@
 
 import { Logger } from "@utils/Logger";
 import * as Webpack from "@webpack";
-import { addPatch, patches } from "plugins";
-import { getBuildNumber } from "webpack/patchWebpack";
+import { getBuildNumber, patchTimings } from "@webpack/patcher";
 
+import { addPatch, patches } from "../plugins";
 import { loadLazyChunks } from "./loadLazyChunks";
 
 async function runReporter() {
@@ -51,7 +51,7 @@ async function runReporter() {
             }
         }
 
-        for (const [plugin, moduleId, match, totalTime] of Vencord.WebpackPatcher.patchTimings) {
+        for (const [plugin, moduleId, match, totalTime] of patchTimings) {
             if (totalTime > 5) {
                 new Logger("WebpackInterceptor").warn(`Patch by ${plugin} took ${Math.round(totalTime * 100) / 100}ms (Module id is ${String(moduleId)}): ${match}`);
             }

--- a/src/plugins/_core/noTrack.ts
+++ b/src/plugins/_core/noTrack.ts
@@ -20,7 +20,7 @@ import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType, StartAt } from "@utils/types";
-import { WebpackRequire } from "webpack";
+import { WebpackRequire } from "@webpack/wreq.d";
 
 const settings = definePluginSettings({
     disableAnalytics: {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -31,6 +31,7 @@ import { Logger } from "@utils/Logger";
 import { canonicalizeFind, canonicalizeReplacement } from "@utils/patches";
 import { Patch, Plugin, PluginDef, ReporterTestable, StartAt } from "@utils/types";
 import { FluxDispatcher } from "@webpack/common";
+import { patches } from "@webpack/patcher";
 import { FluxEvents } from "@webpack/types";
 
 import Plugins from "~plugins";
@@ -41,7 +42,7 @@ const logger = new Logger("PluginManager", "#a6d189");
 
 export const PMLogger = logger;
 export const plugins = Plugins;
-export const patches = [] as Patch[];
+export { patches };
 
 /** Whether we have subscribed to flux events of all the enabled plugins when FluxDispatcher was ready */
 let enabledPluginsSubscribedFlux = false;

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -61,7 +61,7 @@ export function getFactoryPatchedBy(moduleId: PropertyKey, webpackRequire = wreq
 
 const logger = new Logger("WebpackInterceptor", "#8caaee");
 
-/** Whether we tried to fallback to WebpackRequire of the factory, or disabled patches */
+/** Whether we tried to fallback to the WebpackRequire of the factory, or disabled patches */
 let wreqFallbackApplied = false;
 
 const define: typeof Reflect.defineProperty = (target, p, attributes) => {
@@ -81,9 +81,9 @@ const define: typeof Reflect.defineProperty = (target, p, attributes) => {
 
 // Factories can be patched in two ways. Eagerly or lazily.
 // If we are patching eagerly, pre-populated factories are patched immediately and new factories are patched when set.
-// Else, we only patch when they called.
+// Else, we only patch them when called.
 
-// Factories are always wrapped in a proxy, which allows us to intercept the call to them, patch if it wasnt eagerly patched,
+// Factories are always wrapped in a proxy, which allows us to intercept the call to them, patch if they werent eagerly patched,
 // and call them with our wrapper which notifies our listeners.
 
 // wreq.m is also wrapped in a proxy to intercept when new factories are set, patch them eargely, if enabled, and wrap them in the factory proxy.
@@ -153,7 +153,7 @@ define(Function.prototype, "m", {
     }
 });
 
-// The proxy for patching eagerly and/or wrapping factories in their proxy
+// The proxy for patching eagerly and/or wrapping factories in their proxy.
 const moduleFactoriesHandler: ProxyHandler<AnyWebpackRequire["m"]> = {
     /*
     If Webpack ever decides to set module factories using the variable of the modules object directly instead of wreq.m, we need to switch the proxy to the prototype
@@ -182,7 +182,7 @@ const moduleFactoriesHandler: ProxyHandler<AnyWebpackRequire["m"]> = {
     }
 };
 
-// The proxy for patching lazily and/or running factories with our wrapper
+// The proxy for patching lazily and/or running factories with our wrapper.
 const moduleFactoryHandler: ProxyHandler<MaybePatchedModuleFactory> = {
     apply(target, thisArg: unknown, argArray: Parameters<AnyModuleFactory>) {
         // SAFETY: Factories have `name` as their key in the module factories object, and that is always their module id
@@ -200,7 +200,7 @@ const moduleFactoryHandler: ProxyHandler<MaybePatchedModuleFactory> = {
     get(target, p, receiver) {
         const v = Reflect.get(target, p, receiver);
 
-        // Make proxied factories toString return their original factory toString
+        // Make proxied factories `toString` return their original factory `toString`
         if (p === "toString") {
             return (...args: unknown[]) => v.apply(target[SYM_ORIGINAL_FACTORY] ?? target, args);
         }
@@ -293,7 +293,7 @@ function runFactoryWithWrap(moduleId: PropertyKey, patchedFactory: PatchedModule
         delete patchedFactory[SYM_ORIGINAL_FACTORY];
     }
 
-    // Restore the original factory in all the module factories objects.
+    // Restore the original factory in all the module factories objects, discarding our proxy and allowing it to be garbage collected
     for (const wreq of Object.values(allWebpackInstances)) {
         define(wreq.m, moduleId, { value: originalFactory });
     }

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -206,7 +206,7 @@ const moduleFactoryHandler: ProxyHandler<MaybePatchedModuleFactory> = {
 
         // Make proxied factories `toString` return their original factory `toString`
         if (p === "toString") {
-            return (...args: unknown[]) => v.apply(target[SYM_ORIGINAL_FACTORY] ?? target, args);
+            return v.bind(target[SYM_ORIGINAL_FACTORY] ?? target);
         }
 
         return v;

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -198,6 +198,10 @@ const moduleFactoryHandler: ProxyHandler<MaybePatchedModuleFactory> = {
     },
 
     get(target, p, receiver) {
+        if (target[SYM_ORIGINAL_FACTORY] != null && (p === SYM_PATCHED_SOURCE || p === SYM_PATCHED_BY)) {
+            return Reflect.get(target[SYM_ORIGINAL_FACTORY], p, target[SYM_ORIGINAL_FACTORY]);
+        }
+
         const v = Reflect.get(target, p, receiver);
 
         // Make proxied factories `toString` return their original factory `toString`
@@ -538,8 +542,6 @@ function patchFactory(moduleId: PropertyKey, originalFactory: AnyModuleFactory):
     if (IS_DEV && patchedFactory !== originalFactory) {
         originalFactory[SYM_PATCHED_SOURCE] = patchedSource;
         originalFactory[SYM_PATCHED_BY] = patchedBy;
-        patchedFactory[SYM_PATCHED_SOURCE] = patchedSource;
-        patchedFactory[SYM_PATCHED_BY] = patchedBy;
     }
 
     return patchedFactory as PatchedModuleFactory;

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -18,7 +18,7 @@ import { AnyModuleFactory, AnyWebpackRequire, MaybePatchedModuleFactory, ModuleE
 export const SYM_ORIGINAL_FACTORY = Symbol("WebpackPatcher.originalFactory");
 export const SYM_PATCHED_SOURCE = Symbol("WebpackPatcher.patchedSource");
 export const SYM_PATCHED_BY = Symbol("WebpackPatcher.patchedBy");
-export const allWebpackInstances = new WeakSet<AnyWebpackRequire>();
+export const allWebpackInstances = new Set<AnyWebpackRequire>();
 
 export const patchTimings = [] as Array<[plugin: string, moduleId: PropertyKey, match: PatchReplacement["match"], totalTime: number]>;
 
@@ -222,7 +222,7 @@ const moduleFactoryHandler: ProxyHandler<MaybePatchedModuleFactory> = {
 function updateExistingFactory(moduleFactoriesTarget: AnyWebpackRequire["m"], moduleId: PropertyKey, newFactory: AnyModuleFactory, receiver: any, ignoreExistingInTarget: boolean = false) {
     let existingFactory: TypedPropertyDescriptor<AnyModuleFactory> | undefined;
     let moduleFactoriesWithFactory: AnyWebpackRequire["m"] | undefined;
-    for (const wreq of Object.values(allWebpackInstances)) {
+    for (const wreq of allWebpackInstances) {
         if (ignoreExistingInTarget && wreq.m === moduleFactoriesTarget) {
             continue;
         }
@@ -294,7 +294,7 @@ function runFactoryWithWrap(moduleId: PropertyKey, patchedFactory: PatchedModule
     }
 
     // Restore the original factory in all the module factories objects, discarding our proxy and allowing it to be garbage collected
-    for (const wreq of Object.values(allWebpackInstances)) {
+    for (const wreq of allWebpackInstances) {
         define(wreq.m, moduleId, { value: originalFactory });
     }
 

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -12,29 +12,18 @@ import { canonicalizeReplacement } from "@utils/patches";
 import { PatchReplacement } from "@utils/types";
 
 import { traceFunctionWithResults } from "../debug/Tracer";
-import { patches } from "../plugins";
-import { _initWebpack, _shouldIgnoreModule, AnyModuleFactory, AnyWebpackRequire, factoryListeners, findModuleId, MaybeWrappedModuleFactory, ModuleExports, moduleListeners, waitForSubscriptions, WebpackRequire, WrappedModuleFactory, wreq } from ".";
+import { _initWebpack, _shouldIgnoreModule, factoryListeners, findModuleId, moduleListeners, waitForSubscriptions, wreq } from "./webpack";
+import { AnyModuleFactory, AnyWebpackRequire, MaybePatchedModuleFactory, ModuleExports, PatchedModuleFactory, WebpackRequire } from "./wreq.d";
 
 export const SYM_ORIGINAL_FACTORY = Symbol("WebpackPatcher.originalFactory");
 export const SYM_PATCHED_SOURCE = Symbol("WebpackPatcher.patchedSource");
 export const SYM_PATCHED_BY = Symbol("WebpackPatcher.patchedBy");
-/** A set with all the Webpack instances */
 export const allWebpackInstances = new Set<AnyWebpackRequire>();
-export const patchTimings = [] as Array<[plugin: string, moduleId: PropertyKey, match: string | RegExp, totalTime: number]>;
 
-const logger = new Logger("WebpackInterceptor", "#8caaee");
-/** Whether we tried to fallback to factory WebpackRequire, or disabled patches */
-let wreqFallbackApplied = false;
-/** Whether we should be patching factories.
- *
- * This should be disabled if we start searching for the module to get the build number, and then resumed once it's done.
- * */
-let shouldPatchFactories = true;
+export const patchTimings = [] as Array<[plugin: string, moduleId: PropertyKey, match: PatchReplacement["match"], totalTime: number]>;
 
 export const getBuildNumber = makeLazy(() => {
     try {
-        shouldPatchFactories = false;
-
         try {
             if (wreq.m[128014]?.toString().includes("Trying to open a changelog for an invalid build number")) {
                 const hardcodedGetBuildNumber = wreq(128014).b as () => number;
@@ -59,13 +48,23 @@ export const getBuildNumber = makeLazy(() => {
         return typeof buildNumber === "number" ? buildNumber : -1;
     } catch {
         return -1;
-    } finally {
-        shouldPatchFactories = true;
     }
 });
 
-type Define = typeof Reflect.defineProperty;
-const define: Define = (target, p, attributes) => {
+export function getFactoryPatchedSource(id: PropertyKey, webpackRequire = wreq as AnyWebpackRequire) {
+    return webpackRequire.m[id]?.[SYM_PATCHED_SOURCE];
+}
+
+export function getFactoryPatchedBy(id: PropertyKey, webpackRequire = wreq as AnyWebpackRequire) {
+    return webpackRequire.m[id]?.[SYM_PATCHED_BY];
+}
+
+const logger = new Logger("WebpackInterceptor", "#8caaee");
+
+/** Whether we tried to fallback to WebpackRequire of the factory, or disabled patches */
+let wreqFallbackApplied = false;
+
+const define: typeof Reflect.defineProperty = (target, p, attributes) => {
     if (Object.hasOwn(attributes, "value")) {
         attributes.writable = true;
     }
@@ -77,24 +76,6 @@ const define: Define = (target, p, attributes) => {
     });
 };
 
-export function getOriginalFactory(id: PropertyKey, webpackRequire = wreq as AnyWebpackRequire) {
-    const moduleFactory = webpackRequire.m[id];
-    return (moduleFactory?.[SYM_ORIGINAL_FACTORY] ?? moduleFactory) as AnyModuleFactory | undefined;
-}
-
-export function getFactoryPatchedSource(id: PropertyKey, webpackRequire = wreq as AnyWebpackRequire) {
-    return webpackRequire.m[id]?.[SYM_PATCHED_SOURCE];
-}
-
-export function getFactoryPatchedBy(id: PropertyKey, webpackRequire = wreq as AnyWebpackRequire) {
-    return webpackRequire.m[id]?.[SYM_PATCHED_BY];
-}
-
-// wreq.m is the Webpack object containing module factories. It is pre-populated with module factories, and is also populated via webpackGlobal.push
-// We use this setter to intercept when wreq.m is defined and apply the patching in its module factories.
-// We wrap wreq.m with our proxy, which is responsible for patching the module factories when they are set, or defining getters for the patched versions.
-
-// If this is the main Webpack, we also set up the internal references to WebpackRequire.
 define(Function.prototype, "m", {
     enumerable: false,
 
@@ -132,12 +113,16 @@ define(Function.prototype, "m", {
 
         // Patch the pre-populated factories
         for (const id in originalModules) {
-            if (updateExistingFactory(originalModules, id, originalModules[id], true)) {
+            const originalFactory = originalModules[id];
+
+            if (updateExistingFactory(originalModules, id, originalFactory, originalModules, true)) {
                 continue;
             }
 
-            notifyFactoryListeners(originalModules[id]);
-            defineModulesFactoryGetter(id, Settings.eagerPatches && shouldPatchFactories ? wrapAndPatchFactory(id, originalModules[id]) : originalModules[id]);
+            notifyFactoryListeners(id, originalFactory);
+
+            const proxiedFactory = new Proxy(Settings.eagerPatches ? patchFactory(id, originalFactory) : originalFactory, moduleFactoryHandler);
+            Reflect.set(originalModules, id, proxiedFactory, originalModules);
         }
 
         define(originalModules, Symbol.toStringTag, {
@@ -145,7 +130,6 @@ define(Function.prototype, "m", {
             enumerable: false
         });
 
-        // The proxy responsible for patching the module factories when they are set, or defining getters for the patched versions
         const proxiedModuleFactories = new Proxy(originalModules, moduleFactoriesHandler);
         /*
         If Webpack ever decides to set module factories using the variable of the modules object directly, instead of wreq.m, switch the proxy to the prototype
@@ -174,14 +158,40 @@ const moduleFactoriesHandler: ProxyHandler<AnyWebpackRequire["m"]> = {
 
     // The set trap for patching or defining getters for the module factories when new module factories are loaded
     set(target, p, newValue, receiver) {
-        if (updateExistingFactory(target, p, newValue)) {
+        if (updateExistingFactory(target, p, newValue, receiver)) {
             return true;
         }
 
-        notifyFactoryListeners(newValue);
-        defineModulesFactoryGetter(p, Settings.eagerPatches && shouldPatchFactories ? wrapAndPatchFactory(p, newValue) : newValue);
+        notifyFactoryListeners(p, newValue);
 
-        return true;
+        const proxiedFactory = new Proxy(Settings.eagerPatches ? patchFactory(p, newValue) : newValue, moduleFactoryHandler);
+        return Reflect.set(target, p, proxiedFactory, receiver);
+    }
+};
+
+const moduleFactoryHandler: ProxyHandler<MaybePatchedModuleFactory> = {
+    apply(target, thisArg: unknown, argArray: Parameters<AnyModuleFactory>) {
+        // SAFETY: Factories have `name` as their key in the module factories object, and that is always their module id
+        const id = target.name;
+
+        // SYM_ORIGINAL_FACTORY means the factory has already been patched
+        if (target[SYM_ORIGINAL_FACTORY] != null) {
+            return runFactoryWithWrap(id, target as PatchedModuleFactory, thisArg, argArray);
+        }
+
+        const patchedFactory = patchFactory(id, target);
+        return runFactoryWithWrap(id, patchedFactory, thisArg, argArray);
+    },
+
+    get(target, p, receiver) {
+        const v = Reflect.get(target, p, receiver);
+
+        // Make proxied factories toString return their original factory toString
+        if (p === "toString") {
+            return (...args: unknown[]) => v.apply(target[SYM_ORIGINAL_FACTORY] ?? target, args);
+        }
+
+        return v;
     }
 };
 
@@ -191,10 +201,11 @@ const moduleFactoriesHandler: ProxyHandler<AnyWebpackRequire["m"]> = {
  * @target The module factories where this new original factory is being set
  * @param id The id of the module
  * @param newFactory The new original factory
+ * @receiver The receiver of the factory
  * @param ignoreExistingInTarget Whether to ignore checking if the factory already exists in the moduleFactoriesTarget
  * @returns Whether the original factory was updated, or false if it doesn't exist in any Webpack instance
  */
-function updateExistingFactory(moduleFactoriesTarget: AnyWebpackRequire["m"], id: PropertyKey, newFactory: AnyModuleFactory, ignoreExistingInTarget: boolean = false) {
+function updateExistingFactory(moduleFactoriesTarget: AnyWebpackRequire["m"], id: PropertyKey, newFactory: AnyModuleFactory, receiver: any, ignoreExistingInTarget: boolean = false) {
     let existingFactory: TypedPropertyDescriptor<AnyModuleFactory> | undefined;
     let moduleFactoriesWithFactory: AnyWebpackRequire["m"] | undefined;
     for (const wreq of allWebpackInstances) {
@@ -213,7 +224,7 @@ function updateExistingFactory(moduleFactoriesTarget: AnyWebpackRequire["m"], id
         // and let the correct logic apply (normal set, or defineModuleFactoryGetter setter)
 
         if (moduleFactoriesWithFactory !== moduleFactoriesTarget) {
-            Reflect.defineProperty(moduleFactoriesTarget, id, existingFactory);
+            Reflect.defineProperty(receiver, id, existingFactory);
         }
 
         // Persist patched source and patched by in the new original factory, if the patched one has already been required
@@ -222,7 +233,7 @@ function updateExistingFactory(moduleFactoriesTarget: AnyWebpackRequire["m"], id
             newFactory[SYM_PATCHED_BY] = existingFactory.value[SYM_PATCHED_BY];
         }
 
-        return Reflect.set(moduleFactoriesTarget, id, newFactory, moduleFactoriesTarget);
+        return Reflect.set(moduleFactoriesTarget, id, newFactory, receiver);
     }
 
     return false;
@@ -231,208 +242,149 @@ function updateExistingFactory(moduleFactoriesTarget: AnyWebpackRequire["m"], id
 /**
  * Notify all factory listeners.
  *
+ * @param moduleId The id of the module
  * @param factory The original factory to notify for
  */
-function notifyFactoryListeners(factory: AnyModuleFactory) {
+function notifyFactoryListeners(moduleId: PropertyKey, factory: AnyModuleFactory) {
     for (const factoryListener of factoryListeners) {
         try {
-            factoryListener(factory);
+            factoryListener(moduleId, factory);
         } catch (err) {
             logger.error("Error in Webpack factory listener:\n", err, factoryListener);
         }
     }
 }
 
-/**
- * Define the getter for returning the patched version of the module factory.
- *
- * If eagerPatches is enabled, the factory argument should already be the patched version, else it will be the original
- * and only be patched when accessed for the first time.
- *
- * @param id The id of the module
- * @param factory The original or patched module factory
- */
-function defineModulesFactoryGetter(id: PropertyKey, factory: MaybeWrappedModuleFactory) {
-    const descriptor: PropertyDescriptor = {
-        get() {
-            // SYM_ORIGINAL_FACTORY means the factory is already patched
-            if (!shouldPatchFactories || factory[SYM_ORIGINAL_FACTORY] != null) {
-                return factory;
-            }
+function runFactoryWithWrap(moduleId: PropertyKey, patchedFactory: PatchedModuleFactory, thisArg: unknown, argArray: Parameters<MaybePatchedModuleFactory>) {
+    const originalFactory = patchedFactory[SYM_ORIGINAL_FACTORY];
 
-            return (factory = wrapAndPatchFactory(id, factory));
-        },
-        set(newFactory: MaybeWrappedModuleFactory) {
-            if (IS_DEV) {
-                newFactory[SYM_PATCHED_SOURCE] = factory[SYM_PATCHED_SOURCE];
-                newFactory[SYM_PATCHED_BY] = factory[SYM_PATCHED_BY];
-            }
-
-            if (factory[SYM_ORIGINAL_FACTORY] != null) {
-                factory.toString = newFactory.toString.bind(newFactory);
-                factory[SYM_ORIGINAL_FACTORY] = newFactory;
-            } else {
-                factory = newFactory;
-            }
-        }
-    };
-
-    // Define the getter in all the module factories objects. Patches are only executed once, so make sure all module factories object
-    // have the patched version
-    for (const wreq of allWebpackInstances) {
-        define(wreq.m, id, descriptor);
+    if (patchedFactory === originalFactory) {
+        // @ts-expect-error Clear up ORIGINAL_FACTORY if the factory did not have any patch applied
+        delete patchedFactory[SYM_ORIGINAL_FACTORY];
     }
-}
 
-/**
- * Wraps and patches a module factory.
- *
- * @param id The id of the module
- * @param factory The original or patched module factory
- * @returns The wrapper for the patched module factory
- */
-function wrapAndPatchFactory(id: PropertyKey, originalFactory: AnyModuleFactory) {
-    const [patchedFactory, patchedSource, patchedBy] = patchFactory(id, originalFactory);
+    // Restore the original factory in all the module factories objects.
+    for (const wreq of allWebpackInstances) {
+        define(wreq.m, moduleId, { value: originalFactory });
+    }
 
-    const wrappedFactory: WrappedModuleFactory = function (...args) {
-        // Restore the original factory in all the module factories objects. We want to make sure the original factory is restored properly, no matter what is the Webpack instance
-        for (const wreq of allWebpackInstances) {
-            define(wreq.m, id, { value: wrappedFactory[SYM_ORIGINAL_FACTORY] });
-        }
+    let [module, exports, require] = argArray;
 
-        // eslint-disable-next-line prefer-const
-        let [module, exports, require] = args;
+    if (wreq == null) {
+        if (!wreqFallbackApplied) {
+            wreqFallbackApplied = true;
 
-        if (wreq == null) {
-            if (!wreqFallbackApplied) {
-                wreqFallbackApplied = true;
+            // Make sure the require argument is actually the WebpackRequire function
+            if (typeof require === "function" && require.m != null) {
+                const { stack } = new Error();
+                const webpackInstanceFileName = stack?.match(/\/assets\/(.+?\.js)/)?.[1];
 
-                // Make sure the require argument is actually the WebpackRequire function
-                if (typeof require === "function" && require.m != null) {
-                    const { stack } = new Error();
-                    const webpackInstanceFileName = stack?.match(/\/assets\/(.+?\.js)/)?.[1];
+                logger.warn(
+                    "WebpackRequire was not initialized, falling back to WebpackRequire passed to the first called wrapped module factory (" +
+                    `id: ${String(moduleId)}` + interpolateIfDefined`, WebpackInstance origin: ${webpackInstanceFileName}` +
+                    ")"
+                );
 
-                    logger.warn(
-                        "WebpackRequire was not initialized, falling back to WebpackRequire passed to the first called patched module factory (" +
-                        `id: ${String(id)}` + interpolateIfDefined`, WebpackInstance origin: ${webpackInstanceFileName}` +
-                        ")"
-                    );
-
-                    _initWebpack(require as WebpackRequire);
-                } else if (IS_DEV) {
-                    logger.error("WebpackRequire was not initialized, running modules without patches instead.");
-                    return wrappedFactory[SYM_ORIGINAL_FACTORY].apply(this, args);
-                }
+                // Could technically be wrong, but it's better than nothing
+                _initWebpack(require as WebpackRequire);
             } else if (IS_DEV) {
-                return wrappedFactory[SYM_ORIGINAL_FACTORY].apply(this, args);
+                logger.error("WebpackRequire was not initialized, running modules without patches instead.");
+                return originalFactory.apply(thisArg, argArray);
             }
+        } else if (IS_DEV) {
+            return originalFactory.apply(thisArg, argArray);
+        }
+    }
+
+    let factoryReturn: unknown;
+    try {
+        factoryReturn = patchedFactory.apply(thisArg, argArray);
+    } catch (err) {
+        // Just re-throw Discord errors
+        if (patchedFactory === originalFactory) {
+            throw err;
         }
 
-        let factoryReturn: unknown;
-        try {
-            // Call the patched factory
-            factoryReturn = patchedFactory.apply(this, args);
-        } catch (err) {
-            // Just re-throw Discord errors
-            if (patchedFactory === wrappedFactory[SYM_ORIGINAL_FACTORY]) {
-                throw err;
+        logger.error("Error in patched module factory:\n", err);
+        return originalFactory.apply(thisArg, argArray);
+    }
+
+    exports = module.exports;
+    if (exports == null) {
+        return factoryReturn;
+    }
+
+    if (typeof require === "function") {
+        const shouldIgnoreModule = _shouldIgnoreModule(exports);
+
+        if (shouldIgnoreModule) {
+            if (require.c != null) {
+                Object.defineProperty(require.c, moduleId, {
+                    value: require.c[moduleId],
+                    enumerable: false,
+                    configurable: true,
+                    writable: true
+                });
             }
 
-            logger.error("Error in patched module factory:\n", err);
-            return wrappedFactory[SYM_ORIGINAL_FACTORY].apply(this, args);
-        }
-
-        exports = module.exports;
-        if (exports == null) {
             return factoryReturn;
         }
-
-        if (typeof require === "function") {
-            const shouldIgnoreModule = _shouldIgnoreModule(exports);
-
-            if (shouldIgnoreModule) {
-                if (require.c != null) {
-                    Object.defineProperty(require.c, id, {
-                        value: require.c[id],
-                        enumerable: false,
-                        configurable: true,
-                        writable: true
-                    });
-                }
-
-                return factoryReturn;
-            }
-        }
-
-        for (const callback of moduleListeners) {
-            try {
-                callback(exports, id);
-            } catch (err) {
-                logger.error("Error in Webpack module listener:\n", err, callback);
-            }
-        }
-
-        for (const [filter, callback] of waitForSubscriptions) {
-            try {
-                if (filter(exports)) {
-                    waitForSubscriptions.delete(filter);
-                    callback(exports, id);
-                    continue;
-                }
-
-                if (typeof exports !== "object") {
-                    continue;
-                }
-
-                for (const exportKey in exports) {
-                    const exportValue = exports[exportKey];
-
-                    if (exportValue != null && filter(exportValue)) {
-                        waitForSubscriptions.delete(filter);
-                        callback(exportValue, id);
-                        break;
-                    }
-                }
-            } catch (err) {
-                logger.error("Error while firing callback for Webpack waitFor subscription:\n", err, filter, callback);
-            }
-        }
-
-        return factoryReturn;
-    };
-
-    wrappedFactory.toString = originalFactory.toString.bind(originalFactory);
-    wrappedFactory[SYM_ORIGINAL_FACTORY] = originalFactory;
-
-    if (IS_DEV && patchedFactory !== originalFactory) {
-        wrappedFactory[SYM_PATCHED_SOURCE] = patchedSource;
-        wrappedFactory[SYM_PATCHED_BY] = patchedBy;
-        originalFactory[SYM_PATCHED_SOURCE] = patchedSource;
-        originalFactory[SYM_PATCHED_BY] = patchedBy;
     }
 
-    // @ts-expect-error Allow GC to get into action, if possible
-    originalFactory = undefined;
-    return wrappedFactory;
-}
+    for (const callback of moduleListeners) {
+        try {
+            callback(exports, moduleId);
+        } catch (err) {
+            logger.error("Error in Webpack module listener:\n", err, callback);
+        }
+    }
+
+    for (const [filter, callback] of waitForSubscriptions) {
+        try {
+            if (filter(exports)) {
+                waitForSubscriptions.delete(filter);
+                callback(exports, moduleId);
+                continue;
+            }
+
+            if (typeof exports !== "object") {
+                continue;
+            }
+
+            for (const exportKey in exports) {
+                const exportValue = exports[exportKey];
+
+                if (exportValue != null && filter(exportValue)) {
+                    waitForSubscriptions.delete(filter);
+                    callback(exportValue, moduleId);
+                    break;
+                }
+            }
+        } catch (err) {
+            logger.error("Error while firing callback for Webpack waitFor subscription:\n", err, filter, callback);
+        }
+    }
+
+    return factoryReturn;
+};
 
 /**
  * Patches a module factory.
  *
  * @param id The id of the module
- * @param factory The original module factory
- * @returns The patched module factory, the patched source of it, and the plugins that patched it
+ * @param originalFactory The original module factory
+ * @returns The patched module factory
  */
-function patchFactory(id: PropertyKey, factory: AnyModuleFactory): [patchedFactory: AnyModuleFactory, patchedSource: string, patchedBy: Set<string>] {
+function patchFactory(id: PropertyKey, originalFactory: AnyModuleFactory): PatchedModuleFactory {
     // 0, prefix to turn it into an expression: 0,function(){} would be invalid syntax without the 0,
-    let code: string = "0," + String(factory);
+    let code: string = "0," + String(originalFactory);
     let patchedSource = code;
-    let patchedFactory = factory;
+    let patchedFactory = originalFactory;
 
     const patchedBy = new Set<string>();
 
-    for (let i = 0; i < patches.length; i++) {
-        const patch = patches[i];
+    for (let i = 0; i < Vencord.Plugins.patches.length; i++) {
+        const patch = Vencord.Plugins.patches[i];
 
         const moduleMatches = typeof patch.find === "string"
             ? code.includes(patch.find)
@@ -442,8 +394,8 @@ function patchFactory(id: PropertyKey, factory: AnyModuleFactory): [patchedFacto
             continue;
         }
 
-        // Reporter eagerly patches and cannot retrieve the build number because this code runs before the module for it is loaded
-        const buildNumber = IS_REPORTER ? -1 : getBuildNumber();
+        // Eager patches cannot retrieve the build number because this code runs before the module for it is loaded
+        const buildNumber = Settings.eagerPatches ? -1 : getBuildNumber();
         const shouldCheckBuildNumber = !Settings.eagerPatches && buildNumber !== -1;
 
         if (
@@ -463,7 +415,7 @@ function patchFactory(id: PropertyKey, factory: AnyModuleFactory): [patchedFacto
         });
 
         const previousCode = code;
-        const previousFactory = factory;
+        const previousFactory = originalFactory;
         let markedAsPatched = false;
 
         // We change all patch.replacement to array in plugins/index
@@ -482,7 +434,7 @@ function patchFactory(id: PropertyKey, factory: AnyModuleFactory): [patchedFacto
             }
 
             const lastCode = code;
-            const lastFactory = factory;
+            const lastFactory = originalFactory;
 
             try {
                 const [newCode, totalTime] = executePatch(replacement.match, replacement.replace as string);
@@ -546,11 +498,22 @@ function patchFactory(id: PropertyKey, factory: AnyModuleFactory): [patchedFacto
         }
 
         if (!patch.all) {
-            patches.splice(i--, 1);
+            Vencord.Plugins.patches.splice(i--, 1);
         }
     }
 
-    return [patchedFactory, patchedSource, patchedBy];
+    patchedFactory[SYM_ORIGINAL_FACTORY] = originalFactory;
+
+    if (patchedFactory !== originalFactory) {
+        patchedFactory.toString = originalFactory.toString.bind(originalFactory);
+
+        if (IS_DEV) {
+            originalFactory[SYM_PATCHED_SOURCE] = patchedSource;
+            originalFactory[SYM_PATCHED_BY] = patchedBy;
+        }
+    }
+
+    return patchedFactory as PatchedModuleFactory;
 }
 
 function diffErroredPatch(code: string, lastCode: string, match: RegExpMatchArray) {

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -304,7 +304,6 @@ function runFactoryWithWrap(moduleId: PropertyKey, patchedFactory: PatchedModule
         define(wreq.m, moduleId, { value: originalFactory });
     }
 
-    // eslint-disable-next-line prefer-const
     let [module, exports, require] = argArray;
 
     if (wreq == null) {

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -9,11 +9,13 @@ import { makeLazy } from "@utils/lazy";
 import { Logger } from "@utils/Logger";
 import { interpolateIfDefined } from "@utils/misc";
 import { canonicalizeReplacement } from "@utils/patches";
-import { PatchReplacement } from "@utils/types";
+import { Patch, PatchReplacement } from "@utils/types";
 
 import { traceFunctionWithResults } from "../debug/Tracer";
 import { _initWebpack, _shouldIgnoreModule, factoryListeners, findModuleId, moduleListeners, waitForSubscriptions, wreq } from "./webpack";
 import { AnyModuleFactory, AnyWebpackRequire, MaybePatchedModuleFactory, ModuleExports, PatchedModuleFactory, WebpackRequire } from "./wreq.d";
+
+export const patches = [] as Patch[];
 
 export const SYM_ORIGINAL_FACTORY = Symbol("WebpackPatcher.originalFactory");
 export const SYM_PATCHED_SOURCE = Symbol("WebpackPatcher.patchedSource");
@@ -418,8 +420,8 @@ function patchFactory(moduleId: PropertyKey, originalFactory: AnyModuleFactory):
 
     const patchedBy = new Set<string>();
 
-    for (let i = 0; i < Vencord.Plugins.patches.length; i++) {
-        const patch = Vencord.Plugins.patches[i];
+    for (let i = 0; i < patches.length; i++) {
+        const patch = patches[i];
 
         const moduleMatches = typeof patch.find === "string"
             ? code.includes(patch.find)
@@ -533,7 +535,7 @@ function patchFactory(moduleId: PropertyKey, originalFactory: AnyModuleFactory):
         }
 
         if (!patch.all) {
-            Vencord.Plugins.patches.splice(i--, 1);
+            patches.splice(i--, 1);
         }
     }
 

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -276,7 +276,7 @@ function updateExistingFactory(moduleFactoriesTarget: AnyWebpackRequire["m"], mo
 function notifyFactoryListeners(moduleId: PropertyKey, factory: AnyModuleFactory) {
     for (const factoryListener of factoryListeners) {
         try {
-            factoryListener(moduleId, factory);
+            factoryListener(factory, moduleId);
         } catch (err) {
             logger.error("Error in Webpack factory listener:\n", err, factoryListener);
         }

--- a/src/webpack/patchWebpack.ts
+++ b/src/webpack/patchWebpack.ts
@@ -538,6 +538,8 @@ function patchFactory(moduleId: PropertyKey, originalFactory: AnyModuleFactory):
     if (IS_DEV && patchedFactory !== originalFactory) {
         originalFactory[SYM_PATCHED_SOURCE] = patchedSource;
         originalFactory[SYM_PATCHED_BY] = patchedBy;
+        patchedFactory[SYM_PATCHED_SOURCE] = patchedSource;
+        patchedFactory[SYM_PATCHED_BY] = patchedBy;
     }
 
     return patchedFactory as PatchedModuleFactory;

--- a/src/webpack/webpack.ts
+++ b/src/webpack/webpack.ts
@@ -90,7 +90,7 @@ export const filters = {
 };
 
 export type CallbackFn = (module: ModuleExports, id: PropertyKey) => void;
-export type FactoryListernFn = (factory: AnyModuleFactory) => void;
+export type FactoryListernFn = (moduleId: PropertyKey, factory: AnyModuleFactory) => void;
 
 export const waitForSubscriptions = new Map<FilterFn, CallbackFn>();
 export const moduleListeners = new Set<CallbackFn>();

--- a/src/webpack/webpack.ts
+++ b/src/webpack/webpack.ts
@@ -90,7 +90,7 @@ export const filters = {
 };
 
 export type CallbackFn = (module: ModuleExports, id: PropertyKey) => void;
-export type FactoryListernFn = (moduleId: PropertyKey, factory: AnyModuleFactory) => void;
+export type FactoryListernFn = (factory: AnyModuleFactory, moduleId: PropertyKey) => void;
 
 export const waitForSubscriptions = new Map<FilterFn, CallbackFn>();
 export const moduleListeners = new Set<CallbackFn>();

--- a/src/webpack/wreq.d.ts
+++ b/src/webpack/wreq.d.ts
@@ -200,12 +200,10 @@ export type AnyModuleFactory = ((this: ModuleExports, module: Module, exports: M
     [SYM_PATCHED_BY]?: Set<string>;
 };
 
-export type WrappedModuleFactory = AnyModuleFactory & {
+export type PatchedModuleFactory = AnyModuleFactory & {
     [SYM_ORIGINAL_FACTORY]: AnyModuleFactory;
     [SYM_PATCHED_SOURCE]?: string;
     [SYM_PATCHED_BY]?: Set<string>;
 };
 
-export type MaybeWrappedModuleFactory = AnyModuleFactory | WrappedModuleFactory;
-
-export type WrappedModuleFactories = Record<PropertyKey, WrappedModuleFactory>;
+export type MaybePatchedModuleFactory = PatchedModuleFactory | AnyModuleFactory;

--- a/src/webpack/wreq.d.ts
+++ b/src/webpack/wreq.d.ts
@@ -202,8 +202,6 @@ export type AnyModuleFactory = ((this: ModuleExports, module: Module, exports: M
 
 export type PatchedModuleFactory = AnyModuleFactory & {
     [SYM_ORIGINAL_FACTORY]: AnyModuleFactory;
-    [SYM_PATCHED_SOURCE]?: string;
-    [SYM_PATCHED_BY]?: Set<string>;
 };
 
 export type MaybePatchedModuleFactory = PatchedModuleFactory | AnyModuleFactory;

--- a/src/webpack/wreq.d.ts
+++ b/src/webpack/wreq.d.ts
@@ -202,6 +202,8 @@ export type AnyModuleFactory = ((this: ModuleExports, module: Module, exports: M
 
 export type PatchedModuleFactory = AnyModuleFactory & {
     [SYM_ORIGINAL_FACTORY]: AnyModuleFactory;
+    [SYM_PATCHED_SOURCE]?: string;
+    [SYM_PATCHED_BY]?: Set<string>;
 };
 
 export type MaybePatchedModuleFactory = PatchedModuleFactory | AnyModuleFactory;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,16 +22,16 @@
 
         "baseUrl": "./src/",
         "paths": {
-            "@main/*": [ "./main/*" ],
-            "@api/*": [ "./api/*" ],
-            "@components/*": [ "./components/*" ],
-            "@utils/*": [ "./utils/*" ],
-            "@shared/*": [ "./shared/*" ],
-            "@webpack/types": [ "./webpack/common/types" ],
-            "@webpack/common": [ "./webpack/common" ],
-            "@webpack": [ "./webpack/webpack" ],
-            "@webpack/patcher": [ "./webpack/patchWebpack" ],
-            "@webpack/wreq.d": [ "./webpack/wreq.d" ],
+            "@main/*": ["./main/*"],
+            "@api/*": ["./api/*"],
+            "@components/*": ["./components/*"],
+            "@utils/*": ["./utils/*"],
+            "@shared/*": ["./shared/*"],
+            "@webpack/types": ["./webpack/common/types"],
+            "@webpack/common": ["./webpack/common"],
+            "@webpack": ["./webpack/webpack"],
+            "@webpack/patcher": ["./webpack/patchWebpack"],
+            "@webpack/wreq.d": ["./webpack/wreq.d"],
         },
 
         "plugins": [
@@ -43,5 +43,5 @@
         ],
         "outDir": "who-fucking-cares-dude"
     },
-    "include": [ "src/**/*", "browser/**/*", "scripts/**/*", "eslint.config.mjs" ],
+    "include": ["src/**/*", "browser/**/*", "scripts/**/*", "eslint.config.mjs"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,14 +22,16 @@
 
         "baseUrl": "./src/",
         "paths": {
-            "@main/*": ["./main/*"],
-            "@api/*": ["./api/*"],
-            "@components/*": ["./components/*"],
-            "@utils/*": ["./utils/*"],
-            "@shared/*": ["./shared/*"],
-            "@webpack/types": ["./webpack/common/types"],
-            "@webpack/common": ["./webpack/common"],
-            "@webpack": ["./webpack/webpack"]
+            "@main/*": [ "./main/*" ],
+            "@api/*": [ "./api/*" ],
+            "@components/*": [ "./components/*" ],
+            "@utils/*": [ "./utils/*" ],
+            "@shared/*": [ "./shared/*" ],
+            "@webpack/types": [ "./webpack/common/types" ],
+            "@webpack/common": [ "./webpack/common" ],
+            "@webpack": [ "./webpack/webpack" ],
+            "@webpack/patcher": [ "./webpack/patchWebpack" ],
+            "@webpack/wreq.d": [ "./webpack/wreq.d" ],
         },
 
         "plugins": [
@@ -41,5 +43,5 @@
         ],
         "outDir": "who-fucking-cares-dude"
     },
-    "include": ["src/**/*", "browser/**/*", "scripts/**/*", "eslint.config.mjs"],
+    "include": [ "src/**/*", "browser/**/*", "scripts/**/*", "eslint.config.mjs" ],
 }


### PR DESCRIPTION
Decreases the amount of closures WebpackPatcher creates heavily. Before two closures would be created for every module. One for the getter and one for the wrapper. Now none of those creates closures anymore and instead rely on a single proxy handler