### PR TITLE
Plugin: VisualDefresh

### DIFF
--- a/src/plugins/visualDefresh/README.md
+++ b/src/plugins/visualDefresh/README.md
@@ -1,0 +1,5 @@
+# Visual Defresh
+
+This plugin makes Discord look mostly like it did before the visual overhaul.
+
+*Classes special to the refresh may still be applied*

--- a/src/plugins/visualDefresh/index.ts
+++ b/src/plugins/visualDefresh/index.ts
@@ -6,11 +6,10 @@
 
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
-import { FluxDispatcher } from "@webpack/common";
-import { FluxEvents } from "@webpack/types";
+import { FluxDispatcher as Flux } from "@webpack/common";
 
-const defaultOptions = {
-    type: "EXPERIMENT_OVERRIDE_BUCKET" as FluxEvents,
+const options = {
+    type: "EXPERIMENT_OVERRIDE_BUCKET" as const,
     experimentId: "2024-05_desktop_visual_refresh",
 };
 
@@ -20,10 +19,6 @@ export default definePlugin({
     authors: [Devs.Inbestigator],
     dependencies: ["Experiments"],
     tags: ["Experiments"],
-    start() {
-        FluxDispatcher.dispatch({ ...defaultOptions, experimentBucket: -1 });
-    },
-    stop() {
-        FluxDispatcher.dispatch({ ...defaultOptions, experimentBucket: null });
-    },
+    start: () => Flux.dispatch({ ...options, experimentBucket: -1 }),
+    stop: () => Flux.dispatch({ ...options, experimentBucket: null }),
 });

--- a/src/plugins/visualDefresh/index.ts
+++ b/src/plugins/visualDefresh/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { FluxDispatcher } from "@webpack/common";
+import { FluxEvents } from "@webpack/types";
+
+const defaultOptions = {
+    type: "EXPERIMENT_OVERRIDE_BUCKET" as FluxEvents,
+    experimentId: "2024-05_desktop_visual_refresh",
+};
+
+export default definePlugin({
+    name: "VisualDefresh",
+    description: "Removes the new desktop visual refresh.",
+    authors: [Devs.Inbestigator],
+    dependencies: ["Experiments"],
+    tags: ["Experiments"],
+    start() {
+        FluxDispatcher.dispatch({ ...defaultOptions, experimentBucket: -1 });
+    },
+    stop() {
+        FluxDispatcher.dispatch({ ...defaultOptions, experimentBucket: null });
+    },
+});


### PR DESCRIPTION
This plugin makes Discord look mostly like it did before the visual overhaul.

*Classes special to the refresh may still be applied*

I noticed that a ton of users are annoyed by the new look, and can't seem to find the experiments tab. So this plugin automagically de-applies the experiment for them.