### PR TITLE
chore: change donor card text to include users without a badge

### DIFF
--- a/src/components/VencordSettings/VencordTab.tsx
+++ b/src/components/VencordSettings/VencordTab.tsx
@@ -115,7 +115,7 @@ function VencordSettings() {
                     <SpecialCard
                         title="Donations"
                         subtitle="Thank you for donating!"
-                        description="If you have gotten a badge from donating, Vencord users are able to see it! You can change it at any time by messaging @vending.machine."
+                        description="You can manage your perks at any time by messaging @vending.machine."
                         cardImage={VENNIE_DONATOR_IMAGE}
                         backgroundImage={DONOR_BACKGROUND_IMAGE}
                         backgroundColor="#ED87A9"

--- a/src/components/VencordSettings/VencordTab.tsx
+++ b/src/components/VencordSettings/VencordTab.tsx
@@ -115,7 +115,7 @@ function VencordSettings() {
                     <SpecialCard
                         title="Donations"
                         subtitle="Thank you for donating!"
-                        description="All Vencord users can see your badge! You can change it at any time by messaging @vending.machine."
+                        description="If you have gotten a badge from donating, Vencord users are able to see it! You can change it at any time by messaging @vending.machine."
                         cardImage={VENNIE_DONATOR_IMAGE}
                         backgroundImage={DONOR_BACKGROUND_IMAGE}
                         backgroundColor="#ED87A9"


### PR DESCRIPTION
title

#

<img width="637" alt="image" src="https://github.com/user-attachments/assets/039a9c38-d71f-4a2c-af25-beb24507a963" />
