### PR TITLE
Disable devtools in QuickCSS editor

### DIFF
--- a/src/main/ipcMain.ts
+++ b/src/main/ipcMain.ts
@@ -134,7 +134,8 @@ ipcMain.handle(IpcEvents.OPEN_MONACO_EDITOR, async () => {
             preload: join(__dirname, IS_DISCORD_DESKTOP ? "preload.js" : "vencordDesktopPreload.js"),
             contextIsolation: true,
             nodeIntegration: false,
-            sandbox: false
+            sandbox: false,
+            devTools: IS_DEV
         }
     });
 


### PR DESCRIPTION
It is possible to open devtools in the QuickCSS editor, which serves little purpose since it's impossible to inject anything into it, and can cause confusion in case it is accidentally focused instead of the main app.
