### PR TITLE
feat: add toggleGuildAndChannelList plugin

### DIFF
--- a/src/plugins/toggleGuildAndChannelList/index.css
+++ b/src/plugins/toggleGuildAndChannelList/index.css
@@ -1,0 +1,24 @@
+.vc-toggle-guild-and-channel-btn,
+.vc-toggle-guild-and-channel-icon {
+    -webkit-app-region: no-drag;
+}
+
+.vc-toggle-guild-and-channel-icon {
+    color: var(--interactive-active);
+}
+
+.vc-toggle-guild-and-channel-btn[class*="selected"] .vc-toggle-guild-and-channel-icon {
+    color: var(--interactive-normal);
+}
+
+.vc-toggle-guild-and-channel-btn:hover .vc-toggle-guild-and-channel-icon {
+    color: var(--interactive-hover);
+}
+
+.vc-toggle-guild-and-channel-btn:focus-visible .vc-toggle-guild-and-channel-icon {
+    color: var(--interactive-hover);
+}
+
+body.hm-hide-sidebar div[class^="sidebar_"] {
+    display: none !important;
+}

--- a/src/plugins/toggleGuildAndChannelList/index.tsx
+++ b/src/plugins/toggleGuildAndChannelList/index.tsx
@@ -1,0 +1,93 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./index.css";
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import definePlugin from "@utils/types";
+import { findComponentByCodeLazy } from "@webpack";
+import { React, useRef, useState } from "@webpack/common";
+
+/** Use the exact same header icon component  */
+const HeaderBarIcon = findComponentByCodeLazy(".HEADER_BAR_BADGE_TOP:", '.iconBadge,"top"');
+
+/** Body class & style to hide the left Channels sidebar (matches hashed prefix) */
+const BODY_TOGGLE = "hm-hide-sidebar";
+
+/* ----------------------------- Header Icon ----------------------------- */
+
+function ToggleGuildAndChannelListIcon() {
+    const buttonRef = useRef<HTMLDivElement | null>(null);
+    const [hidden, setHidden] = useState(document.body.classList.contains(BODY_TOGGLE));
+
+
+    const onClick = () => {
+        document.body.classList.toggle(BODY_TOGGLE);
+        setHidden(document.body.classList.contains(BODY_TOGGLE));
+    };
+
+    const refresh = () => setHidden(document.body.classList.contains(BODY_TOGGLE));
+
+    const tooltip = hidden ? "Show Guilds and Channels" : "Hide Guilds and Channels";
+
+    return (
+        <HeaderBarIcon
+            ref={buttonRef as any}
+            className="vc-toggle-guild-and-channel-btn"
+            onClick={onClick}
+            onMouseEnter={refresh}
+            onFocus={refresh}
+            tooltip={tooltip}
+            selected={hidden}
+            icon={() => (
+                <svg fill="currentColor" viewBox="0 0 24 24" width={24} height={24} className="vc-toggle-guild-and-channel-icon">
+                    <circle cx="5" cy="6" r="1.6" />
+                    <rect x="9" y="5" width="11" height="2" rx="1" />
+                    <circle cx="5" cy="12" r="1.6" />
+                    <rect x="9" y="11" width="11" height="2" rx="1" />
+                    <circle cx="5" cy="18" r="1.6" />
+                    <rect x="9" y="17" width="11" height="2" rx="1" />
+                </svg>
+            )}
+        />
+    );
+}
+
+function ToggleGuildAndChannelListFragmentWrapper({ children }: { children: React.ReactNode[]; }) {
+    return <>
+        <ErrorBoundary noop key="vc-toggle-guild-and-channel">
+            <ToggleGuildAndChannelListIcon />
+        </ErrorBoundary>
+        {...children}
+    </>;
+}
+
+
+export default definePlugin({
+    name: "ToggleGuildAndChannelList",
+    description: "Adds a channel header icon to toggle the left Channels and Guild sidebars.",
+    authors: [],
+
+    patches: [
+        {
+            find: ".controlButtonWrapper,",
+            replacement: {
+                match: /(?<=toolbar:function\(.{0,100}\()\i.Fragment,/,
+                replace: "$self.ToggleGuildAndChannelListFragmentWrapper,"
+            }
+        }
+    ],
+
+    ToggleGuildAndChannelListFragmentWrapper: ErrorBoundary.wrap(ToggleGuildAndChannelListFragmentWrapper, {
+        fallback: () => <span style={{ color: "red" }}>ToggleGuildAndChannelList failed to render</span>
+    }),
+
+    start() {
+    },
+
+    stop() {
+    }
+});


### PR DESCRIPTION
feat: add toggleGuildAndChannelList plugin

Introduces a new plugin that adds a header bar icon to toggle visibility of
the Guilds and Channels sidebars. The icon uses a custom SVG inspired by
the guilds/channels layout (three vertical bullets with horizontal lines).

Features:
- Toolbar button integrated with Discord’s HeaderBarIcon, full hover/tooltip behavior
- Functional toggle by applying `hm-hide-sidebar` body class
- Hover and focus-visible states styled to match native buttons

Note:
There is currently a conflict with VencordToolbox when both plugins attempt
to patch the header toolbar. With limited plugin development knowledge, we
are unsure of the best approach to resolve this gracefully.

I also omitted the authors for now, as I will seek guidance on that if this gets accepted.


<img width="558" height="1387" alt="image" src="https://github.com/user-attachments/assets/055255da-4c87-4081-ab1f-9121b630430f" />
