### PR TITLE
Fixed tags turning red on message Logger

### DIFF
--- a/src/plugins/messageLogger/deleteStyleText.css
+++ b/src/plugins/messageLogger/deleteStyleText.css
@@ -1,4 +1,6 @@
-.messagelogger-deleted {
+.messagelogger-deleted [class*="messageContent"],
+.messagelogger-deleted [class*="repliedTextContent"],
+.messagelogger-deleted [class*="markup"] {
     --text-normal: var(--status-danger, #f04747);
     --interactive-normal: var(--status-danger, #f04747);
     --text-muted: var(--status-danger, #f04747);


### PR DESCRIPTION
# Before 
![image](https://github.com/user-attachments/assets/0ea6dfad-45eb-4bea-b67e-61ca09aab116)
# After
![image](https://github.com/user-attachments/assets/0cddbad8-9d99-47dd-9510-5d2c7be1d55e)
