### PR TITLE
fix: \\i crashes patchHelper

### DIFF
--- a/src/utils/patches.ts
+++ b/src/utils/patches.ts
@@ -40,7 +40,12 @@ export function canonicalizeMatch<T extends RegExp | string>(match: T): T {
         return partialCanon as T;
     }
 
-    const canonSource = partialCanon.replaceAll("\\i", String.raw`(?:[A-Za-z_$][\w$]*)`);
+    const canonMatches = [...partialCanon.matchAll(/([^\\])\\i/g)];
+    let canonSource = partialCanon;
+    for (const m of canonMatches) {
+        canonSource = canonSource.replace(m[0], m[1] + String.raw`(?:[A-Za-z_$][\w$]*)`);
+    }
+
     const canonRegex = new RegExp(canonSource, match.flags);
     canonRegex.toString = match.toString.bind(match);
 


### PR DESCRIPTION
Putting a `\\i` into the `match` box with when it is already showing a diff will crash Patch Helper

<img width="673" alt="image" src="https://github.com/user-attachments/assets/c979003f-e8cd-412f-9d78-f471134028d3" />
