### PR TITLE
Prevent onChange setting option from being fired twice.

### DIFF
--- a/src/shared/SettingsStore.ts
+++ b/src/shared/SettingsStore.ts
@@ -160,7 +160,7 @@ export class SettingsStore<T extends object> {
         // So, we need to extract the top-level setting path (plugins.pluginName.settingName),
         // to be able to notify globalListeners and top-level setting name listeners (let { settingName } = settings.use(["settingName"]),
         // with the new value
-        if (paths.length > 2 && paths[0] === "plugins") {
+        if (paths.length > 3 && paths[0] === "plugins") {
             const settingPath = paths.slice(0, 3);
             const settingPathStr = settingPath.join(".");
             const settingValue = settingPath.reduce((acc, curr) => acc[curr], root);


### PR DESCRIPTION
Currently any declared `onChange` options on a plugin setting are being fired twice.