### PR TITLE
New Plugin: autoTimestamp

### DIFF
--- a/src/plugins/autoTimestamp/index.tsx
+++ b/src/plugins/autoTimestamp/index.tsx
@@ -74,10 +74,12 @@ function parseDate(dateStr: string, format: string, relativePrefix: string): str
     let day = 1, month = 0, year = 1970;
     let match: RegExpMatchArray | null = null;
     let isRelative = false;
+
     if (relativePrefix && dateStr.startsWith(relativePrefix)) {
         isRelative = true;
         dateStr = dateStr.slice(relativePrefix.length);
     }
+
     if (format === "DD/MM/YYYY") {
         match = dateStr.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
         if (match) {
@@ -109,6 +111,7 @@ function parseDate(dateStr: string, format: string, relativePrefix: string): str
     } else {
         return dateStr;
     }
+
     if (!match) return dateStr;
     const date = new Date(year, month, day);
     const unix = Math.floor(date.getTime() / 1000);
@@ -122,15 +125,18 @@ function parseDateTime(dateTimeStr: string, relativePrefix: string): string {
         isRelative = true;
         dateTimeStr = dateTimeStr.slice(relativePrefix.length);
     }
+
     dateTimeStr = dateTimeStr.trim();
     const dateFirst = /(?<date>(\d{1,4}[/-]\d{1,2}[/-]\d{1,4}))\s+(?<time>(\d{1,2}(?::\d{2})?(?::\d{2})?\s*(?:AM|PM|am|pm)?))/;
     const timeFirst = /(?<time>(\d{1,2}(?::\d{2})?(?::\d{2})?\s*(?:AM|PM|am|pm)?))\s+(?<date>(\d{1,4}[/-]\d{1,2}[/-]\d{1,4}))/;
     const match = dateTimeStr.match(dateFirst) || dateTimeStr.match(timeFirst);
+
     if (!match || !match.groups) return dateTimeStr;
     const { date, time } = match.groups;
     let day = 1, month = 0, year = 1970;
     const dmy = date.match(/(\d{1,2})[/-](\d{1,2})[/-](\d{4})/);
     const ymd = date.match(/(\d{4})[/-](\d{1,2})[/-](\d{1,2})/);
+
     if (dmy) {
         day = parseInt(dmy[1], 10);
         month = parseInt(dmy[2], 10) - 1;
@@ -142,6 +148,7 @@ function parseDateTime(dateTimeStr: string, relativePrefix: string): string {
     } else {
         return dateTimeStr;
     }
+
     let hour = 0, minute = 0, second = 0;
     const t = time.match(/(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?\s*(am|pm)?/i);
     if (t) {
@@ -154,6 +161,7 @@ function parseDateTime(dateTimeStr: string, relativePrefix: string): string {
             if (!isPM && hour === 12) hour = 0;
         }
     }
+
     const dateObj = new Date(year, month, day, hour, minute, second);
     const unix = Math.floor(dateObj.getTime() / 1000);
     const tsFormat = isRelative ? "R" : "f";

--- a/src/plugins/autoTimestamp/index.tsx
+++ b/src/plugins/autoTimestamp/index.tsx
@@ -187,7 +187,7 @@ const settings = definePluginSettings({
     parseWrapper: {
         description: "Message wrapper to use for time parsing(e.g. `10pm`)",
         type: OptionType.STRING,
-        default: "`",
+        default: "",
         placeholder: "empty for no wrapper",
     },
     dateFormat: {

--- a/src/plugins/autoTimestamp/index.tsx
+++ b/src/plugins/autoTimestamp/index.tsx
@@ -1,0 +1,230 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 OpenAsar
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+
+function parseTime(message: string, relativePrefix: string): string {
+    const now = new Date();
+    let hour = 0, minute = 0, second = 0;
+    let isPM = false;
+    let hasMinutes = false;
+    let hasSeconds = false;
+
+    let isRelative = false;
+    if (relativePrefix && message.startsWith(relativePrefix)) {
+        isRelative = true;
+        message = message.slice(relativePrefix.length);
+    }
+
+    const timeRegex = /^(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?\s*(am|pm)?$/i;
+    const res = message.trim().match(timeRegex);
+    if (!res) return message;
+
+    hour = parseInt(res[1], 10);
+    if (res[2] !== undefined) {
+        minute = parseInt(res[2], 10);
+        hasMinutes = true;
+    }
+    if (res[3] !== undefined) {
+        second = parseInt(res[3], 10);
+        hasSeconds = true;
+    }
+    if (res[4]) {
+        isPM = res[4].toLowerCase() === "pm";
+    }
+
+    if (res[4]) {
+        if (isPM && hour < 12) hour += 12;
+        if (!isPM && hour === 12) hour = 0;
+    }
+
+    const date = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minute, second);
+    if (date.getTime() <= now.getTime()) {
+        date.setDate(date.getDate() + 1);
+    }
+    const unix = Math.floor(date.getTime() / 1000);
+
+    let format = "t";
+    if ((hasMinutes && minute !== 0) || hasSeconds) {
+        format = "T";
+    }
+    if (isRelative) format = "R";
+    return `<t:${unix}:${format}>`;
+}
+
+function parseDate(dateStr: string, format: string, relativePrefix: string): string {
+    let day = 1, month = 0, year = 1970;
+    let match: RegExpMatchArray | null = null;
+    let isRelative = false;
+    if (relativePrefix && dateStr.startsWith(relativePrefix)) {
+        isRelative = true;
+        dateStr = dateStr.slice(relativePrefix.length);
+    }
+    if (format === "DD/MM/YYYY") {
+        match = dateStr.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+        if (match) {
+            day = parseInt(match[1], 10);
+            month = parseInt(match[2], 10) - 1;
+            year = parseInt(match[3], 10);
+        }
+    } else if (format === "MM/DD/YYYY") {
+        match = dateStr.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+        if (match) {
+            month = parseInt(match[1], 10) - 1;
+            day = parseInt(match[2], 10);
+            year = parseInt(match[3], 10);
+        }
+    } else if (format === "YYYY/MM/DD") {
+        match = dateStr.match(/(\d{4})\/(\d{1,2})\/(\d{1,2})/);
+        if (match) {
+            year = parseInt(match[1], 10);
+            month = parseInt(match[2], 10) - 1;
+            day = parseInt(match[3], 10);
+        }
+    } else if (format === "YYYY/DD/MM") {
+        match = dateStr.match(/(\d{4})\/(\d{1,2})\/(\d{1,2})/);
+        if (match) {
+            year = parseInt(match[1], 10);
+            day = parseInt(match[2], 10);
+            month = parseInt(match[3], 10) - 1;
+        }
+    } else {
+        return dateStr;
+    }
+    if (!match) return dateStr;
+    const date = new Date(year, month, day);
+    const unix = Math.floor(date.getTime() / 1000);
+    const tsFormat = isRelative ? "R" : "D";
+    return `<t:${unix}:${tsFormat}>`;
+}
+
+function parseDateTime(dateTimeStr: string, relativePrefix: string): string {
+    let isRelative = false;
+    if (relativePrefix && dateTimeStr.startsWith(relativePrefix)) {
+        isRelative = true;
+        dateTimeStr = dateTimeStr.slice(relativePrefix.length);
+    }
+    dateTimeStr = dateTimeStr.trim();
+    const dateFirst = /(?<date>(\d{1,4}[/-]\d{1,2}[/-]\d{1,4}))\s+(?<time>(\d{1,2}(?::\d{2})?(?::\d{2})?\s*(?:AM|PM|am|pm)?))/;
+    const timeFirst = /(?<time>(\d{1,2}(?::\d{2})?(?::\d{2})?\s*(?:AM|PM|am|pm)?))\s+(?<date>(\d{1,4}[/-]\d{1,2}[/-]\d{1,4}))/;
+    const match = dateTimeStr.match(dateFirst) || dateTimeStr.match(timeFirst);
+    if (!match || !match.groups) return dateTimeStr;
+    const { date, time } = match.groups;
+    let day = 1, month = 0, year = 1970;
+    const dmy = date.match(/(\d{1,2})[/-](\d{1,2})[/-](\d{4})/);
+    const ymd = date.match(/(\d{4})[/-](\d{1,2})[/-](\d{1,2})/);
+    if (dmy) {
+        day = parseInt(dmy[1], 10);
+        month = parseInt(dmy[2], 10) - 1;
+        year = parseInt(dmy[3], 10);
+    } else if (ymd) {
+        year = parseInt(ymd[1], 10);
+        month = parseInt(ymd[2], 10) - 1;
+        day = parseInt(ymd[3], 10);
+    } else {
+        return dateTimeStr;
+    }
+    let hour = 0, minute = 0, second = 0;
+    const t = time.match(/(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?\s*(am|pm)?/i);
+    if (t) {
+        hour = parseInt(t[1], 10);
+        if (t[2]) minute = parseInt(t[2], 10);
+        if (t[3]) second = parseInt(t[3], 10);
+        if (t[4]) {
+            const isPM = t[4].toLowerCase() === "pm";
+            if (isPM && hour < 12) hour += 12;
+            if (!isPM && hour === 12) hour = 0;
+        }
+    }
+    const dateObj = new Date(year, month, day, hour, minute, second);
+    const unix = Math.floor(dateObj.getTime() / 1000);
+    const tsFormat = isRelative ? "R" : "f";
+    return `<t:${unix}:${tsFormat}>`;
+}
+
+const settings = definePluginSettings({
+    replaceTime: {
+        description: "Replace time in message contents(e.g. 10:00, 10pm)",
+        type: OptionType.BOOLEAN,
+        default: true,
+    },
+    replaceDate: {
+        description: "Replace date in message contents(e.g. 20/2/2005)",
+        type: OptionType.BOOLEAN,
+        default: true,
+    },
+    replaceDateTime: {
+        description: "Replace date and time in message contents(e.g. 20/2/2005 10:00 or 10pm 20/2/2005)",
+        type: OptionType.BOOLEAN,
+        default: true,
+    },
+    parseWrapper: {
+        description: "Message wrapper to use for time parsing(e.g. `10pm`)",
+        type: OptionType.STRING,
+        default: "`",
+        placeholder: "empty for no wrapper",
+    },
+    dateFormat: {
+        description: "Date format to use for date replacement",
+        type: OptionType.SELECT,
+        options: [
+            { label: "DD/MM/YYYY", value: "DD/MM/YYYY" },
+            { label: "MM/DD/YYYY", value: "MM/DD/YYYY" },
+            { label: "YYYY/MM/DD", value: "YYYY/MM/DD" },
+            { label: "YYYY/DD/MM", value: "YYYY/DD/MM" },
+        ],
+        default: "DD/MM/YYYY",
+    },
+    relativePrefix: {
+        description: "Prefix for relative timestamps (e.g. ':10pm', ':20/2/2005', ':10pm 20/2/2005')",
+        type: OptionType.STRING,
+        default: ":",
+        placeholder: "empty for disabled",
+    }
+
+});
+
+export default definePlugin({
+    name: "AutoTimestamp",
+    description: "Automatically convert times in messages to Discord timestamps",
+    authors: [Devs.catsonluna],
+    settings,
+
+
+    onBeforeMessageSend(_, msg) {
+        const wrapper = settings.store.parseWrapper.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+        const { relativePrefix } = settings.store;
+        const relPrefixPattern = relativePrefix ? `${relativePrefix}` : "";
+        if (settings.store.replaceDateTime) {
+            const dateTimeRegex = new RegExp(`(?:${relPrefixPattern})?(?:\\d{1,2}(?::\\d{2})?(?::\\d{2})?\\s*(?:AM|PM|am|pm)?\\s+[\\d/-]{6,}|[\\d/-]{6,}\\s+\\d{1,2}(?::\\d{2})?(?::\\d{2})?\\s*(?:AM|PM|am|pm)?)`, "g");
+            msg.content = msg.content.replace(dateTimeRegex, substring => parseDateTime(substring, relativePrefix));
+        }
+        if (settings.store.replaceTime) {
+            const regex = new RegExp(`${wrapper}(${relPrefixPattern}?(?:\\d{1,2}:(?:\\d{2})(?::\\d{2})?\\s*(?:AM|PM|am|pm)?|\\d{1,2}\\s*(?:AM|PM|am|pm)))${wrapper}`, "g");
+            msg.content = msg.content.replace(regex, (_, time) => parseTime(time, relativePrefix));
+        }
+        if (settings.store.replaceDate) {
+            const dateRegex = new RegExp(`${wrapper}(${relPrefixPattern}?(?:\\d{1,4}[/-]\\d{1,2}[/-]\\d{1,4}))${wrapper}`, "g");
+            msg.content = msg.content.replace(dateRegex, (substring, date) => parseDate(String(date), settings.store.dateFormat ?? "DD/MM/YYYY", relativePrefix));
+        }
+    }
+
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -598,6 +598,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Cootshk",
         id: 921605971577548820n
     },
+    catsonluna: {
+        name: "catsonluna",
+        id: 324553306682818561n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Description: Automatically convert times in messages to Discord timestamps.

features:
- automatically converts time and date in text to timestamps
- supports both am/pm and military time (18:00)
- append ":" to the start of the time to make it relative
-- all date, time, and datetime support relative
- converts all times and dates in a single text
- if you say "10pm" at 11pm for example, it will automatically make it 10pm tomorrow 

examples:
- "i will be there at 10pm" the "10pm" will be turned into a timestamp
- "i will be there 20/08/2025" the "20/08/2025" get converted into a date
- "i will be there at 10pm 20/08/2025" the whole "10pm 20/08/2025" will be turned into a single timestamp, if time is placed right before or after the date
- "i will be there at :10pm 20/08/2025" the whole "10pm 20/08/2025" will be turned into a relative timestamp

settings:
- toggle time parsing
- toggle date parsing
- toggle datetime parsing
- should a time be wrapped in something, for example if \` is placed, it will only convert times if it is \`10pm\`
- relative time prefix, if its empty, relative time is disabled
- date format, change from the default DD/MM/YYYY



Before:
<img width="1138" height="291" alt="Screenshot 2025-08-04 at 20 55 57" src="https://github.com/user-attachments/assets/d2154e4e-971f-4004-92ad-1b99c81ee509" />

Sent:
<img width="1141" height="349" alt="Screenshot 2025-08-04 at 20 56 16" src="https://github.com/user-attachments/assets/30659f5a-ce4f-43d9-b280-37b9b727318d" />


