### PR TITLE
feat(plugin): Show Role Icons in compact mode

### DIFF
--- a/src/plugins/forceRoleIcon/README.md
+++ b/src/plugins/forceRoleIcon/README.md
@@ -1,0 +1,11 @@
+# ForceRoleIcon
+
+Restores the lost ability to show role icons in compact mode.
+
+## Before and After
+
+### Before
+![Before](https://github.com/user-attachments/assets/58ae9d58-d377-45e5-bf35-114267f491ee)
+
+### After
+![After](https://github.com/user-attachments/assets/e0d9440d-a0b8-4813-a1e7-44375788f75c)

--- a/src/plugins/forceRoleIcon/index.ts
+++ b/src/plugins/forceRoleIcon/index.ts
@@ -19,7 +19,6 @@
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 
-
 export default definePlugin({
     name: "ForceRoleIcon",
     description: "Forces role icons to display next to messages in compact mode.",

--- a/src/plugins/forceRoleIcon/index.ts
+++ b/src/plugins/forceRoleIcon/index.ts
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+
+export default definePlugin({
+    name: "ForceRoleIcon",
+    description: "Forces role icons to display next to messages in compact mode.",
+    authors: [Devs.jamesbt365],
+    patches: [
+        {
+            find: "Message Username",
+            replacement: {
+                match: /(?<=\?2:)0(?=\})/,
+                replace: "1"
+            }
+        }
+    ],
+});


### PR DESCRIPTION
Relatively simple plugin, only submitting it because Discord as per usual broke (either intentionally or unintentionally) being able to do this before.

Before discord released the new UI, you could just enable avatars in compact mode, then just see out the avatar element if you didn't want it. Now even while showing the avatar, you don't see the role icon.

Could be seen as niche, but I'd like this feature back and it doesn't seem like a burden for Vencord, so here we go.
