### PR TITLE
MessageLatency: Fix off by one error on some deltas

### DIFF
--- a/src/plugins/messageLatency/index.tsx
+++ b/src/plugins/messageLatency/index.tsx
@@ -63,11 +63,11 @@ export default definePlugin({
 
     stringDelta(delta: number, showMillis: boolean) {
         const diff: Diff = {
-            days: Math.round(delta / (60 * 60 * 24 * 1000)),
-            hours: Math.round((delta / (60 * 60 * 1000)) % 24),
-            minutes: Math.round((delta / (60 * 1000)) % 60),
-            seconds: Math.round(delta / 1000 % 60),
-            milliseconds: Math.round(delta % 1000)
+            days: Math.floor(delta / (60 * 60 * 24 * 1000)),
+            hours: Math.floor((delta / (60 * 60 * 1000)) % 24),
+            minutes: Math.floor((delta / (60 * 1000)) % 60),
+            seconds: Math.floor(delta / 1000 % 60),
+            milliseconds: Math.floor(delta % 1000)
         };
 
         const str = (k: DiffKey) => diff[k] > 0 ? `${diff[k]} ${diff[k] > 1 ? k : k.substring(0, k.length - 1)}` : null;


### PR DESCRIPTION
Previously, a delta such as `25199000` would display as 
![image](https://github.com/user-attachments/assets/27782d22-27bf-4407-9204-ffe30b594736)

However, this is just incorrect as it is actually 
![image](https://github.com/user-attachments/assets/09f6433f-84c3-471b-a25e-1a4bacd00553)

The logic on this should be correct now, I tested with a few different values.