### PR TITLE
ConsoleJanitor: Support allowing log levels

### DIFF
--- a/src/plugins/consoleJanitor/index.tsx
+++ b/src/plugins/consoleJanitor/index.tsx
@@ -8,7 +8,7 @@ import { definePluginSettings } from "@api/Settings";
 import { ErrorBoundary, Flex } from "@components/index";
 import { Devs } from "@utils/constants";
 import { Margins } from "@utils/margins";
-import definePlugin, { OptionType, StartAt } from "@utils/types";
+import definePlugin, { defineDefault, OptionType, StartAt } from "@utils/types";
 import { Checkbox, Forms, Text } from "@webpack/common";
 
 const Noop = () => { };
@@ -98,15 +98,14 @@ const settings = definePluginSettings({
     allowLevel: {
         type: OptionType.COMPONENT,
         component: AllowLevelSettings,
-        default: {
+        default: defineDefault<AllowLevels>({
             debug: false,
             info: false,
             log: false,
             trace: false,
             warn: false,
-            error: true,
-            // Warn for type errors, but dont take the narrowest type
-        } satisfies AllowLevels as AllowLevels,
+            error: true
+        })
     }
 });
 
@@ -199,7 +198,7 @@ export default definePlugin({
                 replace: ""
             }
         },
-        // Patches discords generic logger function
+        // Patches Discord generic logger function
         {
             find: "Σ:",
             predicate: () => settings.store.disableLoggers,

--- a/src/plugins/consoleJanitor/index.tsx
+++ b/src/plugins/consoleJanitor/index.tsx
@@ -28,12 +28,12 @@ const NoopLogger = {
 const logAllow = new Set();
 
 interface AllowLevels {
-    debug: boolean;
-    info: boolean;
-    log: boolean;
-    trace: boolean;
-    warn: boolean;
     error: boolean;
+    warn: boolean;
+    trace: boolean;
+    log: boolean;
+    info: boolean;
+    debug: boolean;
 }
 
 interface AllowLevelSettingProps {
@@ -95,12 +95,12 @@ const settings = definePluginSettings({
         type: OptionType.COMPONENT,
         component: AllowLevelSettings,
         default: defineDefault<AllowLevels>({
-            debug: false,
-            info: false,
-            log: false,
-            trace: false,
+            error: true,
             warn: false,
-            error: true
+            trace: false,
+            log: false,
+            info: false,
+            debug: false
         })
     }
 });

--- a/src/plugins/consoleJanitor/index.tsx
+++ b/src/plugins/consoleJanitor/index.tsx
@@ -104,8 +104,9 @@ const settings = definePluginSettings({
             log: false,
             trace: false,
             warn: false,
-            error: true
-        } as AllowLevels,
+            error: true,
+            // Warn for type errors, but dont take the narrowest type
+        } satisfies AllowLevels as AllowLevels,
     }
 });
 

--- a/src/plugins/consoleJanitor/index.tsx
+++ b/src/plugins/consoleJanitor/index.tsx
@@ -44,14 +44,10 @@ function AllowLevelSetting({ settingKey }: AllowLevelSettingProps) {
     const { allowLevel } = settings.use(["allowLevel"]);
     const value = allowLevel[settingKey];
 
-    function onChange(_: any, newValue: boolean) {
-        settings.store.allowLevel[settingKey] = newValue;
-    }
-
     return (
         <Checkbox
             value={value}
-            onChange={onChange}
+            onChange={(_, newValue) => settings.store.allowLevel[settingKey] = newValue}
             size={20}
         >
             <Text variant="text-sm/normal">{settingKey[0].toUpperCase() + settingKey.slice(1)}</Text>

--- a/src/plugins/consoleJanitor/index.tsx
+++ b/src/plugins/consoleJanitor/index.tsx
@@ -104,7 +104,7 @@ const settings = definePluginSettings({
             log: false,
             trace: false,
             warn: false,
-            error: false
+            error: true
         } as AllowLevels,
     }
 });

--- a/src/plugins/consoleJanitor/index.tsx
+++ b/src/plugins/consoleJanitor/index.tsx
@@ -125,11 +125,7 @@ export default definePlugin({
     NoopLogger: () => NoopLogger,
 
     shouldLog(logger: string, level: keyof AllowLevels) {
-        if (logAllow.has(logger) || settings.store.allowLevel[level] === true) {
-            return true;
-        }
-
-        return false;
+        return logAllow.has(logger) || settings.store.allowLevel[level] === true;
     },
 
     patches: [

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -202,6 +202,10 @@ export const enum ReporterTestable {
     FluxEvents = 1 << 4
 }
 
+export function defineDefault<T = any>(value: T) {
+    return value;
+}
+
 export const enum OptionType {
     STRING,
     NUMBER,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,7 +26,7 @@ import { MessageDecorationFactory } from "@api/MessageDecorations";
 import { MessageClickListener, MessageEditListener, MessageSendListener } from "@api/MessageEvents";
 import { MessagePopoverButtonFactory } from "@api/MessagePopover";
 import { FluxEvents } from "@webpack/types";
-import { JSX } from "react";
+import { ReactNode } from "react";
 import { Promisable } from "type-fest";
 
 // exists to export default definePlugin({...})
@@ -334,7 +334,8 @@ export interface IPluginOptionComponentProps {
 
 export interface PluginSettingComponentDef {
     type: OptionType.COMPONENT;
-    component: (props: IPluginOptionComponentProps) => JSX.Element;
+    component: (props: IPluginOptionComponentProps) => ReactNode | Promise<ReactNode>;
+    default?: any;
 }
 
 /** Maps a `PluginSettingDef` to its value type */

--- a/src/webpack/common/components.ts
+++ b/src/webpack/common/components.ts
@@ -38,6 +38,7 @@ export const Forms = {
 export const Card = waitForComponent<t.Card>("Card", filters.componentByCode(".editable),", ".outline:"));
 export const Button = waitForComponent<t.Button>("Button", filters.componentByCode("#{intl::A11Y_LOADING_STARTED}))),!1"));
 export const Switch = waitForComponent<t.Switch>("Switch", filters.componentByCode(".labelRow,ref:", ".disabledText"));
+export const Checkbox = waitForComponent("Checkbox", filters.componentByCode(".checkboxWrapperDisabled:"));
 
 const Tooltips = mapMangledModuleLazy(".tooltipTop,bottom:", {
     Tooltip: filters.componentByCode("this.renderTooltip()]"),

--- a/src/webpack/common/components.ts
+++ b/src/webpack/common/components.ts
@@ -38,7 +38,7 @@ export const Forms = {
 export const Card = waitForComponent<t.Card>("Card", filters.componentByCode(".editable),", ".outline:"));
 export const Button = waitForComponent<t.Button>("Button", filters.componentByCode("#{intl::A11Y_LOADING_STARTED}))),!1"));
 export const Switch = waitForComponent<t.Switch>("Switch", filters.componentByCode(".labelRow,ref:", ".disabledText"));
-export const Checkbox = waitForComponent("Checkbox", filters.componentByCode(".checkboxWrapperDisabled:"));
+export const Checkbox = waitForComponent<t.Checkbox>("Checkbox", filters.componentByCode(".checkboxWrapperDisabled:"));
 
 const Tooltips = mapMangledModuleLazy(".tooltipTop,bottom:", {
     Tooltip: filters.componentByCode("this.renderTooltip()]"),

--- a/src/webpack/common/types/components.d.ts
+++ b/src/webpack/common/types/components.d.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import type { ComponentPropsWithRef, ComponentType, CSSProperties, FunctionComponent, HtmlHTMLAttributes, HTMLProps, JSX, KeyboardEvent, MouseEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
+import type { ComponentPropsWithRef, ComponentType, CSSProperties, FunctionComponent, HtmlHTMLAttributes, HTMLProps, JSX, KeyboardEvent, MouseEvent, PointerEvent, PropsWithChildren, PropsWithRef, ReactNode, Ref } from "react";
 
 
 export type TextVariant = "heading-sm/normal" | "heading-sm/medium" | "heading-sm/semibold" | "heading-sm/bold" | "heading-md/normal" | "heading-md/medium" | "heading-md/semibold" | "heading-md/bold" | "heading-lg/normal" | "heading-lg/medium" | "heading-lg/semibold" | "heading-lg/bold" | "heading-xl/normal" | "heading-xl/medium" | "heading-xl/bold" | "heading-xxl/normal" | "heading-xxl/medium" | "heading-xxl/bold" | "eyebrow" | "heading-deprecated-14/normal" | "heading-deprecated-14/medium" | "heading-deprecated-14/bold" | "text-xxs/normal" | "text-xxs/medium" | "text-xxs/semibold" | "text-xxs/bold" | "text-xs/normal" | "text-xs/medium" | "text-xs/semibold" | "text-xs/bold" | "text-sm/normal" | "text-sm/medium" | "text-sm/semibold" | "text-sm/bold" | "text-md/normal" | "text-md/medium" | "text-md/semibold" | "text-md/bold" | "text-lg/normal" | "text-lg/medium" | "text-lg/semibold" | "text-lg/bold" | "display-sm" | "display-md" | "display-lg" | "code";
@@ -196,6 +196,36 @@ export type Switch = ComponentType<PropsWithChildren<{
     note?: ReactNode;
     tooltipNote?: ReactNode;
 }>>;
+
+export type CheckboxAligns = {
+    CENTER: "center";
+    TOP: "top";
+};
+
+export type CheckboxTypes = {
+    DEFAULT: "default";
+    INVERTED: "inverted";
+    GHOST: "ghost";
+    ROW: "row";
+};
+
+export type Checkbox = ComponentType<PropsWithChildren<{
+    value: boolean;
+    onChange(event: PointerEvent, value: boolean): void;
+
+    align?: "center" | "top";
+    disabled?: boolean;
+    displayOnly?: boolean;
+    readOnly?: boolean;
+    reverse?: boolean;
+    shape?: string;
+    size?: number;
+    type?: "default" | "inverted" | "ghost" | "row";
+}>> & {
+    Shapes: Record<"BOX" | "ROUND" | "SMALL_BOX", string>;
+    Aligns: CheckboxAligns;
+    Types: CheckboxTypes;
+};
 
 export type Timestamp = ComponentType<PropsWithChildren<{
     timestamp: Date;


### PR DESCRIPTION
adding this feature because somehow a react error was logged by one of the loggers, and didn't show up anywhere else in the console