### PR TITLE
ShowHiddenChannels: show 'Last message sent' instead of 'Last message created'

### DIFF
--- a/src/plugins/showHiddenChannels/components/HiddenChannelLockScreen.tsx
+++ b/src/plugins/showHiddenChannels/components/HiddenChannelLockScreen.tsx
@@ -210,7 +210,7 @@ function HiddenChannelLockScreen({ channel }: { channel: ExtendedChannel; }) {
 
                 {lastMessageId &&
                     <Text variant="text-md/normal">
-                        Last {channel.isForumChannel() ? "post" : "message"} created:
+                        Last {channel.isForumChannel() ? "post created" : "message sent"}:
                         <Timestamp timestamp={new Date(SnowflakeUtils.extractTimestamp(lastMessageId))} />
                     </Text>
                 }


### PR DESCRIPTION
This clears up confusion especially when viewing a locked text channel

Previous Text Channel:
Same thing as the below screenshot, but with "Last message created."

New Text Channel:
![image](https://github.com/user-attachments/assets/03cea361-f49b-45f3-8a9a-d6cd2ce03fdd)

Forum Channel is kept the same:
![image](https://github.com/user-attachments/assets/fc6f0135-ad73-44dc-8a62-c2b20b359882)
