### PR TITLE
feat(Plugin): serverNotes

### DIFF
--- a/src/plugins/serverNotes/allNotesViewerModal.tsx
+++ b/src/plugins/serverNotes/allNotesViewerModal.tsx
@@ -1,0 +1,239 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./allNotesViewerStyles.css";
+
+import { classNameFactory } from "@api/Styles";
+import { Logger as LoggerClass } from "@utils/Logger";
+import { ModalCloseButton, ModalContent, ModalHeader, ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { findByProps } from "@webpack";
+import {
+    Button,
+    Forms,
+    GuildChannelStore,
+    GuildStore,
+    Parser,
+    React,
+    ScrollerAuto,
+    TextInput,
+    useEffect,
+    useMemo,
+    useState,
+} from "@webpack/common";
+import type { Guild } from "discord-types/general";
+
+import { openServerNotesModal } from "./serverNotesModal";
+import { getAllNotes, getAllUniqueTags, NoteData } from "./settingsUtils";
+
+const cl = classNameFactory("vc-all-notes-");
+const logger = new LoggerClass("ServerNotes");
+
+const IconUtils = findByProps("getGuildIconURL", "getChannelIconURL", "getUserAvatarURL");
+const NavigationRouter = findByProps("transitionToGuild", "transitionTo");
+const MarkupClasses = findByProps("markup", "markdown", "markupRtl");
+
+interface TagPillProps {
+    tag: string;
+    isFilterPill?: boolean;
+    onClick?: () => void;
+    isSelected?: boolean;
+    className?: string;
+}
+const TagPill: React.FC<TagPillProps> = ({ tag, isFilterPill, onClick, isSelected, className }) => (
+    <div
+        className={cl(
+            "tag-pill",
+            isFilterPill ? "filter" : "display",
+            isSelected ? "selected" : "",
+            className
+        )}
+        onClick={onClick}
+        role={isFilterPill ? "button" : undefined}
+        tabIndex={isFilterPill ? 0 : undefined}
+        onKeyDown={isFilterPill && onClick ? (e: React.KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onClick(); } } : undefined}
+        aria-pressed={isFilterPill ? isSelected : undefined}
+    >
+        {tag}
+    </div>
+);
+
+interface AllNotesViewerModalProps {
+    modalProps: {
+        transitionState: number;
+        onClose: () => void;
+    };
+}
+
+interface EnrichedNoteWithTags extends NoteData {
+    guildId: string;
+    guild: Guild;
+}
+
+export const AllNotesViewerModalComponent: React.FC<AllNotesViewerModalProps> = ({ modalProps }) => {
+    const [allNotesData, setAllNotesData] = useState<Record<string, NoteData>>({});
+    const [searchTerm, setSearchTerm] = useState("");
+    const [uniqueTags, setUniqueTags] = useState<string[]>([]);
+    const [selectedFilterTags, setSelectedFilterTags] = useState<string[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        setIsLoading(true);
+        setAllNotesData(getAllNotes());
+        setUniqueTags(getAllUniqueTags());
+        setIsLoading(false);
+    }, []);
+
+    const enrichedNotes: EnrichedNoteWithTags[] = useMemo(() => {
+        return Object.entries(allNotesData)
+            .map(([guildId, noteData]) => ({
+                ...noteData,
+                guildId,
+                guild: GuildStore.getGuild(guildId),
+            }))
+            .filter(enrichedNote => !!enrichedNote.guild) as EnrichedNoteWithTags[];
+    }, [allNotesData]);
+
+    const filteredNotes = useMemo(() => {
+        if (isLoading) return [];
+        const lowerSearchTerm = searchTerm.toLowerCase();
+
+        return enrichedNotes.filter(
+            ({ text, tags, guild }) =>
+                (lowerSearchTerm === "" ||
+                    text.toLowerCase().includes(lowerSearchTerm) ||
+                    guild.name.toLowerCase().includes(lowerSearchTerm) ||
+                    tags.some(tag => tag.toLowerCase().includes(lowerSearchTerm))) &&
+                (selectedFilterTags.length === 0 || selectedFilterTags.every(filterTag => tags.map(t => t.toLowerCase()).includes(filterTag.toLowerCase())))
+        );
+    }, [searchTerm, enrichedNotes, selectedFilterTags, isLoading]);
+
+    const toggleFilterTag = (tagToToggle: string) => {
+        const lowerTagToToggle = tagToToggle.toLowerCase();
+        setSelectedFilterTags(prev =>
+            prev.map(t => t.toLowerCase()).includes(lowerTagToToggle)
+                ? prev.filter(t => t.toLowerCase() !== lowerTagToToggle)
+                : [...prev, tagToToggle]
+        );
+    };
+
+    const ParsedNoteSnippet: React.FC<{ noteText: string; guildId: string; }> = ({ noteText, guildId }) => {
+        if (!noteText) return <div className={cl("list-item-note-snippet", "empty-text")}>(No text content)</div>;
+        const snippet = noteText.length > 200 ? noteText.substring(0, 200) + "..." : noteText;
+        try {
+            const parsedContent = Parser.parse(snippet, true, { channelId: "", guildId, mentioned: true });
+            return <div className={cl("list-item-note-snippet", MarkupClasses?.markup)}>{parsedContent}</div>;
+        } catch (e) {
+            logger.error("Error parsing note snippet in AllNotesViewerModal", e);
+            return <p className={cl("list-item-note-snippet", "parse-error")}>{snippet}</p>;
+        }
+    };
+
+    const handleGoToGuild = (guildId: string) => {
+        const defaultChannel = GuildChannelStore.getDefaultChannel(guildId);
+        const defaultChannelId = defaultChannel?.id;
+        if (NavigationRouter && typeof NavigationRouter.transitionToGuild === "function") {
+            NavigationRouter.transitionToGuild(guildId, defaultChannelId);
+        }
+        modalProps.onClose();
+    };
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE} className={cl("modal-root")}>
+            <ModalHeader className={cl("modal-header")}>
+                <h1 className={cl("title")}>All Server Notes</h1>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+
+            <div className={cl("filter-controls-area")}>
+                <TextInput
+                    placeholder="Search notes, server names, or tags..."
+                    value={searchTerm}
+                    onChange={setSearchTerm}
+                    className={cl("filter-input")}
+                    aria-label="Search all notes"
+                    autoFocus
+                />
+                {uniqueTags.length > 0 && (
+                    <Forms.FormSection title="Filter by Tags" className={cl("tag-filter-section")}>
+                        <ScrollerAuto fade={true} className={cl("tag-filter-scroller")}>
+                            <div className={cl("tag-filter-list")}>
+                                {uniqueTags.map(tag => (
+                                    <TagPill
+                                        key={tag}
+                                        tag={tag}
+                                        isFilterPill
+                                        onClick={() => toggleFilterTag(tag)}
+                                        isSelected={selectedFilterTags.map(t => t.toLowerCase()).includes(tag.toLowerCase())}
+                                        className={cl("filter-tag-pill")}
+                                    />
+                                ))}
+                            </div>
+                        </ScrollerAuto>
+                    </Forms.FormSection>
+                )}
+            </div>
+
+            <ModalContent className={cl("modal-content")}>
+                {isLoading ? (
+                    <div className={cl("loading-state")}>Loading notes...</div>
+                ) : filteredNotes.length === 0 ? (
+                    <div className={cl("empty-state")}>
+                        <p>{searchTerm || selectedFilterTags.length > 0 ? "No notes match your current filters." : "You haven't written any server notes yet!"}</p>
+                    </div>
+                ) : (
+                    <ScrollerAuto fade={true} className={cl("list-scroller")}>
+                        <div className={cl("list-container")}>
+                            {filteredNotes.map(note => {
+                                let guildIconDisplay: React.ReactNode = null;
+                                const { guild, guildId, text: noteText, tags } = note;
+
+                                if (IconUtils && typeof IconUtils.getGuildIconURL === "function" && guild?.id && guild?.icon) {
+                                    const iconUrl = IconUtils.getGuildIconURL({ id: guild.id, icon: guild.icon, size: 32, canAnimate: true });
+                                    if (iconUrl) {
+                                        guildIconDisplay = <img src={iconUrl} alt={`${guild.name} Icon`} className={cl("list-item-guild-icon")} />;
+                                    }
+                                }
+                                if (!guildIconDisplay && guild?.id && guild?.icon) {
+                                    const iconUrl = `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}.${guild.icon.startsWith("a_") ? "gif" : "png"}?size=32`;
+                                    guildIconDisplay = <img src={iconUrl} alt={`${guild.name} Icon`} className={cl("list-item-guild-icon")} />;
+                                }
+                                if (!guildIconDisplay) {
+                                    const initials = guild?.name?.split(" ").map(w => w[0]).join("").substring(0, 3).toUpperCase() || "?";
+                                    guildIconDisplay = <div className={cl("list-item-guild-icon", "placeholder")}>{initials}</div>;
+                                }
+
+                                return (
+                                    <div key={guildId} className={cl("list-item")}>
+                                        <div className={cl("list-item-header")}>
+                                            {guildIconDisplay}
+                                            <span className={cl("list-item-guild-name")}>{guild?.name || "Unknown Server"}</span>
+                                        </div>
+                                        {tags.length > 0 && (
+                                            <div className={cl("list-item-tags-display")}>
+                                                {tags.map(tag => <TagPill key={tag} tag={tag} className={cl("display-tag-pill")} />)}
+                                            </div>
+                                        )}
+                                        <ParsedNoteSnippet noteText={noteText} guildId={guildId} />
+                                        <div className={cl("list-item-actions")}>
+                                            <Button size={Button.Sizes.SMALL} onClick={() => guild && openServerNotesModal(guild)} className={cl("action-button")}>Edit</Button>
+                                            <Button size={Button.Sizes.SMALL} look={Button.Looks.LINK} color={Button.Colors.PRIMARY} onClick={() => handleGoToGuild(guildId)} className={cl("action-button", "go-to-server")}>Go to Server</Button>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </ScrollerAuto>
+                )}
+            </ModalContent>
+        </ModalRoot>
+    );
+};
+
+export function openAllNotesViewerModal() {
+    openModal(props => <AllNotesViewerModalComponent modalProps={props} />, {
+        modalKey: "all-server-notes-viewer-modal"
+    });
+}

--- a/src/plugins/serverNotes/allNotesViewerStyles.css
+++ b/src/plugins/serverNotes/allNotesViewerStyles.css
@@ -1,0 +1,295 @@
+.vc-all-notes-modal-root {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--background-primary);
+}
+
+.vc-all-notes-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--background-modifier-accent);
+    flex-shrink: 0;
+}
+
+.vc-all-notes-title {
+    font-family: var(--font-display);
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--header-primary);
+    line-height: 1.2;
+    margin: 0;
+}
+
+.vc-all-notes-filter-controls-area {
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--background-modifier-accent);
+    background-color: var(--background-secondary-alt);
+    flex-shrink: 0;
+}
+
+.vc-all-notes-filter-input {
+    width: 100%;
+    margin-bottom: 16px;
+}
+
+.vc-all-notes-filter-input input {
+    font-size: 15px;
+}
+
+.vc-all-notes-filter-tags-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--header-secondary);
+    text-transform: uppercase;
+    margin-bottom: 8px;
+}
+
+.vc-all-notes-tag-filter-buttons-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.vc-all-notes-tag-filter-button {
+    font-size: 13px;
+    font-weight: 500;
+    padding: 3px 8px !important;
+    border-radius: 4px;
+    line-height: 1.2;
+    min-height: auto !important;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.vc-all-notes-tag-filter-button.lookOutlined-3sRXeN {
+    border-width: 1px;
+}
+
+.vc-all-notes-tag-filter-button.lookOutlined-3sRXeN:hover {
+     background-color: var(--background-modifier-hover);
+}
+
+.vc-all-notes-tag-filter-button.lookFilled-1Gx00P.colorBrand-3pXr91 {
+    color: var(--white-500);
+}
+
+.vc-all-notes-tag-filter-button.lookFilled-1Gx00P.colorBrand-3pXr91:hover {
+    background-color: var(--brand-experiment-560);
+}
+
+
+.vc-all-notes-no-tags-available {
+    font-size: 13px;
+    color: var(--text-muted);
+    font-style: italic;
+    padding: 4px 0;
+}
+
+.vc-all-notes-clear-tags-button {
+    font-size: 12px;
+    margin-left: 4px;
+    color: var(--text-link);
+}
+
+.vc-all-notes-clear-tags-button:hover {
+    text-decoration: underline;
+    color: var(--text-link-hover, var(--text-link));
+}
+
+.vc-all-notes-modal-content {
+    flex-grow: 1;
+    min-height: 200px;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.vc-all-notes-list-scroller {
+    flex-grow: 1;
+}
+
+.vc-all-notes-list-container {
+    padding: 0 20px 16px;
+}
+
+.vc-all-notes-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 40px 20px;
+    height: 100%;
+    color: var(--text-muted);
+}
+
+.vc-all-notes-empty-state-text {
+    font-size: 16px;
+    line-height: 1.4;
+}
+
+.vc-all-notes-list-item {
+    background-color: var(--background-secondary);
+    border: 1px solid var(--background-modifier-accent);
+    border-radius: 5px;
+    padding: 12px 16px;
+    margin-bottom: 12px;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.vc-all-notes-list-item:last-child {
+    margin-bottom: 0;
+}
+
+.vc-all-notes-list-item:hover {
+    border-color: var(--background-modifier-hover);
+    background-color: var(--background-secondary-alt);
+}
+
+.vc-all-notes-list-item-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.vc-all-notes-list-item-guild-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    margin-right: 10px;
+    object-fit: cover;
+    background-color: var(--background-accent);
+    flex-shrink: 0;
+}
+
+.vc-all-notes-list-item-guild-icon-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--interactive-normal);
+}
+
+.vc-all-notes-list-item-guild-name {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--header-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+
+.vc-all-notes-list-item-tags-display {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.vc-all-notes-tag-pill.vc-all-notes-display-tag-pill {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background-color: var(--background-tertiary);
+    color: var(--text-normal);
+    border: 1px solid var(--background-modifier-accent);
+    line-height: 1.2;
+}
+
+.vc-all-notes-list-item-note-snippet {
+    font-size: 14px;
+    color: var(--text-normal);
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    max-height: calc(1.4em * 4);
+    overflow: hidden;
+    margin: 0;
+}
+
+.vc-all-notes-list-item-note-snippet.empty-text,
+.vc-all-notes-list-item-note-snippet.parse-error {
+    font-style: italic;
+    color: var(--text-muted);
+}
+
+.vc-all-notes-list-item-note-snippet.parse-error {
+    color: var(--text-danger);
+}
+
+.vc-all-notes-list-item-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 12px;
+    align-items: center;
+}
+
+.vc-all-notes-action-button {
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.vc-all-notes-tag-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background-color: var(--background-secondary-alt);
+    border: 1px solid var(--input-background);
+    color: var(--text-normal);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: default;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.vc-all-notes-tag-pill-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 120px;
+}
+
+.vc-all-notes-tag-pill-remove {
+    background: none;
+    border: none;
+    color: var(--interactive-muted);
+    cursor: pointer;
+    padding: 0;
+    margin-left: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.vc-all-notes-tag-pill-remove:hover {
+    color: var(--interactive-hover);
+    background-color: var(--background-modifier-hover);
+}
+
+.vc-all-notes-tag-pill-icon {
+    width: 12px;
+    height: 12px;
+}
+
+.vc-all-notes-tag-pill[role="button"]:hover,
+.vc-all-notes-tag-pill[role="button"]:focus-within {
+    border-color: var(--interactive-hover);
+    background-color: var(--background-modifier-hover);
+}
+
+.vc-all-notes-tag-filter-button:focus,
+.vc-all-notes-clear-tags-button:focus,
+.vc-all-notes-action-button:focus {
+    box-shadow: 0 0 0 2px var(--focus-primary);
+}

--- a/src/plugins/serverNotes/index.tsx
+++ b/src/plugins/serverNotes/index.tsx
@@ -1,0 +1,60 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { addContextMenuPatch, findGroupChildrenByChildId, NavContextMenuPatchCallback, removeContextMenuPatch } from "@api/ContextMenu";
+import definePlugin from "@utils/types";
+import { Menu, React } from "@webpack/common";
+import { Guild } from "discord-types/general";
+
+import { openAllNotesViewerModal } from "./allNotesViewerModal";
+import { openServerNotesModal } from "./serverNotesModal";
+
+const PLUGIN_NAME = "ServerNotes";
+
+const guildContextPatch: NavContextMenuPatchCallback = (children, { guild }: { guild: Guild; }) => {
+    let group = findGroupChildrenByChildId("privacy", children);
+    if (!group) {
+        group = children;
+    }
+
+    if (!group.some(item => item && item.props && typeof (item.props as { id?: string; }).id === "string" && (item.props as { id: string; }).id === "vc-server-notes")) {
+        group.push(
+            <Menu.MenuItem
+                id="vc-server-notes"
+                label="Server Note"
+                action={() => openServerNotesModal(guild)}
+            />
+        );
+    }
+
+    if (!group.some(item => item && item.props && typeof (item.props as { id?: string; }).id === "string" && (item.props as { id: string; }).id === "vc-all-server-notes")) {
+        group.push(
+            <Menu.MenuItem
+                id="vc-all-server-notes"
+                label="View All Server Notes"
+                action={() => openAllNotesViewerModal()}
+            />
+        );
+    }
+};
+
+export default definePlugin({
+    name: PLUGIN_NAME,
+    description: "Take per-server notes and view all notes.",
+    authors: [
+        { name: "m3rcury_", id: 0n }
+    ],
+
+    start() {
+        addContextMenuPatch("guild-context", guildContextPatch);
+        addContextMenuPatch("guild-header-popout", guildContextPatch);
+    },
+
+    stop() {
+        removeContextMenuPatch("guild-context", guildContextPatch);
+        removeContextMenuPatch("guild-header-popout", guildContextPatch);
+    }
+});

--- a/src/plugins/serverNotes/serverNotesModal.tsx
+++ b/src/plugins/serverNotes/serverNotesModal.tsx
@@ -1,0 +1,329 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles.css";
+
+import { classNameFactory } from "@api/Styles";
+import { CogWheel, PencilIcon } from "@components/Icons";
+import {
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalRoot,
+    ModalSize,
+    openModal
+} from "@utils/modal";
+import { findByProps } from "@webpack";
+import {
+    Button,
+    Forms,
+    GuildStore,
+    Parser,
+    React,
+    ScrollerAuto,
+    TextArea,
+    TextInput,
+    Tooltip,
+    useEffect,
+    useMemo,
+    useState
+} from "@webpack/common";
+import type { Guild } from "discord-types/general";
+
+import { getNoteForServer, NoteData, saveNoteForServer } from "./settingsUtils";
+
+const cl = classNameFactory("vc-snotes-");
+const EditIcon = PencilIcon;
+
+const MarkupClasses = findByProps("markup", "markdown", "markupRtl");
+const IconUtils = findByProps("getGuildIconURL", "getChannelIconURL", "getUserAvatarURL");
+
+const ConfirmationModalModule = findByProps("openModalLazy", "openConfirmationModal");
+
+interface TagComponentProps {
+    tag: string;
+    onRemove?: (tag: string) => void;
+    readOnly?: boolean;
+    className?: string;
+}
+const TagComponent: React.FC<TagComponentProps> = ({ tag, onRemove, readOnly, className }) => (
+    <div className={cl("tag-item", readOnly ? "readonly" : "", className)}>
+        <CogWheel className={cl("tag-item-icon")} />
+        <span className={cl("tag-item-text")}>{tag}</span>
+        {!readOnly && onRemove && (
+            <button
+                type="button"
+                className={cl("tag-item-remove")}
+                onClick={() => onRemove(tag)}
+                aria-label={`Remove tag ${tag}`}
+            >
+            </button>
+        )}
+    </div>
+);
+
+interface ServerNotesModalProps {
+    guild: Guild;
+    modalProps: {
+        transitionState: number;
+        onClose: () => void;
+    };
+}
+
+const ServerNotesModalComponent: React.FC<ServerNotesModalProps> = ({ guild, modalProps }) => {
+    const [currentNoteData, setCurrentNoteData] = useState<NoteData>({ text: "", tags: [] });
+    const [currentTextForEdit, setCurrentTextForEdit] = useState<string>("");
+    const [currentTagsForEdit, setCurrentTagsForEdit] = useState<string[]>([]);
+    const [tagInput, setTagInput] = useState<string>("");
+    const [originalNoteDataForEdit, setOriginalNoteDataForEdit] = useState<NoteData>({ text: "", tags: [] });
+
+    const [isEditing, setIsEditing] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [guildName, setGuildName] = useState<string>(guild.name);
+
+    let guildIconDisplay: React.ReactNode = null;
+    const currentGuildForIcon = GuildStore.getGuild(guild.id) || guild;
+
+    if (IconUtils && typeof IconUtils.getGuildIconURL === "function" && currentGuildForIcon?.id && currentGuildForIcon?.icon) {
+        const iconUrl = IconUtils.getGuildIconURL({
+            id: currentGuildForIcon.id,
+            icon: currentGuildForIcon.icon,
+            size: 28,
+            canAnimate: true
+        });
+        if (iconUrl) {
+            guildIconDisplay = <img src={iconUrl} alt={`${currentGuildForIcon.name} Icon`} className={cl("guild-icon")} />;
+        }
+    }
+    if (!guildIconDisplay && currentGuildForIcon?.id && currentGuildForIcon?.icon) {
+        const iconUrl = `https://cdn.discordapp.com/icons/${currentGuildForIcon.id}/${currentGuildForIcon.icon}.${currentGuildForIcon.icon.startsWith("a_") ? "gif" : "png"}?size=32`;
+        guildIconDisplay = <img src={iconUrl} alt={`${currentGuildForIcon.name} Icon`} className={cl("guild-icon")} />;
+    }
+    if (!guildIconDisplay) {
+        const initials = currentGuildForIcon?.name?.split(" ").map(word => word[0]).join("").substring(0, 3).toUpperCase() || "?";
+        guildIconDisplay = <div className={cl("guild-icon", "placeholder")}>{initials}</div>;
+    }
+
+    useEffect(() => {
+        setIsLoading(true);
+        const noteData = getNoteForServer(guild.id);
+        setCurrentNoteData(noteData);
+        setCurrentTextForEdit(noteData.text);
+        setCurrentTagsForEdit([...noteData.tags]);
+        setOriginalNoteDataForEdit(JSON.parse(JSON.stringify(noteData)));
+        setIsLoading(false);
+        setGuildName(GuildStore.getGuild(guild.id)?.name || guild.name);
+    }, [guild.id, guild.name]);
+
+    const hasUnsavedChanges = useMemo(() => {
+        if (!isEditing) return false;
+        const originalTagsString = [...originalNoteDataForEdit.tags].sort().join(",");
+        const currentTagsString = [...currentTagsForEdit].sort().join(",");
+        return originalNoteDataForEdit.text !== currentTextForEdit || originalTagsString !== currentTagsString;
+    }, [isEditing, currentTextForEdit, currentTagsForEdit, originalNoteDataForEdit]);
+
+    const handleEditClick = () => {
+        setCurrentTextForEdit(currentNoteData.text);
+        setCurrentTagsForEdit([...currentNoteData.tags]);
+        setOriginalNoteDataForEdit(JSON.parse(JSON.stringify(currentNoteData)));
+        setIsEditing(true);
+    };
+
+    const handleSaveClick = () => {
+        const cleanedTags = currentTagsForEdit.map(t => t.trim()).filter(t => t !== "");
+        saveNoteForServer(guild.id, currentTextForEdit, cleanedTags);
+        setCurrentNoteData({ text: currentTextForEdit, tags: cleanedTags });
+        setIsEditing(false);
+    };
+
+    const attemptClose = () => {
+        if (isEditing && hasUnsavedChanges) {
+            if (ConfirmationModalModule && typeof ConfirmationModalModule.openConfirmationModal === "function") {
+                ConfirmationModalModule.openConfirmationModal({
+                    title: "Unsaved Changes",
+                    content: "You have unsaved changes. Are you sure you want to discard them and close the modal?",
+                    confirmText: "Discard & Close",
+                    cancelText: "Keep Editing",
+                    danger: true,
+                    onConfirm: modalProps.onClose,
+                });
+            } else {
+                if (window.confirm("You have unsaved changes. Are you sure you want to discard them and close?")) {
+                    modalProps.onClose();
+                }
+            }
+        } else {
+            modalProps.onClose();
+        }
+    };
+
+    const handleCancelClick = () => {
+        if (hasUnsavedChanges) {
+            if (ConfirmationModalModule && typeof ConfirmationModalModule.openConfirmationModal === "function") {
+                ConfirmationModalModule.openConfirmationModal({
+                    title: "Discard Changes?",
+                    content: "Are you sure you want to discard your changes to this note?",
+                    confirmText: "Discard",
+                    cancelText: "Keep Editing",
+                    danger: true,
+                    onConfirm: () => {
+                        setCurrentTextForEdit(currentNoteData.text);
+                        setCurrentTagsForEdit([...currentNoteData.tags]);
+                        setIsEditing(false);
+                    },
+                });
+            } else {
+                if (window.confirm("Are you sure you want to discard your changes?")) {
+                    setCurrentTextForEdit(currentNoteData.text);
+                    setCurrentTagsForEdit([...currentNoteData.tags]);
+                    setIsEditing(false);
+                }
+            }
+        } else {
+            setIsEditing(false);
+        }
+    };
+
+    const handleAddTag = () => {
+        const newTag = tagInput.trim().toLowerCase();
+        if (newTag && !currentTagsForEdit.map(t => t.toLowerCase()).includes(newTag) && currentTagsForEdit.length < 10) {
+            setCurrentTagsForEdit([...currentTagsForEdit, newTag]);
+        }
+        setTagInput("");
+    };
+
+    const handleRemoveTag = (tagToRemove: string) => {
+        setCurrentTagsForEdit(currentTagsForEdit.filter(tag => tag !== tagToRemove));
+    };
+
+    const renderNoteContentViewMode = (noteDataToRender: NoteData, inGuildId: string) => {
+        if (isLoading) {
+            return <div className={cl("rendered-note-area", "empty", MarkupClasses?.markup)}>Loading note...</div>;
+        }
+        const { text: noteText, tags: noteTags } = noteDataToRender;
+        if (!noteText.trim() && noteTags.length === 0) {
+            return <div className={cl("rendered-note-area", "empty", MarkupClasses?.markup)}>No note or tags yet. Click the edit icon to add some!</div>;
+        }
+
+        let parsedTextContent: React.ReactNode = null;
+        if (noteText.trim()) {
+            try {
+                parsedTextContent = Parser.parse(noteText, true, { channelId: "", guildId: inGuildId, mentioned: true });
+            } catch (e) {
+                console.error("ServerNotes: Error parsing note text:", e);
+                parsedTextContent = <div className={cl("parse-error-text")}>Error displaying note content.</div>;
+            }
+        }
+
+        return (
+            <ScrollerAuto className={cl("rendered-note-area", MarkupClasses?.markup)}>
+                {noteTags.length > 0 && (
+                    <div className={cl("tags-view-area")}>
+                        {noteTags.map(tag => <TagComponent key={tag} tag={tag} readOnly className={cl("view-mode-tag")} />)}
+                    </div>
+                )}
+                {parsedTextContent || (noteTags.length > 0 ? null : <div className={cl("empty-text-placeholder")}>No text content.</div>)}
+            </ScrollerAuto>
+        );
+    };
+
+    const noteContentToDisplay = useMemo(() => {
+        if (isEditing) return null;
+        return renderNoteContentViewMode(currentNoteData, guild.id);
+    }, [currentNoteData, guild.id, isEditing, isLoading]);
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE} className={cl("modal-root")}>
+            <ModalHeader className={cl("modal-header")}>
+                <div className={cl("header-info-wrapper")}>
+                    {guildIconDisplay}
+                    <Forms.FormTitle tag="h1" className={cl("title")}>
+                        Note for {guildName}
+                    </Forms.FormTitle>
+                </div>
+                <div className={cl("header-actions-wrapper")}>
+                    {!isEditing && (
+                        <Tooltip text="Edit Note">
+                            {props => (
+                                <Button
+                                    {...props}
+                                    size={Button.Sizes.NONE}
+                                    look={Button.Looks.BLANK}
+                                    onClick={handleEditClick}
+                                    className={cl("edit-button")}
+                                    innerClassName={cl("edit-button-inner")}
+                                >
+                                    <EditIcon />
+                                </Button>
+                            )}
+                        </Tooltip>
+                    )}
+                    <ModalCloseButton onClick={attemptClose} className={cl("modal-close-button")} />
+                </div>
+            </ModalHeader>
+
+            <ModalContent className={cl("modal-content", isEditing ? "editing" : "viewing")}>
+                {isEditing ? (
+                    <div className={cl("edit-container")}>
+                        <TextArea
+                            className={cl("textarea")}
+                            value={currentTextForEdit}
+                            onChange={setCurrentTextForEdit}
+                            autoFocus
+                            rows={8}
+                        />
+                        <Forms.FormSection title="Tags" className={cl("tags-edit-section")}>
+                            <div className={cl("tag-input-area")}>
+                                <TextInput
+                                    value={tagInput}
+                                    onChange={setTagInput}
+                                    placeholder="Add a tag (e.g., important, todo)"
+                                    onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                                        if (e.key === "Enter" || e.key === ",") {
+                                            e.preventDefault();
+                                            handleAddTag();
+                                        }
+                                    }}
+                                    className={cl("tag-input")}
+                                    aria-label="New tag input"
+                                />
+                                <Button onClick={handleAddTag} size={Button.Sizes.SMALL} className={cl("tag-add-button")} disabled={!tagInput.trim()}>Add Tag</Button>
+                            </div>
+                            <ScrollerAuto className={cl("tags-list-scroller")}>
+                                <div className={cl("tags-list-editable")}>
+                                    {currentTagsForEdit.length === 0 && <span className={cl("no-tags-text")}>No tags yet.</span>}
+                                    {currentTagsForEdit.map(tag => (
+                                        <TagComponent key={tag} tag={tag} onRemove={handleRemoveTag} />
+                                    ))}
+                                </div>
+                            </ScrollerAuto>
+                        </Forms.FormSection>
+                    </div>
+                ) : (
+                    noteContentToDisplay
+                )}
+            </ModalContent>
+
+            <ModalFooter className={cl("modal-footer")}>
+                {isEditing ? (
+                    <>
+                        <Button onClick={handleCancelClick} look={Button.Looks.LINK} color={Button.Colors.PRIMARY} className={cl("cancel-button")}>Cancel</Button>
+                        <Button onClick={handleSaveClick} className={cl("save-button")} disabled={!hasUnsavedChanges}>Save</Button>
+                    </>
+                ) : (
+                    <div style={{ height: "40px" }} />
+                )}
+            </ModalFooter>
+        </ModalRoot>
+    );
+};
+
+export function openServerNotesModal(guild: Guild) {
+    openModal(props => <ServerNotesModalComponent guild={guild} modalProps={props} />, {
+        modalKey: `server-notes-modal-${guild.id}`
+    });
+}

--- a/src/plugins/serverNotes/settingsUtils.ts
+++ b/src/plugins/serverNotes/settingsUtils.ts
@@ -1,0 +1,117 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Settings } from "@api/Settings";
+
+const PLUGIN_NAME = "ServerNotes";
+const PLUGIN_SETTINGS_KEY = "notesData";
+
+export interface NoteData {
+    text: string;
+    tags: string[];
+}
+
+export interface ServerNotesData {
+    [guildId: string]: NoteData;
+}
+
+interface PluginSpecificSettings {
+    enabled: boolean;
+    [PLUGIN_SETTINGS_KEY]?: ServerNotesData;
+    [setting: string]: any;
+}
+
+function ensureNoteDataFormat(note: string | NoteData | undefined): NoteData {
+    if (typeof note === "string") {
+        return { text: note, tags: [] };
+    }
+    if (typeof note === "object" && note !== null && typeof note.text === "string") {
+        return {
+            ...note,
+            tags: Array.isArray(note.tags) ? note.tags.map(String) : []
+        };
+    }
+    return { text: "", tags: [] };
+}
+
+export function getAllNotes(): ServerNotesData {
+    let pluginSettings = Settings.plugins[PLUGIN_NAME] as PluginSpecificSettings | undefined;
+
+    if (!pluginSettings) {
+        pluginSettings = { enabled: true, [PLUGIN_SETTINGS_KEY]: {} };
+        Settings.plugins[PLUGIN_NAME] = pluginSettings;
+    } else {
+        if (typeof pluginSettings.enabled === "undefined") {
+            pluginSettings.enabled = true;
+        }
+        if (!pluginSettings[PLUGIN_SETTINGS_KEY]) {
+            pluginSettings[PLUGIN_SETTINGS_KEY] = {};
+        } else {
+            const notesFromSettings = pluginSettings[PLUGIN_SETTINGS_KEY] as Record<string, string | NoteData | undefined>;
+            const migratedNotes: ServerNotesData = {};
+            for (const guildId in notesFromSettings) {
+                if (Object.prototype.hasOwnProperty.call(notesFromSettings, guildId)) {
+                    migratedNotes[guildId] = ensureNoteDataFormat(notesFromSettings[guildId]);
+                }
+            }
+            pluginSettings[PLUGIN_SETTINGS_KEY] = migratedNotes;
+        }
+    }
+
+    return pluginSettings[PLUGIN_SETTINGS_KEY] as ServerNotesData;
+}
+
+export function getNoteForServer(guildId: string): NoteData {
+    const allNotes = getAllNotes();
+    return allNotes[guildId] || { text: "", tags: [] };
+}
+
+export function saveNoteForServer(guildId: string, noteText: string, tags: string[] = []): void {
+    const allNotes = getAllNotes();
+
+    const cleanedTags = tags
+        .map(tag => tag.trim())
+        .filter(tag => tag !== "")
+        .map(tag => tag.toLowerCase())
+        .filter((tag, index, self) => self.indexOf(tag) === index);
+
+    if (noteText.trim() === "" && cleanedTags.length === 0) {
+        delete allNotes[guildId];
+    } else {
+        const newNoteData: NoteData = {
+            text: noteText,
+            tags: cleanedTags.sort(),
+        };
+        allNotes[guildId] = newNoteData;
+    }
+
+    const currentPluginSettings = Settings.plugins[PLUGIN_NAME] as PluginSpecificSettings;
+
+    const plainAllNotesToSave: ServerNotesData = {};
+    for (const gid in allNotes) {
+        if (Object.prototype.hasOwnProperty.call(allNotes, gid)) {
+            const note = allNotes[gid];
+            if (note) {
+                plainAllNotesToSave[gid] = {
+                    text: note.text,
+                    tags: [...note.tags]
+                };
+            }
+        }
+    }
+    currentPluginSettings[PLUGIN_SETTINGS_KEY] = plainAllNotesToSave;
+}
+
+export function getAllUniqueTags(): string[] {
+    const allNotes = getAllNotes();
+    const tagSet = new Set<string>();
+    Object.values(allNotes).forEach(noteData => {
+        if (noteData && Array.isArray(noteData.tags)) {
+            noteData.tags.forEach(tag => tagSet.add(tag));
+        }
+    });
+    return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
+}

--- a/src/plugins/serverNotes/styles.css
+++ b/src/plugins/serverNotes/styles.css
@@ -1,0 +1,299 @@
+.vc-snotes-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--background-modifier-accent);
+    flex-shrink: 0;
+}
+
+.vc-snotes-header-info-wrapper {
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+    margin-right: 16px;
+    overflow: hidden;
+}
+
+.vc-snotes-guild-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 25%;
+    margin-right: 12px;
+    object-fit: cover;
+    flex-shrink: 0;
+    background-color: var(--background-accent);
+}
+
+.vc-snotes-guild-icon.placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--interactive-normal);
+}
+
+.vc-snotes-title {
+    font-family: var(--font-display);
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--header-primary);
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.vc-snotes-header-actions-wrapper {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.vc-snotes-edit-button {
+    color: var(--interactive-normal);
+    margin-right: 8px;
+}
+
+.vc-snotes-edit-button:hover {
+    color: var(--interactive-hover);
+}
+
+.vc-snotes-edit-button-inner svg {
+    width: 20px;
+    height: 20px;
+}
+
+.vc-snotes-modal-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    position: relative;
+}
+
+.vc-snotes-modal-content.vc-snotes-viewing {
+    padding: 16px 20px;
+}
+
+.vc-snotes-modal-content.vc-snotes-editing {
+    padding: 0;
+}
+
+.vc-snotes-rendered-note-area {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    flex-grow: 1;
+    position: relative;
+    line-height: 1.65;
+    color: var(--text-normal);
+}
+
+.vc-snotes-rendered-note-area.empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-muted);
+    font-style: italic;
+    min-height: 150px;
+}
+
+.vc-snotes-rendered-note-area.parse-error {
+    color: var(--text-danger);
+}
+
+.vc-snotes-rendered-note-area.parse-error p {
+    margin-bottom: 10px;
+    font-weight: 500;
+}
+
+.vc-snotes-rendered-note-area.parse-error pre {
+    background-color: var(--background-tertiary);
+    border: 1px solid var(--background-modifier-accent);
+    border-radius: 4px;
+    padding: 10px 12px;
+    color: var(--text-normal);
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.vc-snotes-empty-text-placeholder {
+    color: var(--text-muted);
+    font-style: italic;
+    padding: 10px 0;
+}
+
+.vc-snotes-edit-container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    overflow: hidden;
+}
+
+.vc-snotes-textarea {
+    flex-grow: 1;
+    width: 100%;
+    min-height: 150px;
+    padding: 16px 20px;
+    border: none!important;
+    border-bottom: 1px solid var(--background-modifier-accent);
+    border-radius: 0;
+    box-sizing: border-box;
+    resize: none;
+    color: var(--text-normal);
+    background-color: var(--input-background);
+    font-family: var(--font-primary);
+    font-size: 15px;
+    line-height: 1.65;
+    outline: none;
+}
+
+.vc-snotes-tags-view-area {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+    border-bottom: 1px dashed var(--background-modifier-accent);
+    flex-shrink: 0;
+}
+
+.vc-snotes-tag-item.vc-snotes-view-mode-tag {
+    background-color: var(--background-secondary-alt);
+    font-size: 12px;
+    padding: 4px 8px;
+}
+
+.vc-snotes-tags-edit-section {
+    padding: 12px 20px 16px;
+    border-top: 1px solid var(--background-modifier-accent);
+    flex-shrink: 0;
+    background-color: var(--background-primary);
+}
+
+.vc-snotes-tags-edit-section .vc-snotes-form-title {
+    margin-bottom: 10px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--header-secondary);
+    text-transform: uppercase;
+    line-height: 16px;
+}
+
+.vc-snotes-tag-input-area {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.vc-snotes-tag-input {
+    flex-grow: 1;
+}
+
+.vc-snotes-tag-add-button {
+    flex-shrink: 0;
+}
+
+.vc-snotes-tags-list-scroller {
+    max-height: 80px;
+    position: relative;
+    padding-right: 4px;
+}
+
+.vc-snotes-tags-list-editable {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    min-height: 30px;
+}
+
+.vc-snotes-no-tags-text {
+    color: var(--text-muted);
+    font-size: 14px;
+    line-height: 30px;
+    font-style: italic;
+}
+
+.vc-snotes-tag-item {
+    display: inline-flex;
+    align-items: center;
+    background-color: var(--background-secondary);
+    color: var(--interactive-normal);
+    padding: 4px 8px;
+    border-radius: 14px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: default;
+    gap: 5px;
+    border: 1px solid var(--background-tertiary);
+    transition: background-color 0.1s ease-out, border-color 0.1s ease-out;
+}
+
+.vc-snotes-tag-item:not(.readonly):hover {
+    border-color: var(--background-modifier-hover);
+}
+
+.vc-snotes-tag-item-icon {
+    width: 14px;
+    height: 14px;
+    color: var(--interactive-muted);
+    flex-shrink: 0;
+}
+
+.vc-snotes-tag-item-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 150px;
+}
+
+.vc-snotes-tag-item-remove {
+    background: none;
+    border: none;
+    color: var(--interactive-muted);
+    cursor: pointer;
+    padding: 0;
+    margin-left: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+}
+
+.vc-snotes-tag-item-remove:hover {
+    color: var(--interactive-hover);
+    background-color: var(--background-modifier-hover);
+}
+
+.vc-snotes-tag-item-remove svg {
+    width: 12px;
+    height: 12px;
+}
+
+.vc-snotes-modal-footer {
+    display: flex;
+    align-items: center;
+    padding: 16px 20px;
+    background-color: var(--background-secondary);
+    border-top: 1px solid var(--background-modifier-accent);
+    flex-shrink: 0;
+}
+
+.vc-snotes-cancel-button,
+.vc-snotes-save-button,
+.vc-snotes-close-button-footer {
+    margin-left: 8px;
+}
+
+.vc-snotes-cancel-button:first-child,
+.vc-snotes-save-button:first-child,
+.vc-snotes-close-button-footer:first-child {
+    margin-left: 0;
+}


### PR DESCRIPTION
Allows the users to create per-server notes and view them similar to user notes. You can give tags/categories to notes. Can view all of the notes made via All Notes tab and filter the notes based on tags, content, server.
![image](https://github.com/user-attachments/assets/0788c211-98ab-4eed-b6db-29a5c6bf4ce9)
![image](https://github.com/user-attachments/assets/c2a711de-c7c8-48a0-9696-2512819d0a86)
![image](https://github.com/user-attachments/assets/3dbd09cc-8f53-43dc-809d-a6276f3e9722)
![image](https://github.com/user-attachments/assets/cc4cc997-31c1-471d-87a6-5cf242938ed6)