### PR TITLE
Add NoDiscordJunk plugin

### DIFF
--- a/src/plugins/noDiscordJunk/hideAvatarDecorations.css
+++ b/src/plugins/noDiscordJunk/hideAvatarDecorations.css
@@ -1,0 +1,3 @@
+*[class^="avatarDecoration_"] {
+    display: none !important;
+}

--- a/src/plugins/noDiscordJunk/hideDiscoverButton.css
+++ b/src/plugins/noDiscordJunk/hideDiscoverButton.css
@@ -1,0 +1,3 @@
+div[class^="listItem_"]:has(div[data-list-item-id="guildsnav___guild-discover-button"]) {
+    display: none;
+}

--- a/src/plugins/noDiscordJunk/hideNitroButtons.css
+++ b/src/plugins/noDiscordJunk/hideNitroButtons.css
@@ -1,0 +1,13 @@
+[class^="channel"] > div > [href="/store"], /* Nitro Button above DM List */
+[class^="channelTextArea"] [class^="buttons"] > button, /* Hide Gift Button */
+[class^="upsellVisible"], /* Hide Banner Nitro Upsell Header */
+[class^="premiumIconWrapper"], /* Hide Nitro Icon on Banners */
+[class^="characterCount"] [class*="upsell"], /* "Send longer Messages with Discord Nitro!" */
+[class^="emojiSection"] [class*="shinyButton"], /* "Get Nitro" button in Emoji/Sticker modal" */
+[class*="tryItOutSection"], /*try nitro banner section on profile editor*/
+[class*="bannerNitroUpsell"], /* "Unlock Banner" in profile editor*/
+[class^="imageUploaderHint"], /* Hide nitro button from the text area */
+.channelTextArea_a7d72e .buttons_d0696b .container_efde15
+{
+    display: none !important;
+}

--- a/src/plugins/noDiscordJunk/hideProfileEffects.css
+++ b/src/plugins/noDiscordJunk/hideProfileEffects.css
@@ -1,0 +1,3 @@
+*[class^="profileEffects_"] {
+    display: none !important;
+}

--- a/src/plugins/noDiscordJunk/hideShopButton.css
+++ b/src/plugins/noDiscordJunk/hideShopButton.css
@@ -1,0 +1,3 @@
+a[data-list-item-id$="___shop"] {
+    display: none !important;
+}

--- a/src/plugins/noDiscordJunk/index.ts
+++ b/src/plugins/noDiscordJunk/index.ts
@@ -1,0 +1,117 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { disableStyle, enableStyle } from "@api/Styles";
+
+import hideAvatarDecorations from "./hideAvatarDecorations.css?managed";
+import hideDiscoverButton from "./hideDiscoverButton.css?managed";
+import hideNitroButtons from "./hideNitroButtons.css?managed";
+import hideProfileEffects from "./hideProfileEffects.css?managed";
+import hideShopButton from "./hideShopButton.css?managed";
+
+const settings = definePluginSettings({
+    nitro: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Remove Nitro buttons",
+        restartNeeded: true
+    },
+    shop: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Remove the Shop button",
+        restartNeeded: true
+    },
+    themes: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Remove profile themes",
+        restartNeeded: true
+    },
+    effects: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Remove profile effects",
+        restartNeeded: true
+    },
+    decorations: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Remove profile decorations",
+        restartNeeded: true
+    },
+    discover: {
+        type: OptionType.BOOLEAN,
+        default: false,
+        description: "Remove the \"Discover\" button",
+        restartNeeded: true
+    },
+});
+
+export default definePlugin({
+    name: "NoDiscordJunk",
+    description: "Gives the user options to disable default Discord junk such as nitro buttons, shop buttons etc.",
+    authors: [Devs.bamboooz],
+    patches: [
+        {
+            find: "hasThemeColors(){",
+            replacement: {
+                match: /get canUsePremiumProfileCustomization\(\){return /,
+                replace: "$&$self.showThemes()&&"
+            }
+        },
+    ],
+    start() {
+        if (settings.store.nitro) {
+            enableStyle(hideNitroButtons);
+        } else {
+            disableStyle(hideNitroButtons);
+        }
+
+        if (settings.store.shop) {
+            enableStyle(hideShopButton);
+        } else {
+            disableStyle(hideShopButton);
+        }
+
+        if (settings.store.effects) {
+            enableStyle(hideProfileEffects);
+        } else {
+            disableStyle(hideProfileEffects);
+        }
+
+        if (settings.store.decorations) {
+            enableStyle(hideAvatarDecorations);
+        } else {
+            disableStyle(hideAvatarDecorations);
+        }
+
+        if (settings.store.discover) {
+            enableStyle(hideDiscoverButton);
+        } else {
+            disableStyle(hideDiscoverButton);
+        }
+    },
+    settings,
+    showThemes: () => {
+        return !settings.store.themes;
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -588,6 +588,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    bamboooz: {
+        name: "Bamboooz",
+        id: 686996046408056873n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Adds a NoDiscordJunk plugin that allows the user to turn off annoying Discord features such as: profile effects, avatar decorations, profile themes, nitro buttons, shop buttons, discover button.