### PR TITLE
Add plugin OldUIBack

### DIFF
--- a/src/plugins/oldUIBack/index.ts
+++ b/src/plugins/oldUIBack/index.ts
@@ -1,0 +1,31 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { Webpack } from "Vencord";
+
+export default definePlugin({
+    name: "OldUIBack",
+    authors: [Devs.minsiam],
+    description: "Brings back the old client UI (before March 2025)",
+
+    start() {
+        Webpack.Common.FluxDispatcher.dispatch({
+            type: "EXPERIMENT_OVERRIDE_BUCKET",
+            experimentId: "2024-05_desktop_visual_refresh",
+            experimentBucket: 0
+        });
+    },
+
+    stop() {
+        Webpack.Common.FluxDispatcher.dispatch({
+            type: "EXPERIMENT_OVERRIDE_BUCKET",
+            experimentId: "2024-05_desktop_visual_refresh",
+            experimentBucket: null
+        });
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,6 +589,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    minsiam: {
+        name: "0m11",
+        id: 222008551327924224n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Hey, this is a simple plugin that brings reverts the new client UI. Currently it's really simple, but I want to keep on updating it again and again when Discord patches it.