### PR TITLE
FavGifSearch: Encode search query

### DIFF
--- a/src/plugins/favGifSearch/index.tsx
+++ b/src/plugins/favGifSearch/index.tsx
@@ -157,10 +157,11 @@ function SearchBar({ instance, SearchBarComponent }: { instance: Instance; Searc
             ?.firstElementChild?.scrollTo(0, 0);
 
 
+        const encodedQuery = encodeURI(searchQuery).toLowerCase();
         const result =
             props.favCopy
                 .map(gif => ({
-                    score: fuzzySearch(searchQuery.toLowerCase(), getTargetString(gif.url ?? gif.src).replace(/(%20|[_-])/g, " ").toLowerCase()),
+                    score: fuzzySearch(encodedQuery, getTargetString(gif.url ?? gif.src).replace(/(%20|[_-])/g, " ").toLowerCase()),
                     gif,
                 }))
                 .filter(m => m.score != null) as { score: number; gif: Gif; }[];


### PR DESCRIPTION
Find gifs with non ascii characters in the link

before:
<img width="496" height="227" alt="image" src="https://github.com/user-attachments/assets/f64a435c-0a96-465e-a3ad-0cdc44911c5d" />
after:
<img width="496" height="227" alt="image" src="https://github.com/user-attachments/assets/6fa309b9-4896-4863-a63f-a2437aca3d4f" />
