### PR TITLE
ServerInfo: Rename "Nitro Boosts" to "Server Boosts"

### DIFF
--- a/src/plugins/serverInfo/GuildInfoModal.tsx
+++ b/src/plugins/serverInfo/GuildInfoModal.tsx
@@ -198,7 +198,7 @@ function ServerInfoTab({ guild }: GuildProps) {
         "Vanity Link": guild.vanityURLCode ? (<a>{`discord.gg/${guild.vanityURLCode}`}</a>) : "-", // Making the anchor href valid would cause Discord to reload
         "Preferred Locale": guild.preferredLocale || "-",
         "Verification Level": ["None", "Low", "Medium", "High", "Highest"][guild.verificationLevel] || "?",
-        "Nitro Boosts": `${guild.premiumSubscriberCount ?? 0} (Level ${guild.premiumTier ?? 0})`,
+        "Server Boosts": `${guild.premiumSubscriberCount ?? 0} (Level ${guild.premiumTier ?? 0})`,
         "Channels": GuildChannelStore.getChannels(guild.id)?.count - 1 || "?", // - null category
         "Roles": Object.keys(GuildStore.getRoles(guild.id)).length - 1, // - @everyone
     };


### PR DESCRIPTION
Minor correction. The official name is Server Boosts, not Nitro Boosts.
![Screenshot 2025-04-06 100726](https://github.com/user-attachments/assets/fe20a74e-bb74-41d1-b5b1-04306cacbddb)
