### PR TITLE
feat(plugin): HideActiveNowSidebar

### DIFF
--- a/src/plugins/hideActiveNowSidebar/README.md
+++ b/src/plugins/hideActiveNowSidebar/README.md
@@ -1,0 +1,1 @@
+removes that boring "Active Now" sidebar in discord, sometimes we just don't wanna see some name

--- a/src/plugins/hideActiveNowSidebar/index.ts
+++ b/src/plugins/hideActiveNowSidebar/index.ts
@@ -1,0 +1,73 @@
+/*
+* Vencord, a Discord client mod
+* Copyright (c) 2025 Vendicated and contributors*
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "Hide Active Now Sidebar",
+    description: "Hides the 'Active Now' sidebar",
+    authors: [Devs.bayrem],
+
+    start() {
+        this.addStyles();
+        this.observeAndHide();
+    },
+
+    stop() {
+        this.removeStyles();
+        if (this.observer) {
+            this.observer.disconnect();
+        }
+    },
+
+    observer: null as MutationObserver | null,
+
+    addStyles() {
+        const style = document.createElement("style");
+        style.id = "hide-active-now-sidebar";
+        style.textContent = `
+            /* Hide elements with nowPlayingColumn in their class name */
+            [class*="nowPlayingColumn"] {
+                display: none !important;
+            }
+        `;
+        document.head.appendChild(style);
+    },
+
+    removeStyles() {
+        const style = document.getElementById("hide-active-now-sidebar");
+        if (style) {
+            style.remove();
+        }
+    },
+
+    hideElements() {
+        // Find all elements with nowPlayingColumn in their class name
+        const elements = document.querySelectorAll('[class*="nowPlayingColumn"]');
+        elements.forEach(element => {
+            (element as HTMLElement).style.display = "none";
+        });
+    },
+
+    observeAndHide() {
+        // Initial hide
+        this.hideElements();
+
+        // Create observer to hide dynamically added elements
+        this.observer = new MutationObserver(() => {
+            this.hideElements();
+        });
+
+        // Start observing
+        this.observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["class"]
+        });
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -602,6 +602,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Cootshk",
         id: 921605971577548820n
     },
+    bayrem: {
+        name: "bayrem",
+        id: 186769123072540673n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Introduces a new plugin that hides the 'Active Now' sidebar in Discord by injecting CSS and observing DOM changes.