### PR TITLE
"Quick Userscript" setting

### DIFF
--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -155,6 +155,12 @@ async function init() {
     }
 }
 
+/* The quickUserscript runs here, so it may add custom plugins and patches. */
+try {
+    new Function(Settings.quickUserscript)();
+} catch (exception) {
+    PMLogger.error("Error in QuickUserscript", exception);
+}
 startAllPlugins(StartAt.Init);
 init();
 

--- a/src/api/Settings.ts
+++ b/src/api/Settings.ts
@@ -32,6 +32,7 @@ export interface Settings {
     autoUpdate: boolean;
     autoUpdateNotification: boolean,
     useQuickCss: boolean;
+    quickUserscript: string;
     eagerPatches: boolean;
     enabledThemes: string[];
     enableReactDevtools: boolean;
@@ -81,6 +82,7 @@ const DefaultSettings: Settings = {
     autoUpdate: true,
     autoUpdateNotification: true,
     useQuickCss: true,
+    quickUserscript: "",
     themeLinks: [],
     eagerPatches: IS_REPORTER,
     enabledThemes: [],

--- a/src/components/PluginSettings/UserscriptModal.tsx
+++ b/src/components/PluginSettings/UserscriptModal.tsx
@@ -1,0 +1,57 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Settings, useSettings } from "@api/Settings";
+import { classNameFactory } from "@api/Styles";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { Flex } from "@components/Flex";
+import { ModalContent, ModalRoot, openModal } from "@utils/modal";
+import { Button, Forms, TextArea, useState } from "@webpack/common";
+
+const cl = classNameFactory("vc-userscript-modal-");
+
+export function openUserscriptModal() {
+    openModal(modalProps =>
+        <ModalRoot {...modalProps}>
+            <ErrorBoundary>
+                <ModalContent className={cl("root")}>
+                    <UserscriptModal />
+                </ModalContent>
+            </ErrorBoundary>
+        </ModalRoot>
+    );
+}
+
+function UserscriptModal() {
+    const { quickUserscript } = useSettings(["quickUserscript"]);
+    const [needsReload, setNeedsReload] = useState(false);
+    const [value, setValue] = useState(quickUserscript);
+
+    const placeholderCode = "/*\n * Be careful! Arbitrary JavaScript code can be written here, which could do anything.\n * Only run JavaScript from people who you would trust a plugin from.\n */";
+
+    return (
+        <>
+            <Forms.FormTitle>QuickUserscript</Forms.FormTitle>
+            <TextArea placeholder={placeholderCode} onChange={setValue} value={value} />
+            <Flex>
+                <Button
+                    onClick={() => {
+                        Settings.quickUserscript = value;
+                        setNeedsReload(true);
+                    }}
+                    size={Button.Sizes.SMALL}
+                >
+                    Save
+                </Button>
+            </Flex>
+            {needsReload && (
+                <Forms.FormText>
+                    Userscripts will not be reloaded until you <a href="#" onClick={() => location.reload()}>reload the page</a>.
+                </Forms.FormText>
+            )}
+        </>
+    );
+}

--- a/src/components/VencordSettings/VencordTab.tsx
+++ b/src/components/VencordSettings/VencordTab.tsx
@@ -22,6 +22,7 @@ import { classNameFactory } from "@api/Styles";
 import DonateButton from "@components/DonateButton";
 import { openContributorModal } from "@components/PluginSettings/ContributorModal";
 import { openPluginModal } from "@components/PluginSettings/PluginModal";
+import { openUserscriptModal } from "@components/PluginSettings/UserscriptModal";
 import { gitRemote } from "@shared/vencordUserAgent";
 import { DONOR_ROLE_ID, VENCORD_GUILD_ID } from "@utils/constants";
 import { Margins } from "@utils/margins";
@@ -155,6 +156,11 @@ function VencordSettings() {
                         Icon={PaintbrushIcon}
                         text="Edit QuickCSS"
                         action={() => VencordNative.quickCss.openEditor()}
+                    />
+                    <QuickAction
+                        Icon={PaintbrushIcon}
+                        text="Edit QuickUserscript"
+                        action={() => openUserscriptModal()}
                     />
                     {!IS_WEB && (
                         <QuickAction


### PR DESCRIPTION
I develop and maintain a number of personal userscripts for browser-based Discord. These are, effectively, implementing something slightly more powerful than QuickCSS, capable of containing some dynamic logic and element injection.

I can't run these on current Vencord without reimplementing them as plugins, but this increases maintenance effort (I use the browser to save RAM when possible) for what are ultimately rather simple scripts, not particularly more complicated than `oneko.js`.

Something I did consider was the idea of implementing a loader similar to the oneko.js plugin - I decided against this. I have assumed that Vencord's current model of plugin distribution, while user-unfriendly, is for security purposes to prevent rogue updates.

However, regardless of if it's in the devtools or in a userscript box, a user who wishes to directly inject external code can. Adding the userscript box does not add much persistence that cannot be achieved already by, for instance, rewriting Vesktop files for their own purposes. To a user who knows what they are doing, but does not wish to manually track Vencord updates, it adds a great degree of flexibility.