### PR TITLE
Make a plugin with only hidden settings not show the cog icon instead of the info icon

### DIFF
--- a/src/components/PluginSettings/PluginModal.tsx
+++ b/src/components/PluginSettings/PluginModal.tsx
@@ -26,7 +26,7 @@ import { Flex } from "@components/Flex";
 import { gitRemote } from "@shared/vencordUserAgent";
 import { proxyLazy } from "@utils/lazy";
 import { Margins } from "@utils/margins";
-import { classes, isObjectEmpty } from "@utils/misc";
+import { classes } from "@utils/misc";
 import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
 import { OptionType, Plugin } from "@utils/types";
 import { findByPropsLazy, findComponentByCodeLazy } from "@webpack";
@@ -98,7 +98,7 @@ export default function PluginModal({ plugin, onRestartNeeded, onClose, transiti
 
     const canSubmit = () => Object.values(errors).every(e => !e);
 
-    const hasSettings = Boolean(pluginSettings && plugin.options && !isObjectEmpty(plugin.options));
+    const hasSettings = Boolean(plugin.settings?.def && !Object.values(plugin.settings?.def || {})?.every(o => "hidden" in o && o?.hidden));
 
     React.useEffect(() => {
         (async () => {

--- a/src/components/PluginSettings/index.tsx
+++ b/src/components/PluginSettings/index.tsx
@@ -30,7 +30,7 @@ import { ChangeList } from "@utils/ChangeList";
 import { proxyLazy } from "@utils/lazy";
 import { Logger } from "@utils/Logger";
 import { Margins } from "@utils/margins";
-import { classes, isObjectEmpty } from "@utils/misc";
+import { classes } from "@utils/misc";
 import { useAwaiter } from "@utils/react";
 import { Plugin } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
@@ -141,6 +141,8 @@ export function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, on
         settings.enabled = !wasEnabled;
     }
 
+    const shouldShowCog = plugin.settings?.def && !Object.values(plugin.settings?.def || {})?.every(o => "hidden" in o && o?.hidden);
+
     return (
         <AddonCard
             name={plugin.name}
@@ -157,7 +159,7 @@ export function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, on
                     onClick={() => openPluginModal(plugin, onRestartNeeded)}
                     className={classes(ButtonClasses.button, cl("info-button"))}
                 >
-                    {plugin.options && !isObjectEmpty(plugin.options)
+                    {shouldShowCog
                         ? <CogWheel className={cl("info-icon")} />
                         : <InfoIcon className={cl("info-icon")} />}
                 </button>


### PR DESCRIPTION
Previously a plugin with settings that have hidden set to true would still show the plugin cog icon instead of the info icon.
This PR adds a check to make sure there is a visible setting before showing the cog icon.

Before:
![image](https://github.com/user-attachments/assets/5a536cb1-0f8d-4576-8aec-0264829857cf)
![image](https://github.com/user-attachments/assets/1335d2e2-82ae-4c21-bf54-6b8f0afb4e00)

After:
![image](https://github.com/user-attachments/assets/b6b7812e-88e6-4a6f-a97e-5793f620d02b)
![image](https://github.com/user-attachments/assets/31b0d0fb-6a1f-4329-b6dc-59e51c5c7b17)
