### PR TITLE
MessageLogger: fix attachment deletion detection

### DIFF
--- a/src/plugins/messageLogger/HistoryModal.tsx
+++ b/src/plugins/messageLogger/HistoryModal.tsx
@@ -31,9 +31,11 @@ export function openHistoryModal(message: any) {
 }
 
 export function HistoryModal({ modalProps, message }: { modalProps: ModalProps; message: any; }) {
-    const [currentTab, setCurrentTab] = useState(message.editHistory.length);
-    const timestamps = [message.firstEditTimestamp, ...message.editHistory.map(m => m.timestamp)];
-    const contents = [...message.editHistory.map(m => m.content), message.content];
+    const filteredEditHistory = message.editHistory.filter(edit => edit.attachmentsEdited === false);
+
+    const [currentTab, setCurrentTab] = useState(filteredEditHistory.length);
+    const timestamps = [message.firstEditTimestamp, ...filteredEditHistory.map(m => m.timestamp)];
+    const contents = [...filteredEditHistory.map(m => m.content), message.content];
 
     return (
         <ModalRoot {...modalProps} size={ModalSize.LARGE}>

--- a/src/plugins/messageLogger/deleteStyleOverlay.css
+++ b/src/plugins/messageLogger/deleteStyleOverlay.css
@@ -1,3 +1,24 @@
 .messagelogger-deleted {
+    transition: 150ms background-color ease-in-out;
+}
+
+.messagelogger-deleted:not(.messagelogger-highlight-bypass) {
     background-color: hsla(var(--red-430-hsl, 0 85% 61%) / 15%) !important;
+}
+
+.messagelogger-deleted-attachment-overlay::after {
+    transition: 150ms opacity ease-in-out;
+    position: absolute;
+    pointer-events: none;
+    content: "";
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #ff2919;
+    opacity: 0;
+}
+
+.messagelogger-deleted-attachment-overlay:not(.messagelogger-highlight-bypass)::after {
+    opacity: 0.2;
 }

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,4 +1,4 @@
-.messagelogger-deleted {
+.messagelogger-deleted:not(.messagelogger-highlight-bypass) {
     --text-normal: var(--status-danger, #f04747);
     --interactive-normal: var(--status-danger, #f04747);
     --text-muted: var(--status-danger, #f04747);

--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -6,3 +6,20 @@
     --text-link: var(--red-460, #be3535);
     --header-primary: var(--red-460, #be3535);
 }
+
+.messagelogger-deleted-attachment-overlay::after {
+    transition: 150ms opacity ease-in-out;
+    position: absolute;
+    pointer-events: none;
+    content: "";
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #ff2919;
+    opacity: 0;
+}
+
+.messagelogger-deleted-attachment-overlay:not(.messagelogger-highlight-bypass)::after {
+    opacity: 0.2;
+}

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -375,13 +375,11 @@ export default definePlugin({
                         "   $3.message.edited_timestamp && ($3.message.content !== m.content || $3.message.attachments.length != m.attachments.length) ? (() => {" +
                         "       if (m.attachments && m.attachments.length > 0) {" +
                         "           const newAttachmentIds = new Set($3.message.attachments.map(a => a.id));" +
-                        "           const deletedAttachments = m.attachments.filter(a => !newAttachmentIds.has(a.id))" +
-                        "               .map(a => ({...a, deleted: true}));" +
-                        "           if (deletedAttachments.length > 0) {" +
-                        "               const combinedAttachments = [...$3.message.attachments, ...deletedAttachments];" +
-                        "               $3.message.attachments = combinedAttachments;" +
-                        "               $4 = $4.update(m.id, m => m.set('attachments', combinedAttachments));" +
-                        "           }" +
+                        "           const updatedAttachments = m.attachments.map(a =>" +
+                        "               newAttachmentIds.has(a.id) ? a : { ...a, deleted: true }" +
+                        "           );" +
+                        "           $3.message.attachments = updatedAttachments;" +
+                        "           $4 = $4.update(m.id, m => m.set('attachments', updatedAttachments));" +
                         "       }" +
                         "       return m.set('editHistory',[...(m.editHistory || []), $self.makeEdit($3.message, m)]);" +
                         "   })() :" +

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -2,15 +2,12 @@
     display: none;
 }
 
-.messagelogger-deleted
-:is(
-    .messagelogger-deleted-attachment,
+.messagelogger-deleted:is(.messagelogger-deleted-attachment,
     .emoji,
     [data-type="sticker"],
     [class*="embedIframe"],
     [class*="embedSpotify"],
-    [class*="imageContainer"]
-) {
+    [class*="imageContainer"]) {
     filter: grayscale(1) !important;
     transition: 150ms filter ease-in-out;
 
@@ -21,6 +18,17 @@
     &:hover {
         filter: grayscale(0) !important;
     }
+}
+
+.messagelogger-deleted-attachment-overlay::after {
+    position: absolute;
+    content: "";
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #ff2919;
+    opacity: 0.2;
 }
 
 .messagelogger-deleted [class*="spoilerWarning"] {

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -2,7 +2,7 @@
     display: none;
 }
 
-.messagelogger-deleted:is(.messagelogger-deleted-attachment,
+.messagelogger-deleted:not(.messagelogger-highlight-bypass):is(.messagelogger-deleted-attachment,
     .emoji,
     [data-type="sticker"],
     [class*="embedIframe"],
@@ -20,19 +20,7 @@
     }
 }
 
-.messagelogger-deleted-attachment-overlay::after {
-    position: absolute;
-    pointer-events: none;
-    content: "";
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: #ff2919;
-    opacity: 0.2;
-}
-
-.messagelogger-deleted [class*="spoilerWarning"] {
+.messagelogger-deleted:not(.messagelogger-highlight-bypass) [class*="spoilerWarning"] {
     color: var(--status-danger);
 }
 

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -22,6 +22,7 @@
 
 .messagelogger-deleted-attachment-overlay::after {
     position: absolute;
+    pointer-events: none;
     content: "";
     top: 0;
     left: 0;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -588,6 +588,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    xNasuni: {
+        name: "xNasuni",
+        id: 515356922585677834n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/c4549e11-e6fb-4435-9ec0-5486fc43124a" width="390px"/><img src="https://github.com/user-attachments/assets/212e3d5e-d2d6-47c8-8af0-7d76fb8ed2e9" height="462px" align="right"/>



i opted for a red overlay instead of grayscale since it is hard to notice on certain images and impossible on other types of attachments
i haven't seen any bugs with this after testing for a bit, and i don't think any of my changes have any negative unintended side effects

fixes #2249 