### PR TITLE
FakeNitro: fix crash when embed.url is undefined

### DIFF
--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -677,19 +677,21 @@ export default definePlugin({
 
             switch (embed.type) {
                 case "image": {
+                    const url = embed.url ?? embed.image?.url;
+                    if (!url) return false;
                     if (
                         !settings.store.transformCompoundSentence
-                        && !contentItems.some(item => item === embed.url! || item.match(hyperLinkRegex)?.[1] === embed.url!)
+                        && !contentItems.some(item => item === url || item.match(hyperLinkRegex)?.[1] === url)
                     ) return false;
 
                     if (settings.store.transformEmojis) {
-                        if (fakeNitroEmojiRegex.test(embed.url!)) return true;
+                        if (fakeNitroEmojiRegex.test(url)) return true;
                     }
 
                     if (settings.store.transformStickers) {
-                        if (fakeNitroStickerRegex.test(embed.url!)) return true;
+                        if (fakeNitroStickerRegex.test(url)) return true;
 
-                        const gifMatch = embed.url!.match(fakeNitroGifStickerRegex);
+                        const gifMatch = url.match(fakeNitroGifStickerRegex);
                         if (gifMatch) {
                             // There is no way to differentiate a regular gif attachment from a fake nitro animated sticker, so we check if the StickerStore contains the id of the fake sticker
                             if (StickerStore.getStickerById(gifMatch[1])) return true;

--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -671,32 +671,36 @@ export default definePlugin({
     },
 
     shouldIgnoreEmbed(embed: Message["embeds"][number], message: Message) {
-        const contentItems = message.content.split(/\s/);
-        if (contentItems.length > 1 && !settings.store.transformCompoundSentence) return false;
+        try {
+            const contentItems = message.content.split(/\s/);
+            if (contentItems.length > 1 && !settings.store.transformCompoundSentence) return false;
 
-        switch (embed.type) {
-            case "image": {
-                if (
-                    !settings.store.transformCompoundSentence
-                    && !contentItems.some(item => item === embed.url! || item.match(hyperLinkRegex)?.[1] === embed.url!)
-                ) return false;
+            switch (embed.type) {
+                case "image": {
+                    if (
+                        !settings.store.transformCompoundSentence
+                        && !contentItems.some(item => item === embed.url! || item.match(hyperLinkRegex)?.[1] === embed.url!)
+                    ) return false;
 
-                if (settings.store.transformEmojis) {
-                    if (fakeNitroEmojiRegex.test(embed.url!)) return true;
-                }
-
-                if (settings.store.transformStickers) {
-                    if (fakeNitroStickerRegex.test(embed.url!)) return true;
-
-                    const gifMatch = embed.url!.match(fakeNitroGifStickerRegex);
-                    if (gifMatch) {
-                        // There is no way to differentiate a regular gif attachment from a fake nitro animated sticker, so we check if the StickerStore contains the id of the fake sticker
-                        if (StickerStore.getStickerById(gifMatch[1])) return true;
+                    if (settings.store.transformEmojis) {
+                        if (fakeNitroEmojiRegex.test(embed.url!)) return true;
                     }
-                }
 
-                break;
+                    if (settings.store.transformStickers) {
+                        if (fakeNitroStickerRegex.test(embed.url!)) return true;
+
+                        const gifMatch = embed.url!.match(fakeNitroGifStickerRegex);
+                        if (gifMatch) {
+                            // There is no way to differentiate a regular gif attachment from a fake nitro animated sticker, so we check if the StickerStore contains the id of the fake sticker
+                            if (StickerStore.getStickerById(gifMatch[1])) return true;
+                        }
+                    }
+
+                    break;
+                }
             }
+        } catch (e) {
+            new Logger("FakeNitro").error("Error in shouldIgnoreEmbed:", e);
         }
 
         return false;


### PR DESCRIPTION
haven't tested myself yet, but elvyra says it works fine