### PR TITLE
Fix spelling mistake with plugin description

### DIFF
--- a/src/plugins/pauseInvitesForever/index.tsx
+++ b/src/plugins/pauseInvitesForever/index.tsx
@@ -45,7 +45,7 @@ function disableInvites(guildId: string) {
 export default definePlugin({
     name: "PauseInvitesForever",
     tags: ["DisableInvitesForever"],
-    description: "Brings back the option to pause invites indefinitely that stupit Discord removed.",
+    description: "Brings back the option to pause invites indefinitely that stupid Discord removed.",
     authors: [Devs.Dolfies, Devs.amia],
 
     patches: [


### PR DESCRIPTION
Noticed the error in client so wrote up a quick pull request so a fix can be included in the next Vencord update. 