### PR TITLE
fix: disable deep links on the accept invite page

### DIFF
--- a/src/plugins/noDeepLinks.web/index.ts
+++ b/src/plugins/noDeepLinks.web/index.ts
@@ -15,8 +15,7 @@ export default definePlugin({
 
     noop: () => { },
     acceptInvite: () => {
-        const server_invite = document.location.href.slice("https://discord.com/invite/".length);
-        open(`https://discord.com/app/invite-with-guild-onboarding/${server_invite}`, "_self");
+        open(document.location.href.replace(/invite/, "app/invite-with-guild-onboarding"), "_self");
     },
 
     patches: [
@@ -30,7 +29,7 @@ export default definePlugin({
         { // This says that it has no effect, but it does
             find: /openApp\(/,
             replacement: {
-                match: /(\i)\.(\i)\.launch\((\i),(\i)=>\{(\i)\.(\i)\.dispatch\((\i)\?(\{.*?\}):(\{.*?\})\)\}\)/,
+                match: /\i\.\i\.launch\(\i,\i=>\{\i\.\i\.dispatch\(\i\?\{.*?\}:\{.*?\}\)\}\)/,
                 replace: "$self.acceptInvite()",
             },
             all: true

--- a/src/plugins/noDeepLinks.web/index.ts
+++ b/src/plugins/noDeepLinks.web/index.ts
@@ -10,16 +10,30 @@ import definePlugin from "@utils/types";
 export default definePlugin({
     name: "DisableDeepLinks",
     description: "Disables Discord's stupid deep linking feature which tries to force you to use their Desktop App",
-    authors: [Devs.Ven],
+    authors: [Devs.Ven, Devs.Cootshk],
     required: true,
 
     noop: () => { },
+    acceptInvite: () => {
+        const server_invite = document.location.href.slice("https://discord.com/invite/".length);
+        open(`https://discord.com/app/invite-with-guild-onboarding/${server_invite}`, "_self");
+    },
 
-    patches: [{
-        find: /\.openNativeAppModal\(.{0,50}?\.DEEP_LINK/,
-        replacement: {
-            match: /\i\.\i\.openNativeAppModal/,
-            replace: "$self.noop",
+    patches: [
+        {
+            find: /\.openNativeAppModal\(.{0,50}?\.DEEP_LINK/,
+            replacement: {
+                match: /\i\.\i\.openNativeAppModal/,
+                replace: "$self.noop",
+            }
+        },
+        { // This says that it has no effect, but it does
+            find: /openApp\(/,
+            replacement: {
+                match: /(\i)\.(\i)\.launch\((\i),(\i)=>\{(\i)\.(\i)\.dispatch\((\i)\?(\{.*?\}):(\{.*?\})\)\}\)/,
+                replace: "$self.acceptInvite()",
+            },
+            all: true
         }
-    }]
+    ]
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,6 +589,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    Cootshk: {
+        name: "Cootshk",
+        id: 921605971577548820n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Even with the DisableDeepLinks plugin, discord will still try to force you to use the app on the invite (https://discord.gg/vencord) page.

This PR allows makes the `Accept Invite` button redirect to `https://discord.com/app/invite-with-guild-onboarding/vencord`, skipping the desktop app.

Even though the link says invite-with-guild-onboarding, you can join servers without onboarding and you can also join new servers just fine.