### PR TITLE
Make NoDevtoolsWarning required

### DIFF
--- a/src/plugins/noDevtoolsWarning/index.ts
+++ b/src/plugins/noDevtoolsWarning/index.ts
@@ -23,6 +23,7 @@ export default definePlugin({
     name: "NoDevtoolsWarning",
     description: "Disables the 'HOLD UP' banner in the console. As a side effect, also prevents Discord from hiding your token, which prevents random logouts.",
     authors: [Devs.Ven],
+    required: true,
     patches: [{
         find: "setDevtoolsCallbacks",
         replacement: {


### PR DESCRIPTION
Since NoDevtoolsWarning also fixes session issues, making NoDevtoolsWarning a required plugin would get rid of reoccurring issues being opened up on logouts.

The plugin's impact is minimal aside from the session fix and removing the console banner, so nothing else is changed that could potentially get in the way of the user.