### PR TITLE
Add setting to Spotify Controlls

### DIFF
--- a/src/plugins/spotifyControls/PlayerComponent.tsx
+++ b/src/plugins/spotifyControls/PlayerComponent.tsx
@@ -295,6 +295,49 @@ function Info({ track }: { track: Track; }) {
         return (
             <div id={cl("album-expanded-wrapper")}>
                 {i}
+                {Settings.plugins.SpotifyControls.showAlbumInfoOnExpand && <div id={cl("titles")}>
+                    <Forms.FormText
+                        variant="text-sm/semibold"
+                        id={cl("song-title")}
+                        className={cl("ellipoverflow")}
+                        title={track.name}
+                        {...makeLinkProps("Song", track.id, `/track/${track.id}`)}
+                    >
+                        {track.name}
+                    </Forms.FormText>
+                    {track.artists.some(a => a.name) && (
+                        <Forms.FormText variant="text-sm/normal" className={cl(["ellipoverflow", "secondary-song-info"])}>
+                            <span className={cl("song-info-prefix")}>by&nbsp;</span>
+                            {track.artists.map((a, i) => (
+                                <React.Fragment key={a.name}>
+                                    <span
+                                        className={cl("artist")}
+                                        style={{ fontSize: "inherit" }}
+                                        title={a.name}
+                                        {...makeLinkProps("Artist", a.id, `/artist/${a.id}`)}
+                                    >
+                                        {a.name}
+                                    </span>
+                                    {i !== track.artists.length - 1 && <span className={cl("comma")}>{", "}</span>}
+                                </React.Fragment>
+                            ))}
+                        </Forms.FormText>
+                    )}
+                    {track.album.name && (
+                        <Forms.FormText variant="text-sm/normal" className={cl(["ellipoverflow", "secondary-song-info"])}>
+                            <span className={cl("song-info-prefix")}>on&nbsp;</span>
+                            <span
+                                id={cl("album-title")}
+                                className={cl("album")}
+                                style={{ fontSize: "inherit" }}
+                                title={track.album.name}
+                                {...makeLinkProps("Album", track.album.id, `/album/${track.album.id}`)}
+                            >
+                                {track.album.name}
+                            </span>
+                        </Forms.FormText>
+                    )}
+                </div>}
             </div>
         );
 

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -49,6 +49,11 @@ export default definePlugin({
             type: OptionType.BOOLEAN,
             description: "Restart currently playing track when pressing the previous button if playtime is >3s",
             default: true
+        },
+        showAlbumInfoOnExpand: {
+            type: OptionType.BOOLEAN,
+            description: "Show album info when expanding the album cover",
+            default: false
         }
     },
     patches: [

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -32,7 +32,7 @@ function toggleHoverControls(value: boolean) {
 export default definePlugin({
     name: "SpotifyControls",
     description: "Adds a Spotify player above the account panel",
-    authors: [Devs.Ven, Devs.afn, Devs.KraXen72, Devs.Av32000, Devs.nin0dev],
+    authors: [Devs.Ven, Devs.afn, Devs.KraXen72, Devs.Av32000, Devs.nin0dev, Devs.froggypanda],
     options: {
         hoverControls: {
             description: "Show controls on hover",

--- a/src/plugins/spotifyControls/index.tsx
+++ b/src/plugins/spotifyControls/index.tsx
@@ -50,7 +50,7 @@ export default definePlugin({
             description: "Restart currently playing track when pressing the previous button if playtime is >3s",
             default: true
         },
-        showAlbumInfoOnExpand: {
+        showAlbumInfoOnAlbumExpand: {
             type: OptionType.BOOLEAN,
             description: "Show album info when expanding the album cover",
             default: false

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,6 +589,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    froggypanda: {
+        name: "froggypanda",
+        id: 188851079050428427n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Added the "Show Album Info On Album Expand" setting to show track name, artist name, and album name when the album image is expanded.