### PR TITLE
Grant unsafeWindow in Userscript for AdGuard Extensions

### DIFF
--- a/browser/userscript.meta.js
+++ b/browser/userscript.meta.js
@@ -9,6 +9,7 @@
 // @license         GPL-3.0
 // @match           *://*.discord.com/*
 // @grant           GM_xmlhttpRequest
+// @grant           unsafeWindow
 // @run-at          document-start
 // @compatible      chrome Chrome + Tampermonkey or Violentmonkey
 // @compatible      firefox Firefox Tampermonkey


### PR DESCRIPTION
Add `@grant unsafeWindow` to make it work with [AdGuard Extensions](https://adguard.com/kb/general/extensions/)
Tested on macOS in official Discord App and Safari