### PR TITLE
New Plugin: (NotiQuick) Context Menu for New Notifications Button, 

### DIFF
--- a/src/plugins/notiQuick/README.md
+++ b/src/plugins/notiQuick/README.md
@@ -1,0 +1,39 @@
+<p align="center">
+    <img src="https://github.com/user-attachments/assets/8c58424e-5742-48e3-a617-4344f951e955" alt="NotiQuick" height="220">
+</p>
+
+<h2>What is NotiQuick?</h2>
+<p><b>NotiQuick</b> is a streamlined Discord/Vencord plugin that enhances your notification management by adding a convenient context menu to Discord's notification bell. With just a right-click, you can quickly mark all server notifications or all DM notifications as read, making your Discord experience cleaner and more organized.</p>
+
+<h2>Features</h2>
+<ul>
+<li><b>Right-click Context Menu</b>: Right-click the notification bell (Inside Server List) to access quick options</li>
+<li><b>Mark All Servers As Read</b>: Clear all server notifications (guilds, channels, threads) at once</li>
+<li><b>Mark All DMs As Read</b>: Clear only direct message notifications</li>
+<li><b>Bell Animation</b>: Satisfying bell shake animation when clicking the notification bell</li>
+</ul>
+
+<h2>Usage</h2>
+<p>After installing the plugin:</p>
+<ol>
+<li><b>Right-click</b> the notification bell (inbox icon) in Discord's sidebar</li>
+<li>Choose from the options:
+<ul>
+<li><b>Mark All Servers As Read</b>: Clears all server-related notifications</li>
+<li><b>Mark All DMs As Read</b>: Only clears direct message notifications</li>
+</ul>
+</li>
+</ol>
+
+<h2>Settings</h2>
+<ul>
+<li><b>Show Icons</b>: Display icons in the context menu for better visual organization</li>
+<li><b>Show Counts</b>: Display notification counts in brackets next to each context menu option</li>
+<li><b>Bell Animation</b>: Toggle the bell shake animation when clicking the notification bell</li>
+</ul>
+
+<h2>Screenshots</h2>
+<p align="center">
+    <img src="https://github.com/user-attachments/assets/fdb45036-149a-443d-be8b-fd3dca105dc6" alt="ContextMenu" height="220">
+    <img src="https://github.com/user-attachments/assets/4f7ee166-ce48-4228-bc20-97e422399fe0" alt="PluginSettings" height="220">
+</p>

--- a/src/plugins/notiQuick/index.tsx
+++ b/src/plugins/notiQuick/index.tsx
@@ -1,0 +1,293 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { definePluginSettings } from "@api/Settings";
+import { DeleteIcon, NotesIcon } from "@components/Icons";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+import { ChannelStore, ContextMenuApi, FluxDispatcher, GuildChannelStore, GuildStore, Menu, ReadStateStore, Toasts } from "@webpack/common";
+
+const ActiveJoinedThreadsStore = findByPropsLazy("getActiveJoinedThreadsForGuild");
+
+const settings = definePluginSettings({
+    showIcons: {
+        type: OptionType.BOOLEAN,
+        description: "Show icons in context menu",
+        default: true
+    },
+    showCounts: {
+        type: OptionType.BOOLEAN,
+        description: "Show notification counts in context menu",
+        default: true
+    },
+    bellAnimation: {
+        type: OptionType.BOOLEAN,
+        description: "Enable bell icon animation when clicking notifications button",
+        default: true
+    }
+});
+
+const BUTTON_SELECTOR = '[data-list-item-id="guildsnav___notifications-inbox"]';
+const MIN_CLICK_INTERVAL = 300;
+
+let lastClickTs = 0;
+
+interface AckChannelPayload {
+    channelId: string;
+    messageId: string | null;
+    readStateType: number;
+}
+
+function animateBellIcon(rootEl: HTMLElement) {
+    if (!settings.store.bellAnimation) return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const svg = rootEl.querySelector("svg");
+    if (!svg) return;
+
+    svg.style.animation = "bell 0.45s cubic-bezier(0.4, 0, 0.2, 1)";
+    setTimeout(() => svg.style.animation = "", 450);
+}
+
+function collectUnreadChannels(guildId?: string): AckChannelPayload[] {
+    try {
+        const acks: AckChannelPayload[] = [];
+        const guilds = guildId ? { [guildId]: GuildStore.getGuild(guildId) } : GuildStore.getGuilds();
+
+        if (!guilds) return acks;
+
+        for (const guild of Object.values(guilds)) {
+            if (!guild?.id) continue;
+
+            try {
+                const guildChannels = GuildChannelStore.getChannels(guild.id);
+                if (!guildChannels) continue;
+
+                const pushIfUnread = (id: string) => {
+                    try {
+                        if (id && ReadStateStore.hasUnread(id)) {
+                            acks.push({
+                                channelId: id,
+                                messageId: ReadStateStore.lastMessageId(id),
+                                readStateType: 0
+                            });
+                        }
+                    } catch (error) {
+                        console.warn("[NotiQuick] Error checking unread status for channel:", id, error);
+                    }
+                };
+
+                guildChannels.SELECTABLE?.forEach(c => c?.channel?.id && pushIfUnread(c.channel.id));
+                guildChannels.VOCAL?.forEach(c => c?.channel?.id && pushIfUnread(c.channel.id));
+
+                try {
+                    const threadsByParent = ActiveJoinedThreadsStore.getActiveJoinedThreadsForGuild(guild.id);
+                    if (threadsByParent) {
+                        for (const threadGroup of Object.values(threadsByParent)) {
+                            if (threadGroup && typeof threadGroup === "object") {
+                                for (const thread of Object.values(threadGroup as Record<string, any>)) {
+                                    if (thread?.channel?.id) {
+                                        pushIfUnread(thread.channel.id);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } catch (error) {
+                    console.warn("[NotiQuick] Error processing threads for guild:", guild.id, error);
+                }
+            } catch (error) {
+                console.warn("[NotiQuick] Error processing guild:", guild.id, error);
+            }
+        }
+        return acks;
+    } catch (error) {
+        console.error("[NotiQuick] Error collecting unread channels:", error);
+        return [];
+    }
+}
+
+function collectUnreadDMs(): AckChannelPayload[] {
+    try {
+        const channels = ChannelStore.getSortedPrivateChannels();
+        if (!channels || !Array.isArray(channels)) return [];
+
+        return channels
+            .filter(channel => {
+                try {
+                    return channel?.id && ReadStateStore.hasUnread(channel.id);
+                } catch (error) {
+                    console.warn("[NotiQuick] Error checking unread status for DM:", channel?.id, error);
+                    return false;
+                }
+            })
+            .map(channel => ({
+                channelId: channel.id,
+                messageId: ReadStateStore.lastMessageId(channel.id),
+                readStateType: 0
+            }));
+    } catch (error) {
+        console.error("[NotiQuick] Error collecting unread DMs:", error);
+        return [];
+    }
+}
+
+function getNotificationCounts() {
+    const serverChannels = collectUnreadChannels();
+    const dmChannels = collectUnreadDMs();
+
+    const unreadServerIds = new Set<string>();
+    for (const channel of serverChannels) {
+        const guildId = ChannelStore.getChannel(channel.channelId)?.guild_id;
+        if (guildId) unreadServerIds.add(guildId);
+    }
+
+    return {
+        servers: unreadServerIds.size,
+        dms: dmChannels.length,
+        serverChannels,
+        dmChannels
+    };
+}
+
+async function markAsRead(channels: AckChannelPayload[], type: "all" | "dms" = "all") {
+    if (channels.length === 0) {
+        Toasts.show({
+            message: "No unread channels found",
+            type: Toasts.Type.MESSAGE,
+            id: "notif-plus-no-unread"
+        });
+        return;
+    }
+
+    const message = type === "dms" ?
+        `Marked ${channels.length} DM${channels.length === 1 ? "" : "s"} as read` :
+        `Marked ${channels.length} notification${channels.length === 1 ? "" : "s"} as read`;
+
+    FluxDispatcher.dispatch({ type: "BULK_ACK", context: "APP", channels });
+
+    Toasts.show({
+        message,
+        type: Toasts.Type.SUCCESS,
+        id: "notif-plus-mark-read"
+    });
+}
+
+async function onClick(channels: AckChannelPayload[], type: "all" | "dms") {
+    const now = Date.now();
+    if (now - lastClickTs < MIN_CLICK_INTERVAL) return;
+    lastClickTs = now;
+
+    await markAsRead(channels, type);
+}
+
+function attachToNotificationsButton(onContext: (e: MouseEvent) => void, onBellClick: () => void): () => void {
+    const host = document.querySelector(BUTTON_SELECTOR) as HTMLElement;
+    if (!host) return () => { };
+
+    const handleClick = (e: MouseEvent) => e.button === 0 && onBellClick();
+    const handleContextMenu = (e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onContext(e);
+    };
+
+    host.addEventListener("click", handleClick);
+    host.addEventListener("contextmenu", handleContextMenu);
+
+    return () => {
+        host.removeEventListener("click", handleClick);
+        host.removeEventListener("contextmenu", handleContextMenu);
+    };
+}
+
+function observeAndAttach(onContext: (e: MouseEvent) => void, onBellClick: () => void): () => void {
+    let detachCurrent: (() => void) | null = null;
+    let currentHost: HTMLElement | null = null;
+
+    const reconcile = () => {
+        const host = document.querySelector(BUTTON_SELECTOR) as HTMLElement;
+        if (host && host !== currentHost) {
+            detachCurrent?.();
+            currentHost = host;
+            detachCurrent = attachToNotificationsButton(onContext, onBellClick);
+        } else if (!host && detachCurrent) {
+            detachCurrent();
+            detachCurrent = null;
+            currentHost = null;
+        }
+    };
+
+    reconcile();
+    const mo = new MutationObserver(reconcile);
+    mo.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+        detachCurrent?.();
+        mo.disconnect();
+    };
+}
+
+export default definePlugin({
+    name: "NotiQuick",
+    description: "Enhances the notifications inbox button with context menu actions for quickly marking all servers or DMs as read, and adds a smooth bell icon animation.",
+    authors: [Devs.drk],
+    settings,
+
+    start() {
+        const onContextMenu = (e: MouseEvent) => {
+            try {
+                e.preventDefault();
+                e.stopPropagation();
+
+                const { servers, dms, serverChannels, dmChannels } = getNotificationCounts();
+                const allChannels = [...serverChannels, ...dmChannels];
+                const { showCounts } = settings.store;
+
+                ContextMenuApi.openContextMenu(e as unknown as React.UIEvent, () => {
+                    return (
+                        <Menu.Menu navId="notif-plus-context" onClose={ContextMenuApi.closeContextMenu}>
+                            <Menu.MenuItem
+                                id="mark-all-read"
+                                label={`Mark All Servers As Read${showCounts ? ` (${servers})` : ""}`}
+                                icon={settings.store.showIcons ? DeleteIcon : undefined}
+                                action={() => onClick(allChannels, "all")}
+                            />
+                            <Menu.MenuItem
+                                id="mark-dms-read"
+                                label={`Mark All DMs As Read${showCounts ? ` (${dms})` : ""}`}
+                                icon={settings.store.showIcons ? NotesIcon : undefined}
+                                action={() => onClick(dmChannels, "dms")}
+                            />
+                        </Menu.Menu>
+                    );
+                });
+            } catch (error) {
+                console.error("[NotiQuick] Error in context menu:", error);
+                Toasts.show({
+                    message: "Error opening context menu",
+                    type: Toasts.Type.FAILURE,
+                    id: "notif-plus-error"
+                });
+            }
+        };
+
+        const onBellClick = () => {
+            const host = document.querySelector(BUTTON_SELECTOR) as HTMLElement;
+            if (host) animateBellIcon(host);
+        };
+
+        this.cleanup = observeAndAttach(onContextMenu, onBellClick);
+    },
+
+    stop() {
+        this.cleanup?.();
+    },
+
+    cleanup: null as (() => void) | null
+});

--- a/src/plugins/notiQuick/style.css
+++ b/src/plugins/notiQuick/style.css
@@ -1,0 +1,32 @@
+@keyframes bell {
+
+    0%,
+    100% {
+        transform-origin: 50% 5%;
+        transform: rotate(0deg);
+    }
+
+    18% {
+        transform: rotate(-18deg);
+    }
+
+    34% {
+        transform: rotate(14deg);
+    }
+
+    48% {
+        transform: rotate(-10deg);
+    }
+
+    60% {
+        transform: rotate(6deg);
+    }
+
+    72% {
+        transform: rotate(-3deg);
+    }
+
+    85% {
+        transform: rotate(2deg);
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -598,6 +598,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Cootshk",
         id: 921605971577548820n
     },
+    drk: {
+        name: "𝓓𝓡𝓚",
+        id: 637368233166635008n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This pull request introduces the new `NotiQuick` plugin for Discord/Vencord, which streamlines notification management by adding a right-click context menu to the notifications bell and provides quick actions to mark all server or DM notifications as read. The PR includes the full implementation, plugin settings, a README, and a bell icon animation for improved user experience.

**New Plugin Implementation and Features:**

* Added the `NotiQuick` plugin in `index.tsx`, which attaches a context menu to the Discord notifications bell, allowing users to quickly mark all server or DM notifications as read. The plugin includes robust error handling and a bell icon animation.
* Introduced plugin settings for toggling context menu icons, showing notification counts, and enabling/disabling the bell animation.
* Implemented a custom bell shake animation in `style.css` to visually enhance notification actions.

**Documentation:**

* Added a detailed `README.md` for `NotiQuick`, detailing its purpose, features, usage instructions, settings, and including screenshots for clarity. (Dont know if the fact it contains embedded html will be an issue?)

**Contributor Update:**

* Added the new contributor `drk` to the `Devs` object in `constants.ts`, crediting the author of the plugin.

<h2>I generated this PR description with Copilot, so if it seems odd, that's probably why :) But I did proofread it and it seems accurate.</h2>