### PR TITLE
Added size 96 for fake nitro emojis

### DIFF
--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -127,7 +127,7 @@ const settings = definePluginSettings({
         description: "Size of the emojis when sending",
         type: OptionType.SLIDER,
         default: 48,
-        markers: [32, 48, 64, 128, 160, 256, 512]
+        markers: [32, 48, 64, 96, 128, 160, 256, 512]
     },
     transformEmojis: {
         description: "Whether to transform fake emojis into real ones",


### PR DESCRIPTION
This might seem like a little thing, but I personally feel like size 96 is just the perfect size for sending emojis in acceptable quality without them being too big. Size 64 appears rather blurred, but size 128 is just too big in my personal opinion. When using [this](https://github.com/Rico040/bunny-plugins/tree/master/plugins/freemoji) plugin with Revenge I always use size 96, and I think having that in Vencord would be nice as well.