### PR TITLE
feat(plugin): FixAudioFiles

### DIFF
--- a/src/plugins/FixAudioFiles/index.tsx
+++ b/src/plugins/FixAudioFiles/index.tsx
@@ -13,7 +13,7 @@ let last: HTMLAudioElement | null = null;
 export default definePlugin({
     name: "FixAudioFiles",
     description: "Prevents overlapping audio by enforcing one 'sound' at a time.",
-    authors: [Devs.eagle],
+    authors: [Devs.prodbyeagle],
 
     start() {
         if (originalPlay) return;

--- a/src/plugins/FixAudioFiles/index.tsx
+++ b/src/plugins/FixAudioFiles/index.tsx
@@ -1,0 +1,49 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 prodbyeagle and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+let originalPlay: typeof Audio.prototype.play | null = null;
+let last: HTMLAudioElement | null = null;
+
+export default definePlugin({
+    name: "FixAudioFiles",
+    description: "Prevents overlapping audio by enforcing one 'sound' at a time.",
+    authors: [Devs.eagle],
+
+    start() {
+        if (originalPlay) return;
+
+        originalPlay = Audio.prototype.play;
+
+        Audio.prototype.play = function (...args: any[]) {
+            if (last && last !== this) {
+                try {
+                    last.pause();
+                    last.dispatchEvent(new Event("pause"));
+                    last.dispatchEvent(new Event("ended"));
+                } catch { }
+            }
+
+            last = this as HTMLAudioElement;
+
+            try {
+                return originalPlay!.apply(this, args);
+            } catch (e) {
+                return Promise.reject(e);
+            }
+        };
+    },
+
+    stop() {
+        if (!originalPlay) return;
+
+        Audio.prototype.play = originalPlay;
+        originalPlay = null;
+        last = null;
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,8 +589,8 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
-    eagle: {
-        name: "eagle",
+    prodbyeagle: {
+        name: "prodbyeagle",
         id: 893759402832699392n
     }
 } satisfies Record<string, Dev>);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,6 +589,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    eagle: {
+        name: "eagle",
+        id: 893759402832699392n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
this plugin ensures that only one audio source plays at a time. when a new sound starts, any currently playing sound is automatically paused. this can especially be useful for quickly previewing sound effects or samples.