### PR TITLE
Fix Imgur & Add Gofile support

### DIFF
--- a/src/main/csp.ts
+++ b/src/main/csp.ts
@@ -31,11 +31,12 @@ export const CspPolicies: PolicyMap = {
 
     "fonts.googleapis.com": CssSrc, // Google Fonts, used by many themes
 
-    "i.imgur.com": MediaSrc, // Imgur, used by some themes
+    "*.imgur.com": MediaSrc, // Imgur, used by some themes
     "i.ibb.co": MediaSrc, // ImgBB, used by some themes
     "i.pinimg.com": MediaSrc, // Pinterest, used by some themes
     "*.tenor.com": MediaSrc, // Tenor, used by some themes
     "files.catbox.moe": MediaSrc, // Catbox, used by some themes
+    "gofile.io": MediaSrc, // Gofile, used by some themes
 
     "cdn.discordapp.com": MediaAndCssSrc, // Discord CDN, used by Vencord and some themes to load media
     "media.discordapp.net": MediaSrc, // Discord media CDN, possible alternative to Discord CDN


### PR DESCRIPTION
Fixes Imgur support, instead of only being able to use `i.imgur.com` links it can use `*.imgur.com` letting people directly refer to the image.

https://discord.com/channels/1015060230222131221/1026515880080842772/1380756584463994962

Adds Gofile support. Self explanatory.