### PR TITLE
New plugin: betterTitleBar

### DIFF
--- a/src/plugins/betterTitleBar/index.tsx
+++ b/src/plugins/betterTitleBar/index.tsx
@@ -29,11 +29,12 @@ export default definePlugin({
 
         const tryMove = () => {
             const upper = document.querySelector('[class^="upperContainer_"]');
-
-
+            document.querySelector('[class^="subtitleContainer:"]')?.remove();
             if (this.storedTrailing && upper && !upper.contains(this.storedTrailing)) {
+                (upper as HTMLElement)?.style?.setProperty("webkitAppRegion", "drag");
                 upper.appendChild(this.storedTrailing);
                 this.storedTrailing.setAttribute("style", "margin-left: auto; display: flex; align-items: center;");
+
             }
 
 
@@ -54,6 +55,7 @@ export default definePlugin({
         });
 
         this.observer.observe(document.body, { childList: true, subtree: true });
+
     },
 
     stop() {

--- a/src/plugins/betterTitleBar/index.tsx
+++ b/src/plugins/betterTitleBar/index.tsx
@@ -1,0 +1,59 @@
+import definePlugin from "@utils/types";
+import { Devs } from "@utils/constants";
+
+export default definePlugin({
+    name: "Remove title bar",
+    description: "Remove title bar and move buttons to the top bar. \n you will lose the ability to drag the window from the title bar. v1.0",
+    authors: [Devs.thiagosch],
+    storedTrailing: null as HTMLElement | null,
+    observer: null as MutationObserver | null,
+
+    start() {
+        const style = document.createElement("style");
+        style.id = "better-titlebar-gridfix";
+        style.textContent = `
+            @supports (grid-template-columns:subgrid) and (white-space-collapse:collapse) {
+            .visual-refresh [class^="base_"] {
+                grid-template-rows: [top] 0 [titleBarEnd] min-content [noticeEnd] 1fr [end] !important;
+            }
+            }`;
+        document.head.appendChild(style);
+
+
+
+        const tryMove = () => {
+            const upper = document.querySelector('[class^="upperContainer_"]');
+
+
+            if (this.storedTrailing && upper && !upper.contains(this.storedTrailing)) {
+                upper.appendChild(this.storedTrailing);
+                this.storedTrailing.setAttribute("style", "margin-left: auto; display: flex; align-items: center;");
+            }
+
+
+        };
+
+        const tryCapture = () => {
+            const trailing = document.querySelector('[class^="trailing_c38106"]');
+            if (trailing && !this.storedTrailing) {
+                this.storedTrailing = trailing as HTMLElement;
+                tryMove();
+            }
+        };
+
+        tryCapture();
+        this.observer = new MutationObserver(() => {
+            tryCapture();
+            tryMove();
+        });
+
+        this.observer.observe(document.body, { childList: true, subtree: true });
+    },
+
+    stop() {
+        this.observer?.disconnect();
+        this.storedTrailing = null;
+        this.observer = null;
+        document.documentElement.style.removeProperty("--custom-app-top-bar-height");
+    }
+});

--- a/src/plugins/betterTitleBar/index.tsx
+++ b/src/plugins/betterTitleBar/index.tsx
@@ -1,3 +1,8 @@
+/*
+* Vencord, a Discord client mod
+* Copyright (c) 2025 Vendicated and contributors*
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
 import definePlugin from "@utils/types";
 import { Devs } from "@utils/constants";
 
@@ -11,7 +16,7 @@ export default definePlugin({
     start() {
         const style = document.createElement("style");
         style.id = "better-titlebar-gridfix";
-        style.textContent = `
+        style.textContent = ` 
             @supports (grid-template-columns:subgrid) and (white-space-collapse:collapse) {
             .visual-refresh [class^="base_"] {
                 grid-template-rows: [top] 0 [titleBarEnd] min-content [noticeEnd] 1fr [end] !important;

--- a/src/plugins/betterTitleBar/index.tsx
+++ b/src/plugins/betterTitleBar/index.tsx
@@ -1,10 +1,11 @@
 /*
-* Vencord, a Discord client mod
-* Copyright (c) 2025 Vendicated and contributors*
-* SPDX-License-Identifier: GPL-3.0-or-later
-*/
-import definePlugin from "@utils/types";
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "Remove title bar",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -589,6 +589,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "samsam",
         id: 836452332387565589n,
     },
+    thiagosch: {
+        name: "thiagosch",
+        id: 180067587042836480n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Removes unnecessary window bar at the top of the UI.
Moves the windows window buttons down to the top bar.


![image](https://github.com/user-attachments/assets/3e158252-bcfc-4765-965a-defc284b8f83)


problems:
- Window buttons aren't present on config screens.