### PR TITLE
Add Plugin: ReEmbed by TheCat

### DIFF
--- a/src/plugins/reEmbed/README.md
+++ b/src/plugins/reEmbed/README.md
@@ -1,0 +1,6 @@
+# ReEmbed
+Converts unsupported embeds to supported embeds  
+  
+For example twitter.com (or x.com) get converted to fxtwitter.com  
+
+Current supports instagramm and twitter (x)

--- a/src/plugins/reEmbed/README.md
+++ b/src/plugins/reEmbed/README.md
@@ -1,6 +1,8 @@
 # ReEmbed
-Converts unsupported embeds to supported embeds  
-  
-For example twitter.com (or x.com) get converted to fxtwitter.com  
+Converts unsupported embeds to supported embeds
 
-Current supports instagramm and twitter (x)
+For example twitter.com (or x.com) get converted to fxtwitter.com
+
+Current supports instagramm, twitter (x) and tiktok
+
+Also gives the user the choice of which twitter mirror they want to use

--- a/src/plugins/reEmbed/index.ts
+++ b/src/plugins/reEmbed/index.ts
@@ -1,0 +1,73 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { MessageObject } from "@api/MessageEvents";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { definePluginSettings } from "@api/Settings";
+import redirectMap from "./redirectMap";
+import { twitterMirrors } from "./mirrors";
+
+const settings = definePluginSettings({
+  twitterMirror: {
+    type: OptionType.SELECT,
+    description: "Preferred Twitter/X mirror",
+    default: Object.keys(twitterMirrors)[0],
+    options: Object.entries(twitterMirrors).map(([domain, name]) => ({
+      label: name,
+      value: domain
+    }))
+  }
+});
+
+export default definePlugin({
+  name: "ReEmbed",
+  description: "Converts unsupported embeds to supported embeds and supports differents types of Twitter/X mirrors.",
+  authors: [Devs.TheCat],
+  settings,
+
+  onBeforeMessageSend(_, msg) {
+    return this.replaceLinks(msg);
+  },
+
+  onBeforeMessageEdit(_, __, msg) {
+    return this.replaceLinks(msg);
+  },
+
+  replaceLinks(msg: MessageObject) {
+    if (!msg.content) return;
+
+    const chosen = settings.store.twitterMirror;
+
+    msg.content = msg.content.replace(
+      /https?:\/\/(?:www\.)?twitter\.com\/([^\s<.,:;"')\]\[|]+)/gi,
+      (_match, path) => `https://${chosen}/${path}`
+    );
+
+    msg.content = msg.content.replace(
+      /https?:\/\/(?:www\.)?([a-zA-Z0-9.-]+)\/([^\s<.,:;"')\]\[|]+)/gi,
+      (match, domain, path) => {
+        const newDomain = redirectMap[domain.toLowerCase()];
+        if (!newDomain) return match;
+        return `https://${newDomain}/${path}`;
+      }
+    );
+
+    return msg;
+  }
+});

--- a/src/plugins/reEmbed/mirrors.ts
+++ b/src/plugins/reEmbed/mirrors.ts
@@ -1,0 +1,7 @@
+export const twitterMirrors = {
+    "fxtwitter.com": "FXTwitter",
+    "vxtwitter.com": "VXTwitter",
+    "twittpr.com": "Twittpr",
+    "fixupx.com": "FixupX",
+    "girlcockx.com": "GirlcockX"
+};

--- a/src/plugins/reEmbed/redirectMap.ts
+++ b/src/plugins/reEmbed/redirectMap.ts
@@ -1,7 +1,8 @@
 const redirectMap: Record<string, string> = {
     "twitter.com": "fxtwitter.com",
     "x.com": "fxtwitter.com",
-    "instagram.com": "ddinstagram.com"
+    "instagram.com": "ddinstagram.com",
+    "tiktok.com": "tnktok.com"
 };
 
 export default redirectMap;

--- a/src/plugins/reEmbed/redirectMap.ts
+++ b/src/plugins/reEmbed/redirectMap.ts
@@ -1,0 +1,7 @@
+const redirectMap: Record<string, string> = {
+    "twitter.com": "fxtwitter.com",
+    "x.com": "fxtwitter.com",
+    "instagram.com": "ddinstagram.com"
+};
+
+export default redirectMap;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -593,6 +593,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Cootshk",
         id: 921605971577548820n
     },
+    TheCat: {
+        name: "TheCat",
+        id: 502494485993881613n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Converts unsupported embeds to supported embeds

For example twitter.com (or x.com) get converted to fxtwitter.com

Current supports instagramm, twitter (x) and tiktok

Also gives the user the choice of which twitter mirror they want to use