### PR TITLE
Remove code font from callTimer

### DIFF
--- a/src/plugins/callTimer/index.tsx
+++ b/src/plugins/callTimer/index.tsx
@@ -91,6 +91,6 @@ export default definePlugin({
             deps: [channelId]
         });
 
-        return <p style={{ margin: 0 }}>Connected for <span style={{ fontFamily: "var(--font-code)" }}>{formatDuration(time)}</span></p>;
+        return <p style={{ margin: 0 }}>Connected for <span>{formatDuration(time)}</span></p>;
     }
 });


### PR DESCRIPTION
Why would this be using the code font?? I know I could change it with css but there really should be sensible defaults.