### PR TITLE
ReplaceGoogleSearch: Added Startpage as a search engine

### DIFF
--- a/src/plugins/replaceGoogleSearch/index.tsx
+++ b/src/plugins/replaceGoogleSearch/index.tsx
@@ -20,6 +20,7 @@ const DefaultEngines = {
     GitHub: "https://github.com/search?q=",
     Reddit: "https://www.reddit.com/search?q=",
     Wikipedia: "https://wikipedia.org/w/index.php?search=",
+    Startpage: "https://www.startpage.com/sp/search?query="
 } as const;
 
 const settings = definePluginSettings({


### PR DESCRIPTION
Added Startpage as a search engine for the [ReplaceGoogleSearch](https://vencord.dev/plugins/ReplaceGoogleSearch) command.
[Location in my PR](https://github.com/dxamima/Vencord/blob/main/src/plugins/replaceGoogleSearch/index.tsx) - [Location in the official repository](https://github.com/Vendicated/Vencord/blob/main/src/plugins/replaceGoogleSearch/index.tsx)