### PR TITLE
Fix CspViolation process to catch online theme with blocked domain

### DIFF
--- a/src/utils/cspViolations.ts
+++ b/src/utils/cspViolations.ts
@@ -8,7 +8,7 @@ import { useLayoutEffect } from "@webpack/common";
 
 import { useForceUpdater } from "./react";
 
-const cssRelevantDirectives = ["style-src", "img-src", "font-src"] as const;
+const cssRelevantDirectives = ["style-src", "img-src", "font-src", "style-src-elem"] as const;
 
 export const CspBlockedUrls = new Set<string>();
 const CspErrorListeners = new Set<() => void>();


### PR DESCRIPTION
This small patch allow the already existing CspViolation (added by #3476) to also catch csp violation created by online themes.

This souldn't have any other side effect since no plugins should inject remote stylesheet in discord, but it would also catch thoses (and display them as all others).

tested on my machine with my own domain, and it works.
The workaround is to either edit the settings file manually, or to make a dummy (local) themes that tries to load something from the desiered url. as this will trigger the event (and not be ignored)m allowing the user to choose weither they want to allow/deny the domain.

Cheers :)