### PR TITLE
feat(Plugin): BetterBanModal

### DIFF
--- a/src/plugins/betterBanModal/index.tsx
+++ b/src/plugins/betterBanModal/index.tsx
@@ -1,0 +1,133 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { React } from "@webpack/common";
+
+const settings = definePluginSettings({
+    source: {
+        description: "Source to display in ban modal (Video or GIF)",
+        type: OptionType.STRING,
+        default: "https://i.imgur.com/O3DHIA5.gif",
+        restartNeeded: false,
+    },
+    width: {
+        description: "Width of the media element (pixels)",
+        type: OptionType.NUMBER,
+        default: 400,
+        restartNeeded: false,
+    },
+    autoplay: {
+        description: "Auto-play videos (only applies to video files)",
+        type: OptionType.BOOLEAN,
+        default: true,
+        restartNeeded: false,
+    },
+    moveTitle: {
+        description: "Move the ban title to the modal header",
+        type: OptionType.BOOLEAN,
+        default: true,
+        restartNeeded: true,
+    }
+});
+
+export default definePlugin({
+    name: "BetterBanModal",
+    description: "Reintroduces customizable media (video/GIF) to the Discord ban modal and optionally moves the title to the header",
+    authors: [Devs.crepnf],
+    settings,
+
+    patches: [
+        // Target the ban modal main content container and inject media
+        {
+            find: "#{intl::tamLhY::raw}", // Suspicious or spam account
+            replacement: {
+                // Inject media at the beginning of main content
+                match: /(gap:24,children:\[)/,
+                replace: "$1$self.renderBanMedia(),"
+            }
+        },
+        // Move the ban title to the modal header
+        {
+            find: "g.t.jeKpoq", // Ban user text
+            replacement: [
+                {
+                    // Replace the header to include the title alongside the close button
+                    match: /(\(0,l\.jsx\)\(s\.xBx,{separator:!1,children:\(0,l\.jsx\)\(s\.olH,{className:v\.closeIcon,onClick:k}\)}\))/,
+                    replace: "(0,l.jsxs)(s.xBx,{separator:!1,children:[(0,l.jsx)(s.X6q,{variant:\"heading-lg/semibold\",color:\"text-primary\",children:U}),(0,l.jsx)(s.olH,{className:v.closeIcon,onClick:k})]})"
+                },
+                {
+                    // Remove the original title section from the body content
+                    match: /\(0,l\.jsxs\)\(s\.Kqy,{direction:"vertical",gap:8,children:\[\(0,l\.jsx\)\(s\.X6q,{variant:"heading-lg\/semibold",color:"text-primary",children:U}\)[^\]]*\]\}\),/,
+                    replace: ""
+                }
+            ],
+            predicate: () => settings.store.moveTitle
+        }
+    ],
+
+    renderBanMedia() {
+        const { source, width, autoplay } = settings.store;
+
+        if (!source) return null;
+
+        const isVideo = /\.(mp4|webm|mov|avi)(\?.*)?$/i.test(source);
+
+        const style = {
+            maxWidth: "100%",
+            height: "auto",
+            borderRadius: "8px",
+            display: "block"
+        };
+
+        try {
+            if (isVideo) {
+                return React.createElement("video", {
+                    key: "banger-video",
+                    src: source,
+                    width: width,
+                    autoPlay: autoplay,
+                    loop: true,
+                    muted: true,
+                    style: style,
+                    onError: (e: any) => {
+                        console.warn("BetterBanModal: Failed to load video", e);
+                        e.target.style.display = "none";
+                    }
+                });
+            } else {
+                return React.createElement("img", {
+                    key: "banger-image",
+                    src: source,
+                    width: width,
+                    alt: "Ban media",
+                    style: style,
+                    onError: (e: any) => {
+                        console.warn("BetterBanModal: Failed to load image", e);
+                        e.target.style.display = "none";
+                    }
+                });
+            }
+        } catch (error) {
+            console.error("BetterBanModal: Error rendering ban media:", error);
+            return null;
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -593,6 +593,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Cootshk",
         id: 921605971577548820n
     },
+    crepnf: {
+        name: "crepnf",
+        id: 0n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Discord removed the media slot in the ban modal. Consequently, the BANger plugin was [removed from Vencord](https://github.com/Vendicated/Vencord/commit/7f2c4a35660002cbf31df72ad43bff67b7026fc0). 

This plugin reintroduces the media slot and provides users with the ability to customise the URL to a GIF or video. Additionally, it moves the modal title from the modal content to the modal header, where it should logically be positioned.

Without this plugin, the modal header title slot would be empty, with the title appearing in the modal content instead[^1]. The media slot would also be unavailable, since Discord's product managers decided that we can't have fun anymore.

The comparison below shows Discord's ban modal circa 2022 (left) versus the current ban modal with BetterBanModal activated (right):

[^1]: This might be a bug that Discord fixes eventually, which would simplify this plugin and leave less room for error. Any improvements to the current patching logic would be most appreciated.

![banger](https://github.com/user-attachments/assets/4e6c1a61-6dd5-4b99-bc93-54974f122295)