### PR TITLE
Add currently useless option to the `showHiddenChannels` plugin.

### DIFF
--- a/src/plugins/showHiddenChannels/index.tsx
+++ b/src/plugins/showHiddenChannels/index.tsx
@@ -62,6 +62,12 @@ export const settings = definePluginSettings({
         description: "Whether the allowed users and roles dropdown on hidden channels should be open by default",
         type: OptionType.BOOLEAN,
         default: true
+    },
+    hideHiddenChannelsAndShowInMessages: {
+        description: "Show or hide hidden channels in the channel list.",
+        type: OptionType.BOOLEAN,
+        default: false,
+        restartNeeded: true
     }
 });
 


### PR DESCRIPTION
Add useless `hideHiddenChannelsAndShowInMessages` setting in the `showHiddenChannels` plugin.

Hopefully this acts like a feature request to the plugin and gets implemented. The reason as to why this is incomplete is because I don't know what I'm doing, and I only copied and pasted a bit of code.