### PR TITLE
vcNarrator: Add ability to use Friend Nickname

### DIFF
--- a/src/plugins/vcNarrator/index.tsx
+++ b/src/plugins/vcNarrator/index.tsx
@@ -333,7 +333,7 @@ export default definePlugin({
                 </Forms.FormText>
                 <Forms.FormText>
                     The special placeholders <code>{"{{USER}}"}</code>, <code>{"{{DISPLAY_NAME}}"}</code>, <code>{"{{NICKNAME}}"}</code>, <code>{"{{FRIEND_NICKNAME}}"}</code> and <code>{"{{CHANNEL}}"}</code>{" "}
-                    will be replaced with the user's name (nothing if it's yourself), the user's display name, the user's nickname on current server and the channel's name respectively
+                    will be replaced with the user's name (nothing if it's yourself), the user's display name, the user's nickname on current server, your custom defined friend nickname, and the channel's name respectively
                 </Forms.FormText>
                 {hasEnglishVoices && (
                     <>


### PR DESCRIPTION
The {{FRIEND_NICKNAME}} tag will narrate the user's friend nickname. In the case that you do not have a friend nickname defined for the user, it will have the same functionality as {{DISPLAY_NAME}}.