### PR TITLE
fix: exclude whole support category from venbot in messagelogger

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -23,7 +23,7 @@ import { updateMessage } from "@api/MessageUpdater";
 import { Settings } from "@api/Settings";
 import { disableStyle, enableStyle } from "@api/Styles";
 import ErrorBoundary from "@components/ErrorBoundary";
-import { Devs } from "@utils/constants";
+import { Devs, SUPPORT_CATEGORY_ID, VENBOT_USER_ID } from "@utils/constants";
 import { getIntlMessage } from "@utils/discord";
 import { Logger } from "@utils/Logger";
 import { classes } from "@utils/misc";
@@ -295,8 +295,8 @@ export default definePlugin({
             ignoreChannels.includes(ChannelStore.getChannel(message.channel_id)?.parent_id) ||
             (isEdit ? !logEdits : !logDeletes) ||
             ignoreGuilds.includes(ChannelStore.getChannel(message.channel_id)?.guild_id) ||
-            // Ignore Venbot in the support channel
-            (message.channel_id === "1026515880080842772" && message.author?.id === "1017176847865352332");
+            // Ignore Venbot in the support channels
+            (ChannelStore.getChannel(message.channel_id)?.parent_id === SUPPORT_CATEGORY_ID && message.author?.id === VENBOT_USER_ID);
     },
 
     EditMarker({ message, className, children, ...props }: any) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/341e4c5b-f29c-4aaf-859b-e92f1e59f413)

# 

So this doesn't happen, doesn't happen when a new channel is created here with vencord-support