### PR TITLE
Replace UNPKG with jsDelivr

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -101,7 +101,7 @@ if (IS_VESKTOP || !IS_VANILLA) {
                 // TODO: Restrict this to only imported packages with fixed version.
                 // Perhaps auto generate with esbuild
                 csp["script-src"] ??= [];
-                csp["script-src"].push("'unsafe-eval'", "https://unpkg.com", "https://cdnjs.cloudflare.com");
+                csp["script-src"].push("'unsafe-eval'", "https://cdn.jsdelivr.net", "https://cdnjs.cloudflare.com");
                 headers[header] = [stringifyPolicy(csp)];
             }
         };

--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -69,8 +69,8 @@ export interface ApngFrameData {
 // The below code is only used on the Desktop (electron) build of Vencord.
 // Browser (extension) builds do not contain these remote imports.
 
-export const shikiWorkerSrc = `https://unpkg.com/@vap/shiki-worker@0.0.8/dist/${IS_DEV ? "index.js" : "index.min.js"}`;
-export const shikiOnigasmSrc = "https://unpkg.com/@vap/shiki@0.10.3/dist/onig.wasm";
+export const shikiWorkerSrc = `https://cdn.jsdelivr.net/npm/@vap/shiki-worker@0.0.8/dist/${IS_DEV ? "index.js" : "index.min.js"}`;
+export const shikiOnigasmSrc = "https://cdn.jsdelivr.net/npm/@vap/shiki@0.10.3/dist/onig.wasm";
 
 // @ts-expect-error
-export const getStegCloak = /* #__PURE__*/ makeLazy(() => import("https://unpkg.com/stegcloak-dist@1.0.0/index.js"));
+export const getStegCloak = /* #__PURE__*/ makeLazy(() => import("https://cdn.jsdelivr.net/npm/stegcloak-dist@1.0.0/index.js"));


### PR DESCRIPTION
UNPKG has not been actively maintained and has been down since `Mar 15, 2025` (https://github.com/unpkg/unpkg/issues/412).

The PR replaces UNPKG usage so that the Monaco Editor and Shiki are loaded from jsDelivr. And since all the UNPKG usages are replaced, the CSP is also changed to `cdn.jsdelivr.net`.