### PR TITLE
PluginSettings: stop authors overflow from showing +0

### DIFF
--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -248,6 +248,7 @@ export default function PluginModal({ plugin, onRestartNeeded, onClose, transiti
                     <Forms.FormTitle tag="h3" style={{ marginTop: 8, marginBottom: 0 }}>Authors</Forms.FormTitle>
                     <div style={{ width: "fit-content", marginBottom: 8 }}>
                         <UserSummaryItem
+                            className="user-summary-item"
                             users={authors}
                             count={plugin.authors.length}
                             guildId={undefined}

--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -174,6 +174,11 @@ export default function PluginModal({ plugin, onRestartNeeded, onClose, transiti
 
     function renderMoreUsers(_label: string, count: number) {
         const sliceCount = plugin.authors.length - count;
+
+        if (sliceCount <= 0) {
+            return null;
+        }
+
         const sliceStart = plugin.authors.length - sliceCount;
         const sliceEnd = sliceStart + plugin.authors.length - count;
 

--- a/src/components/PluginSettings/styles.css
+++ b/src/components/PluginSettings/styles.css
@@ -81,3 +81,7 @@
 .vc-plugins-info-icon:not(:hover, :focus) {
     color: var(--text-muted);
 }
+
+.user-summary-item svg:last-child>foreignObject {
+    mask: none !important;
+}


### PR DESCRIPTION
this is what it looks like before & after

![image of 6 authors with +0 showing at the end](https://github.com/user-attachments/assets/6b62c510-5c5b-45e3-ae5b-593bcb3edaf0)
![image of 6 authors without +0 overflow](https://github.com/user-attachments/assets/26011281-6af6-40be-97c1-0a30e94f93fd)
