### PR TITLE
Fix BetterFolders plugin

### DIFF
--- a/src/plugins/betterFolders/FolderSideBar.tsx
+++ b/src/plugins/betterFolders/FolderSideBar.tsx
@@ -48,7 +48,7 @@ export default ErrorBoundary.wrap(guildsBarProps => {
         gridArea: "betterFoldersSidebar"
     } satisfies CSSProperties;
 
-    if (!guilds || !settings.store.sidebarAnim) {
+    if (!guilds || !!!settings.store.sidebarAnimDuration) {
         return visible
             ? <div style={barStyle}>{Sidebar}</div>
             : null;
@@ -60,7 +60,7 @@ export default ErrorBoundary.wrap(guildsBarProps => {
             from={{ width: 0 }}
             enter={{ width: guilds.getBoundingClientRect().width }}
             leave={{ width: 0 }}
-            config={{ duration: 200 }}
+            config={{ duration: settings.store.sidebarAnimDuration }}
         >
             {(animationStyle, show) =>
                 show && (

--- a/src/plugins/betterFolders/index.tsx
+++ b/src/plugins/betterFolders/index.tsx
@@ -317,11 +317,21 @@ export default definePlugin({
         return child => {
             if (!isBetterFolders) return true;
 
-            if (child?.type === "ul" && child.props?.children != null) {
+            if (child?.type === "ul" && child.props?.children?.props?.children?.props?.children !== null) {
                 // Filter out everything but the guild list (removes the DM button & favorites button)
-                child.props.children.props.children.props.children = child.props.children.props.children.props.children.filter(child => child?.props?.renderTreeNode != null)[0];
-                // Assign properties of the sidebar somewhere where the other functions can read them
-                child.props.children.props.children.props.children.props = { ...child.props.children.props.children.props.children.props, isBetterFolders, betterFoldersExpandedIds };
+                child.props.children.props.children.props.children = child.props.children.props.children.props.children.filter(child => child?.props?.renderTreeNode != null || child?.props?.className != null && child.props.className.startsWith("bottomSection"))[0];
+                if (child.props.children.props.children.props.children.props.className != null && child.props.children.props.children.props.children.props.className.startsWith("bottomSection")) { // Discord experiment
+                    // The experiment splits the sidebar into two sections: a topSection (DMs and favorited channels), and a bottomSection
+                    // We want the bottom section, as that is where guilds, folders, etc are put
+                    child.props.children.props.children.props.children.props.children = child.props.children.props.children.props.children.props.children.filter(child => child?.props?.children != null)[0];
+                    // The bottomSection has some junk inside it, so we need to clean it out
+                    child.props.children.props.children.props.children.props.children.props.children = child.props.children.props.children.props.children.props.children.props.children.filter(child => child?.props?.renderTreeNode != null)[0];
+                    // Now we can assign the properties we want to the guilds list so that the other functions can read them
+                    child.props.children.props.children.props.children.props.children.props.children.props = { ...child.props.children.props.children.props.children.props.children.props.children.props, isBetterFolders, betterFoldersExpandedIds };
+                } else {
+                    // No experiment is enabled, so we just go straight to assigning properties to the guilds list
+                    child.props.children.props.children.props.children.props = { ...child.props.children.props.children.props.children.props, isBetterFolders, betterFoldersExpandedIds };
+                }
                 return true;
             }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,6 +589,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    alfuwu: {
+        name: "alfuwu",
+        id: 1038466644353232967n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This PR fixes the Better Folders plugin's sidebar, and additionally turns the Sidebar Anim boolean config value into a slider determining the time it takes for the animation to finish for more customizability.

For the past few days, whenever I opened a folder with the Better Folders plugin while having the custom sidebar enabled, it would simply provide me with a blank bar and no guilds inside it.
![image](https://github.com/user-attachments/assets/05b78001-bb92-49ee-b4c4-1824a9440a7a)

This PR restores the functionality to how it worked before:
![image](https://github.com/user-attachments/assets/42e23ddf-36fc-4f07-95fa-036bf9bf05a7)

After writing the fix I found #3396, so if this is a duplicate, please close it.