### PR TITLE
messageLatency: fix bot check

### DIFF
--- a/src/plugins/messageLatency/index.tsx
+++ b/src/plugins/messageLatency/index.tsx
@@ -98,7 +98,7 @@ export default definePlugin({
         if (!isNonNullish(nonce)) return null;
 
         // Bots basically never send a nonce, and if someone does do it then it's usually not a snowflake
-        if (message.bot) return null;
+        if (message.author.bot) return null;
 
         let isDiscordKotlin = false;
         let delta = SnowflakeUtils.extractTimestamp(id) - SnowflakeUtils.extractTimestamp(nonce); // milliseconds


### PR DESCRIPTION
Accurately checks if a message is sent from a bot, preventing the bot form extracting bogus timestamps from bots that use their own format for nonces.