### PR TITLE
MessageClickActions: make delete key detection consistent on lost focus

### DIFF
--- a/src/plugins/messageClickActions/index.ts
+++ b/src/plugins/messageClickActions/index.ts
@@ -20,7 +20,7 @@ import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
-import { FluxDispatcher, PermissionsBits, PermissionStore, UserStore } from "@webpack/common";
+import { FluxDispatcher, PermissionsBits, PermissionStore, UserStore, WindowStore } from "@webpack/common";
 
 const MessageActions = findByPropsLazy("deleteMessage", "startEditMessage");
 const EditStore = findByPropsLazy("isEditing", "isEditingAny");
@@ -28,7 +28,7 @@ const EditStore = findByPropsLazy("isEditing", "isEditingAny");
 let isDeletePressed = false;
 const keydown = (e: KeyboardEvent) => e.key === "Backspace" && (isDeletePressed = true);
 const keyup = (e: KeyboardEvent) => e.key === "Backspace" && (isDeletePressed = false);
-const blur = () => isDeletePressed = false;
+const changed = () => !WindowStore.isFocused() && (isDeletePressed = false);
 
 const settings = definePluginSettings({
     enableDeleteOnClick: {
@@ -63,13 +63,13 @@ export default definePlugin({
     start() {
         document.addEventListener("keydown", keydown);
         document.addEventListener("keyup", keyup);
-        window.addEventListener("blur", blur);
+        WindowStore.addChangeListener(changed);
     },
 
     stop() {
         document.removeEventListener("keydown", keydown);
         document.removeEventListener("keyup", keyup);
-        window.removeEventListener("blur", blur);
+        WindowStore.removeChangeListener(changed);
     },
 
     onMessageClick(msg: any, channel, event) {

--- a/src/plugins/messageClickActions/index.ts
+++ b/src/plugins/messageClickActions/index.ts
@@ -28,7 +28,7 @@ const EditStore = findByPropsLazy("isEditing", "isEditingAny");
 let isDeletePressed = false;
 const keydown = (e: KeyboardEvent) => e.key === "Backspace" && (isDeletePressed = true);
 const keyup = (e: KeyboardEvent) => e.key === "Backspace" && (isDeletePressed = false);
-const changed = () => !WindowStore.isFocused() && (isDeletePressed = false);
+const focusChanged = () => !WindowStore.isFocused() && (isDeletePressed = false);
 
 const settings = definePluginSettings({
     enableDeleteOnClick: {
@@ -63,13 +63,13 @@ export default definePlugin({
     start() {
         document.addEventListener("keydown", keydown);
         document.addEventListener("keyup", keyup);
-        WindowStore.addChangeListener(changed);
+        WindowStore.addChangeListener(focusChanged);
     },
 
     stop() {
         document.removeEventListener("keydown", keydown);
         document.removeEventListener("keyup", keyup);
-        WindowStore.removeChangeListener(changed);
+        WindowStore.removeChangeListener(focusChanged);
     },
 
     onMessageClick(msg: any, channel, event) {

--- a/src/plugins/messageClickActions/index.ts
+++ b/src/plugins/messageClickActions/index.ts
@@ -28,6 +28,7 @@ const EditStore = findByPropsLazy("isEditing", "isEditingAny");
 let isDeletePressed = false;
 const keydown = (e: KeyboardEvent) => e.key === "Backspace" && (isDeletePressed = true);
 const keyup = (e: KeyboardEvent) => e.key === "Backspace" && (isDeletePressed = false);
+const blur = () => isDeletePressed = false;
 
 const settings = definePluginSettings({
     enableDeleteOnClick: {
@@ -62,11 +63,13 @@ export default definePlugin({
     start() {
         document.addEventListener("keydown", keydown);
         document.addEventListener("keyup", keyup);
+        window.addEventListener("blur", blur);
     },
 
     stop() {
         document.removeEventListener("keydown", keydown);
         document.removeEventListener("keyup", keyup);
+        window.removeEventListener("blur", blur);
     },
 
     onMessageClick(msg: any, channel, event) {


### PR DESCRIPTION
when holding backspace and alt-tabbing out, the `isDeletePressed` variable stays true, which causes messages to be deleted unintentionally on click.

this bug has happened to me like **30** times on accident and it's annoying. it’s not super frequent, but when it does happen, it’s really frustrating.

this probably impacts a lot of other users. in fact i know it impacts a few of my friends using vencord.

![cat](https://github.com/user-attachments/assets/9ccfec39-973c-4a05-b822-fddcd092b2b1)