### PR TITLE
Add the DuckDuckGo image mirror to the CSP policy

### DIFF
--- a/src/main/csp/index.ts
+++ b/src/main/csp/index.ts
@@ -44,6 +44,8 @@ export const CspPolicies: PolicyMap = {
     "cdn.discordapp.com": ImageAndCssSrc, // Discord CDN, used by Vencord and some themes to load media
     "media.discordapp.net": ImageSrc, // Discord media CDN, possible alternative to Discord CDN
 
+    "external-content.duckduckgo.com": ImageSrc, // DuckDuckGo image mirror, reasonably private and secure
+
     // CDNs used for some things by Vencord.
     // FIXME: we really should not be using CDNs anymore
     "cdnjs.cloudflare.com": ImageScriptsAndCssSrc,


### PR DESCRIPTION
e.g.: https://external-content.duckduckgo.com/iu/?u=https://avatars.githubusercontent.com/u/167055039?v=4

Any image can be fetched through the DDG mirror, but they're sanitized and proxied through DDG servers to not reveal the user's IP address.