### PR TITLE
MessageLatency: add option to ignore own messages

### DIFF
--- a/src/plugins/messageLatency/index.tsx
+++ b/src/plugins/messageLatency/index.tsx
@@ -11,7 +11,7 @@ import { isNonNullish } from "@utils/guards";
 import definePlugin, { OptionType } from "@utils/types";
 import { Message } from "@vencord/discord-types";
 import { findComponentByCodeLazy } from "@webpack";
-import { SnowflakeUtils, Tooltip } from "@webpack/common";
+import { SnowflakeUtils, Tooltip, UserStore } from "@webpack/common";
 
 type FillValue = ("status-danger" | "status-warning" | "status-positive" | "text-muted");
 type Fill = [FillValue, FillValue, FillValue];
@@ -47,6 +47,11 @@ export default definePlugin({
         showMillis: {
             type: OptionType.BOOLEAN,
             description: "Show milliseconds",
+            default: false
+        },
+        ignoreSelf: {
+            type: OptionType.BOOLEAN,
+            description: "Ignores your own messages",
             default: false
         }
     }),
@@ -91,7 +96,7 @@ export default definePlugin({
     },
 
     latencyTooltipData(message: Message) {
-        const { latency, detectDiscordKotlin, showMillis } = this.settings.store;
+        const { latency, detectDiscordKotlin, showMillis, ignoreSelf } = this.settings.store;
         const { id, nonce } = message;
 
         // Message wasn't received through gateway
@@ -99,6 +104,8 @@ export default definePlugin({
 
         // Bots basically never send a nonce, and if someone does do it then it's usually not a snowflake
         if (message.author.bot) return null;
+
+        if (ignoreSelf && message.author.id === UserStore.getCurrentUser().id) return null;
 
         let isDiscordKotlin = false;
         let delta = SnowflakeUtils.extractTimestamp(id) - SnowflakeUtils.extractTimestamp(nonce); // milliseconds


### PR DESCRIPTION
Would be a great feature if your own time is wrong but you still want to see other people's latency without being bothered from your own