### PR TITLE
Update NSFWGateBypass to allow users in the UK/Australia to bypass nsfw age filter

### DIFF
--- a/src/plugins/nsfwGateBypass/index.ts
+++ b/src/plugins/nsfwGateBypass/index.ts
@@ -32,9 +32,9 @@ export default definePlugin({
             },
         },
         {
-            find: ".ageVerificationStatus=1",
+            find: ".ageVerificationStatus=null",
             replacement: {
-                match: /(?<=\.ageVerificationStatus=)(1|2)(?=[,;])/,
+                match: /(?<=\.ageVerificationStatus=)null!==.+?(?=[,;])/,
                 replace: "3",
             },
         },

--- a/src/plugins/nsfwGateBypass/index.ts
+++ b/src/plugins/nsfwGateBypass/index.ts
@@ -1,6 +1,6 @@
 /*
  * Vencord, a modification for Discord's desktop app
- * Copyright (c) 2022 Vendicated and contributors
+ * Copyright (c) 2025 Vendicated and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,13 +22,20 @@ import definePlugin from "@utils/types";
 export default definePlugin({
     name: "NSFWGateBypass",
     description: "Allows you to access NSFW channels without setting/verifying your age",
-    authors: [Devs.Commandtechno],
+    authors: [Devs.Commandtechno, Devs.dotle31],
     patches: [
         {
             find: ".nsfwAllowed=null",
             replacement: {
                 match: /(?<=\.nsfwAllowed=)null!==.+?(?=[,;])/,
                 replace: "!0",
+            },
+        },
+        {
+            find: ".ageVerificationStatus=1",
+            replacement: {
+                match: /(?<=\.ageVerificationStatus=)(1|2)(?=[,;])/,
+                replace: "3",
             },
         },
     ],

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -588,6 +588,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    dotle31: {
+        name: "dotle31",
+        id: 1197702222893547590n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Discord has recently added age verification for certain users in the UK and Australia, meaning that the current bypass will not work. I have added a new regex to match the new property (`ageVerificationStatus`) and set it to `3` (verified) 