### PR TITLE
new plugin: noDiscordTitleBar

### DIFF
--- a/src/plugins/noDiscordTitleBar/index.ts
+++ b/src/plugins/noDiscordTitleBar/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "noDiscordTitleBar",
+    description: "Removes the Discord title bar. (useful if you use bucket 0 on the experimental Desktop Visual Refresh or if Discord adds back the disease title bar)",
+    authors: [Devs.developerv],
+
+    start() {
+        const style = document.createElement("style");
+        style.id = "no-discord-titlebar";
+        style.textContent = `
+            [class*=titleBar] { display: none !important; }
+        `;
+        document.head.appendChild(style);
+    },
+
+    stop() {
+        document.getElementById("no-discord-titlebar")?.remove();
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,6 +589,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    developerv: {
+        name: "dev_v1545",
+        id: 1211429000346476564n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Removes the Discord title bar. If you use the experimental Visual Desktop Refresh on bucket 0, you may hate the disease disgusting Discord title bar. This plugin removes it. Also, if Discord for some reason adds back the title bar this will be useful too.