### PR TITLE
fix(utils): improve `wordsFromCamel` correctness

### DIFF
--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -21,7 +21,8 @@ import { moment } from "@webpack/common";
 // Utils for readable text transformations eg: `toTitle(fromKebab())`
 
 // Case style to words
-export const wordsFromCamel = (text: string) => text.split(/(?=[A-Z])/).map(w => w.toLowerCase());
+export const wordsFromCamel = (text: string) =>
+    text.split(/(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])/).map(w => w.match(/^[A-Z]+$/) ? w : w.toLowerCase());
 export const wordsFromSnake = (text: string) => text.toLowerCase().split("_");
 export const wordsFromKebab = (text: string) => text.toLowerCase().split("-");
 export const wordsFromPascal = (text: string) => text.split(/(?=[A-Z])/).map(w => w.toLowerCase());


### PR DESCRIPTION
Currently settings keys such as `"customEngineURL"` get parsed into `["custom", "engine", "u", "r", "l"]`, and when turned into title case become "Custom Engine U R L". The new implementation, despite being slightly verbose, makes sure that acronyms stay intact.
