### PR TITLE
Allow LastFM plugin to load credentials from path

### DIFF
--- a/src/plugins/lastfm/index.tsx
+++ b/src/plugins/lastfm/index.tsx
@@ -20,7 +20,7 @@ import { definePluginSettings } from "@api/Settings";
 import { Link } from "@components/Link";
 import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
-import definePlugin, { OptionType } from "@utils/types";
+import definePlugin, { OptionType, PluginNative } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
 import { ApplicationAssetUtils, FluxDispatcher, Forms } from "@webpack/common";
 
@@ -106,7 +106,7 @@ const settings = definePluginSettings({
         type: OptionType.STRING,
     },
     apiKey: {
-        description: "last.fm api key",
+        description: "last.fm api key, or path to the api key",
         type: OptionType.STRING,
     },
     shareUsername: {
@@ -192,6 +192,8 @@ const settings = definePluginSettings({
     }
 });
 
+const Native = VencordNative.pluginHelpers.LastFMRichPresence as PluginNative<typeof import("./native")>;
+
 export default definePlugin({
     name: "LastFMRichPresence",
     description: "Little plugin for Last.fm rich presence",
@@ -229,9 +231,17 @@ export default definePlugin({
             return null;
 
         try {
+            let apiKey: string;
+
+            if (IS_DISCORD_DESKTOP || IS_VESKTOP) {
+                apiKey = await Native.loadApiKey(settings.store.apiKey);
+            } else {
+                apiKey = settings.store.apiKey;
+            }
+
             const params = new URLSearchParams({
                 method: "user.getrecenttracks",
-                api_key: settings.store.apiKey,
+                api_key: apiKey,
                 user: settings.store.username,
                 limit: "1",
                 format: "json"

--- a/src/plugins/lastfm/native.ts
+++ b/src/plugins/lastfm/native.ts
@@ -1,0 +1,24 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { readFile } from "fs/promises";
+
+// input may be an API key or Path and an API key should be returned asynchronously.
+export async function loadApiKey(_, input: string): Promise<string> {
+    if (/[a-zA-Z0-9]{32}/.test(input))
+        return input;
+
+    try {
+        return await readFile(input, { encoding: "utf-8" });
+    } catch (err) {
+        console.log("Failed to read api key", err);
+
+        // This helps with backwards compatability, just in case
+        // someone has an api key that doesn't test against the
+        // regex.
+        return input;
+    }
+}


### PR DESCRIPTION
Storing secrets in my config.json is less than ideal!

This PR moves to allow the last.fm rich presence plugin to load secrets from a path. Used in combination with a credential manager it can provide a more secure way to store credentials.

