### PR TITLE
New Plugin: AutoFixTwitterEmbeds

### DIFF
--- a/src/plugins/autoFixupEmbeds/index.ts
+++ b/src/plugins/autoFixupEmbeds/index.ts
@@ -1,0 +1,53 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { MessageObject } from "@api/MessageEvents";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+type ReplacementRecords = Record<string, string>;
+
+export default definePlugin({
+    name: "AutoFixTwitterEmbeds",
+    description: "Automatically rewrites on sent message that contains x.com or twitter.com links to fixupx.com and fxtwitter.com to fix broken Twitter embeds in Discord.",
+    authors: [Devs.lpirito],
+
+    start() { },
+
+    replacements: {
+        "x.com": "fixupx.com",
+        "twitter.com": "fxtwitter.com"
+    } as ReplacementRecords,
+
+    onBeforeMessageSend(_, msg: MessageObject) {
+        return this.onSend(msg);
+    },
+
+    onBeforeMessageEdit(_cid, _mid, msg: MessageObject) {
+        return this.onSend(msg);
+    },
+
+    onSend(msg: MessageObject) {
+        if (!msg?.content) return;
+
+        let alreadyFixed = false;
+        for (const [_, target] of Object.entries(this.replacements)) {
+            if (msg.content.includes(target)) {
+                alreadyFixed = true;
+                break;
+            }
+        }
+        if (alreadyFixed) return;
+
+        for (const [source, target] of Object.entries(this.replacements)) {
+            if (msg.content.includes(source)) {
+                const escapedSource = source.replace(/\./g, "\\.");
+                const regex = new RegExp(escapedSource, "g");
+                msg.content = msg.content.replace(regex, target);
+            }
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -225,6 +225,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "lewisakura",
         id: 96269247411400704n
     },
+    lpirito: {
+        name: "lpirito",
+        id: 148851420127428608n
+    },
     RuiNtD: {
         name: "RuiNtD",
         id: 157917665162297344n


### PR DESCRIPTION
# Description
This plugin edits the current user message before being sent/edited to replace `x.com` or `twitter.com` with the corresponding fx embed URLs (`fxtwitter.com` and `fixupx.com`)

_Note: On the future this could improved to affect all the incoming messages or other URLs apart from twitter/x, i wanted to try this simple approach to see if this would be used by someone or if im just lazy._


https://github.com/user-attachments/assets/52d1f357-4109-4f7d-83bc-71c3c35d37d7

