### PR TITLE
Removable Chat Buttons Plugin

### DIFF
--- a/src/plugins/removeChatButtons/README.md
+++ b/src/plugins/removeChatButtons/README.md
@@ -1,0 +1,7 @@
+# RemoveChatButtons
+
+**Customize your chat bar by removing default and plugin-added buttons based on your preferences.**
+
+## Installation
+
+See the [forum thread](https://discord.com/channels/1015060230222131221/1257038407503446176/1257038407503446176) / [Vencord docs](https://docs.vencord.dev/installing/custom-plugins/)

--- a/src/plugins/removeChatButtons/README.md
+++ b/src/plugins/removeChatButtons/README.md
@@ -1,7 +1,3 @@
 # RemoveChatButtons
 
 **Customize your chat bar by removing default and plugin-added buttons based on your preferences.**
-
-## Installation
-
-See the [forum thread](https://discord.com/channels/1015060230222131221/1257038407503446176/1257038407503446176) / [Vencord docs](https://docs.vencord.dev/installing/custom-plugins/)

--- a/src/plugins/removeChatButtons/README.md
+++ b/src/plugins/removeChatButtons/README.md
@@ -1,3 +1,5 @@
 # RemoveChatButtons
 
+![Removable Chat Buttons](https://i.imgur.com/Tg2ELah.png)
+
 **Customize your chat bar by removing default and plugin-added buttons based on your preferences.**

--- a/src/plugins/removeChatButtons/index.tsx
+++ b/src/plugins/removeChatButtons/index.tsx
@@ -1,0 +1,130 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    emojiButton: {
+        type: OptionType.BOOLEAN,
+        description: "Remove Emoji Button from chat",
+        restartNeeded: true,
+        default: false
+    },
+    stickerButton: {
+        type: OptionType.BOOLEAN,
+        description: "Remove Sticker Button from chat",
+        restartNeeded: true,
+        default: true
+    },
+    gifButton: {
+        type: OptionType.BOOLEAN,
+        description: "Remove GIF Button from chat",
+        restartNeeded: true,
+        default: true
+    },
+    giftButton: {
+        type: OptionType.BOOLEAN,
+        description: "Remove Gift Button from chat",
+        restartNeeded: true,
+        default: true
+    },
+    confettiButton: {
+        type: OptionType.BOOLEAN,
+        description: "Remove Confetti Button from chat",
+        restartNeeded: true,
+        default: true
+    },
+    TranslateModalButton: {
+        type: OptionType.BOOLEAN,
+        description: "Remove Translate Modal Button from chat (plugin)",
+        restartNeeded: true,
+        default: false
+    },
+    encryptMessageButton: {
+        type: OptionType.BOOLEAN,
+        description: "Remove Encrypt Message Button from chat (plugin)",
+        restartNeeded: true,
+        default: false
+    },
+});
+
+export default definePlugin({
+    name: "RemoveChatButtons",
+    description: "Remove default and plugin buttons from the chat bar based on settings.",
+    authors: [Devs.Mahiro],
+    settings,
+
+    start() {
+        this.applyStyles();
+    },
+
+    stop() {
+        document.querySelectorAll(".CustomChatButtons-style").forEach(style => style.remove());
+    },
+
+    applyStyles() {
+        const css = this.generateCSS();
+        const style = document.createElement("style");
+        style.className = "CustomChatButtons-style";
+        style.textContent = css;
+        document.head.appendChild(style);
+    },
+
+    generateCSS() {
+        const rules: string[] = [];
+
+        // Using more reliable selectors that don't depend on webpack
+        if (this.settings.store.emojiButton) {
+            rules.push(`
+                button[aria-label="Select emoji"] { display: none !important; }
+                .expression-picker-chat-input-button[aria-label="Select emoji"] { display: none !important; }
+            `);
+        }
+
+        if (this.settings.store.stickerButton) {
+            rules.push(`
+                button[aria-label="Open sticker picker"] { display: none !important; }
+                .expression-picker-chat-input-button[aria-label="Open sticker picker"] { display: none !important; }
+            `);
+        }
+
+        if (this.settings.store.gifButton) {
+            rules.push(`
+                button[aria-label="Open GIF picker"] { display: none !important; }
+                .expression-picker-chat-input-button[aria-label="Open GIF picker"] { display: none !important; }
+            `);
+        }
+
+        if (this.settings.store.giftButton) {
+            rules.push(`
+                button[aria-label="Send a gift"] { display: none !important; }
+                .expression-picker-chat-input-button[aria-label="Send a gift"] { display: none !important; }
+            `);
+        }
+        if (this.settings.store.confettiButton) {
+            rules.push(`
+                button[aria-label="Add Emoji Confetti"] { display: none !important; }
+                .expression-picker-chat-input-button[aria-label="Add Emoji Confetti"] { display: none !important; }
+            `);
+        }
+        if (this.settings.store.TranslateModalButton) {
+            rules.push(`
+                button[aria-label="Open Translate Modal"] { display: none !important; }
+                .expression-picker-chat-input-button[aria-label="Open Translate Modal"] { display: none !important; }
+            `);
+        }
+        if (this.settings.store.encryptMessageButton) {
+            rules.push(`
+                button[aria-label="Encrypt Message"] { display: none !important; }
+                .expression-picker-chat-input-button[aria-label="Encrypt Message"] { display: none !important; }
+            `);
+        }
+
+        return rules.join("\n");
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,6 +589,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    Mahiro: {
+        name: "Mahiro",
+        id: 829806976702873621n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This plugin lets users customize their chat bar by removing default and plugin-added buttons based on their settings. This enhances flexibility and creates a cleaner, clutter-free UI.

![Removable Chat Buttons](https://github.com/user-attachments/assets/6d1ed019-4a9e-4503-8018-3a2bc1819677)