### PR TITLE
fix(webScreenShareFixes): toggle stereo params if `sendingVideo`

### DIFF
--- a/src/plugins/webScreenShareFixes.web/index.ts
+++ b/src/plugins/webScreenShareFixes.web/index.ts
@@ -25,8 +25,8 @@ export default definePlugin({
                     replace: ";b=AS:800000;level-asymmetry-allowed=1"
                 },
                 {
-                    match: "useinbandfec=1",
-                    replace: "useinbandfec=1;stereo=1;sprop-stereo=1"
+                    match: /;usedtx=".concat\((\i).{0,8}\)/,
+                    replace: "$&+`;stereo=${+$1};sprop-stereo=${+$1}`"
                 }
             ]
         }

--- a/src/plugins/webScreenShareFixes.web/index.ts
+++ b/src/plugins/webScreenShareFixes.web/index.ts
@@ -26,7 +26,7 @@ export default definePlugin({
                 },
                 {
                     match: /;usedtx=".concat\((\i)\?"0":"1"\)/,
-                    replace: "$&+`;stereo=${+$1};sprop-stereo=${+$1}`"
+                    replace: '$&.concat($1?";stereo=1;sprop-stereo=1":"")'
                 }
             ]
         }

--- a/src/plugins/webScreenShareFixes.web/index.ts
+++ b/src/plugins/webScreenShareFixes.web/index.ts
@@ -25,7 +25,7 @@ export default definePlugin({
                     replace: ";b=AS:800000;level-asymmetry-allowed=1"
                 },
                 {
-                    match: /;usedtx=".concat\((\i).{0,8}\)/,
+                    match: /;usedtx=".concat\((\i)\?"0":"1"\)/,
                     replace: "$&+`;stereo=${+$1};sprop-stereo=${+$1}`"
                 }
             ]


### PR DESCRIPTION
Toggle WebScreenShareFixes stereo streaming params if the audio stream is a screen share

discord itself already does this for the usedtx param hence the easy variable capture :3