### PR TITLE
FIX: Missing ampersand causing log warning

### DIFF
--- a/src/components/VencordSettings/specialCard.css
+++ b/src/components/VencordSettings/specialCard.css
@@ -61,7 +61,7 @@
     margin-top: 1em;
     cursor: pointer;
 
-    .vc-special-hyperlink-text {
+    & .vc-special-hyperlink-text {
         color: black;
         font-size: 1em;
         font-weight: bold;


### PR DESCRIPTION
An ampersand was missing, causing the logs to show a warning, this fixes that.
Yes it's not much of a PR but the warning was annoying me.