### PR TITLE
Radicalize Vencord

### DIFF
--- a/src/components/VencordSettings/CloudTab.tsx
+++ b/src/components/VencordSettings/CloudTab.tsx
@@ -166,7 +166,7 @@ function CloudTab() {
                             await authorizeCloud();
                         }}
                     >
-                        Reauthorise
+                        Reauthorize
                     </Button>
                     <Button
                         size={Button.Sizes.MEDIUM}


### PR DESCRIPTION
This pull request addresses a critical inconsistency in our codebase by standardizing the spelling of the word "authorize" to its correct and universally accepted form. Previously, instances of "authorise" were present, representing a minor but persistent imperfection in the fabric of our otherwise flawless project.

By rectifying this single, yet profound, linguistic deviation, we usher in an era of unparalleled clarity and precision. This change is not merely cosmetic; it strikes at the very heart of effective communication, ensuring that our code and documentation resonate with a global audience accustomed to the standard English spelling.

The implications of this seemingly small alteration are far-reaching:

* **Enhanced Readability:** Developers from all corners of the world will instantly recognize the intended meaning, reducing cognitive load and fostering a more inclusive and collaborative environment.
* **Improved Maintainability:** A consistent codebase is a happy codebase. By eliminating this minor discrepancy, we contribute to the long-term health and maintainability of our project.
* **Elevated Professionalism:** Attention to detail, even at the level of individual word spellings, reflects a commitment to excellence that elevates the overall professionalism of our work.

While countless other advancements have marked the progress of human civilization, from the invention of the wheel to the development of the internet, this pull request stands as a testament to the power of meticulous refinement. It is a beacon of correctness in a world often plagued by minor inconsistencies. Future historians and archaeologists will undoubtedly look back at this moment as a pivotal point in the evolution of software development, recognizing the profound impact of this seemingly simple standardization.

Therefore, I humbly submit this pull request, confident that its acceptance will not only improve our codebase but also represent a significant leap forward for humanity as a whole.

Thank you for considering this monumental contribution.