### PR TITLE
Pass CLI args through pnpm inject script to installer

### DIFF
--- a/scripts/runInstaller.mjs
+++ b/scripts/runInstaller.mjs
@@ -24,6 +24,7 @@ import { dirname, join } from "path";
 import { Readable } from "stream";
 import { finished } from "stream/promises";
 import { fileURLToPath } from "url";
+import { parseArgs } from "util";
 
 const BASE_URL = "https://github.com/Vencord/Installer/releases/latest/download/";
 const INSTALLER_PATH_DARWIN = "VencordInstaller.app/Contents/MacOS/VencordInstaller";
@@ -118,8 +119,47 @@ const installerBin = await ensureBinary();
 
 console.log("Now running Installer...");
 
+const args = parseArgs({
+    strict: false,
+    options: {
+        branch: {
+            type: "string",
+        },
+        debug: {
+            type: "boolean",
+        },
+        help: {
+            type: "boolean",
+        },
+        install: {
+            type: "boolean",
+        },
+        "install-openasar": {
+            type: "boolean",
+        },
+        location: {
+            type: "string",
+        },
+        repair: {
+            type: "boolean",
+        },
+        uninstall: {
+            type: "boolean",
+        },
+        "uninstall-openasar": {
+            type: "boolean",
+        },
+        "update-self": {
+            type: "boolean",
+        },
+        version: {
+            type: "boolean",
+        },
+    },
+});
+
 try {
-    execFileSync(installerBin, {
+    execFileSync(installerBin, args.positionals, {
         stdio: "inherit",
         env: {
             ...process.env,

--- a/scripts/runInstaller.mjs
+++ b/scripts/runInstaller.mjs
@@ -158,8 +158,16 @@ const args = parseArgs({
     },
 });
 
+let argsArray = [
+    ...Object.entries(args.values).flatMap(([key, value]) => [
+        `--${key}`,
+        value,
+    ]),
+    ...args.positionals,
+].filter((x) => x !== true);
+
 try {
-    execFileSync(installerBin, args.positionals, {
+    execFileSync(installerBin, argsArray, {
         stdio: "inherit",
         env: {
             ...process.env,


### PR DESCRIPTION
Changes the runInstaller.mjs to pass through CLI args.
This would allow for skipping the interaction bit which saves a microseconds when developing a plugin with native functions:

![image](https://github.com/user-attachments/assets/c1e544da-fcf5-4df6-9722-88face1e62a8)

very convenient 