### PR TITLE
VolumeBooster: Fix error when going back to the default device

### DIFF
--- a/src/plugins/volumeBooster/index.ts
+++ b/src/plugins/volumeBooster/index.ts
@@ -136,7 +136,7 @@ export default definePlugin({
         // @ts-expect-error
         if (data.sinkId != null && data.sinkId !== data.audioContext.sinkId && "setSinkId" in AudioContext.prototype) {
             // @ts-expect-error https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/setSinkId
-            data.audioContext.setSinkId(data.sinkId);
+            data.audioContext.setSinkId(data.sinkId === "default" ? "" : data.sinkId);
         }
 
         data.gainNode.gain.value = data._mute


### PR DESCRIPTION
For some reason (please let me know if you know why), setSinkId errors when passed the string "default", despite discords code doing the same thing and not erroring. This can cause errors in the console and audio playback to stop if you swap to the default device after using a non-default device.

an empty string is the same as the default device