### PR TITLE
fix ImageZoom for animated webp images

### DIFF
--- a/src/plugins/imageZoom/components/Magnifier.tsx
+++ b/src/plugins/imageZoom/components/Magnifier.tsx
@@ -203,7 +203,7 @@ export const Magnifier = ErrorBoundary.wrap<MagnifierProps>(({ instance, size: i
                         }}
                         width={`${box.width * zoom.current}px`}
                         height={`${box.height * zoom.current}px`}
-                        src={instance.props.src}
+                        src={instance.props.src + "?animated=true"}
                         alt=""
                     />
                 )}


### PR DESCRIPTION
Animated webps won't animate without `?animated=true` being appended to the URL,
this doesn't currently check for the type of image before appending but from my testing this hasn't broken anything so it should be good enough