### PR TITLE
Add Transcript plugin for richly rendered channel exports

### DIFF
--- a/src/plugins/chatTranscript/README.md
+++ b/src/plugins/chatTranscript/README.md
@@ -1,0 +1,35 @@
+# Transcript
+
+Export messages from any text channel, thread, DM or group DM with fine grain filters and multiple output formats.
+
+## Highlights
+- HTML, Markdown or JSON export with consistent metadata and ready-to-go filenames
+- Discord-like rendering for avatars, nicknames, embeds, reactions and playable media
+- Right click inside the transcript to copy user IDs, message IDs or deep links
+- Date ranges support ISO strings (for example 2025-01-01T12:00) or relative expressions (
+ow, -7d, +2h)
+- From-start toggle gathers history from the first message up to a chosen date or the current moment
+- Keyword, author, pinned and media-only filters to target exactly the messages you need
+
+## Using the Plugin
+1. Right click a channel, thread, DM or message and choose Export Transcript....
+2. Adjust the channel target, output format, range and filters in the modal.
+3. Press **Generate Transcript** to fetch messages and save the file.
+
+### Channel selection
+- The Channel or DM picker includes every text channel, thread and private conversation you can access.
+- Launching from a message can anchor the export to that message automatically.
+
+### Time range controls
+- Enable **Start from the first message** to pull the entire history until the end date.
+- Use **Up to now** for a live snapshot, or enter a custom end timestamp when you need a finite window.
+
+### Output notes
+- HTML exports inline all styling and scripts so avatars, embeds, videos, audio and copy menus work offline.
+- Markdown exports use readable headings and bullet lists for attachments, embeds and reactions.
+- JSON exports include channel metadata plus whichever fields you chose to include.
+
+## Tips
+- Large transcripts can take a moment to fetch. Progress updates appear in the modal while paging.
+- The maximum batch size defaults to 500 messages but can be raised in plugin settings (up to 5000).
+- If Discord rate limits the requests, wait a few seconds and try again with a narrower range.

--- a/src/plugins/chatTranscript/collect.ts
+++ b/src/plugins/chatTranscript/collect.ts
@@ -1,0 +1,64 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Constants, RestAPI, SnowflakeUtils } from "@webpack/common";
+import { Message } from "@vencord/discord-types";
+
+import { FETCH_CHUNK_SIZE } from "./constants";
+import type { CollectMessagesOptions } from "./types";
+
+async function collectMessages(channelId: string, options: CollectMessagesOptions): Promise<Message[]> {
+    const { limit, startTs, endTs, pivotId, fromStart, onProgress } = options;
+    const messages: Message[] = [];
+
+    let before = pivotId ?? (endTs != null ? SnowflakeUtils.fromTimestamp(endTs + 1) : undefined);
+    let done = false;
+
+    while (messages.length < limit && !done) {
+        const chunk = Math.min(FETCH_CHUNK_SIZE, limit - messages.length);
+        const query: Record<string, string | number> = { limit: chunk };
+        if (before) query.before = before;
+
+        const res = await RestAPI.get({
+            url: Constants.Endpoints.MESSAGES(channelId),
+            query,
+            retries: 2
+        }).catch(error => {
+            const reason = error?.message ?? String(error ?? "unknown error");
+            throw new Error(`Failed to fetch messages: ${reason}`);
+        });
+
+        const batch = (res?.body ?? []) as Message[];
+        if (!batch.length) break;
+
+        for (const message of batch) {
+            const timestamp = Date.parse(message.timestamp);
+            if (Number.isNaN(timestamp)) continue;
+            if (endTs != null && timestamp > endTs) continue;
+            if (!fromStart && startTs != null && timestamp < startTs) {
+                done = true;
+                break;
+            }
+
+            messages.push(message);
+            if (messages.length >= limit) break;
+        }
+
+        onProgress?.(messages.length);
+
+        if (messages.length >= limit || done) break;
+
+        const last = batch[batch.length - 1];
+        before = last?.id;
+        if (!before || batch.length < chunk) break;
+    }
+
+    messages.sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+    return messages;
+}
+
+export { collectMessages };
+

--- a/src/plugins/chatTranscript/constants.ts
+++ b/src/plugins/chatTranscript/constants.ts
@@ -1,0 +1,28 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+const MAX_FETCH_LIMIT = 5000;
+const FETCH_CHUNK_SIZE = 100;
+const TEXT_BASED_CHANNEL_TYPES = new Set<number>([0, 1, 3, 5, 10, 11, 12, 15, 16]);
+const NON_SYSTEM_MESSAGE_TYPES = new Set<number>([0, 1, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21, 23, 24, 25, 26, 27, 28, 30]);
+const RELATIVE_DATE_PATTERN = /^([+-]?)(\d+)([smhdw])$/i;
+const RELATIVE_UNITS: Record<string, number> = {
+    s: 1_000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+    w: 604_800_000
+};
+
+export {
+    FETCH_CHUNK_SIZE,
+    MAX_FETCH_LIMIT,
+    NON_SYSTEM_MESSAGE_TYPES,
+    RELATIVE_DATE_PATTERN,
+    RELATIVE_UNITS,
+    TEXT_BASED_CHANNEL_TYPES
+};
+

--- a/src/plugins/chatTranscript/contextMenus.tsx
+++ b/src/plugins/chatTranscript/contextMenus.tsx
@@ -1,0 +1,76 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { Menu } from "@webpack/common";
+import { Channel, Message } from "@vencord/discord-types";
+
+import { openTranscriptModal } from "./modal";
+import { isTextBasedChannel, safeGetChannel } from "./utils";
+
+const CHANNEL_ITEM_ID = "vc-transcript-channel";
+const MESSAGE_ITEM_ID = "vc-transcript-message";
+
+const channelContextPatch: NavContextMenuPatchCallback = (children, props) => {
+    const channel = props.channel as Channel | undefined;
+    if (!isTextBasedChannel(channel)) return;
+
+    const container = findGroupChildrenByChildId("mark-channel-read", children)
+        ?? findGroupChildrenByChildId("close-dm", children)
+        ?? children;
+
+    container.push(
+        <Menu.MenuItem
+            id={CHANNEL_ITEM_ID}
+            label="Export Transcript..."
+            action={() => openTranscriptModal({ channelId: channel.id })}
+        />
+    );
+};
+
+const dmContextPatch: NavContextMenuPatchCallback = (children, props) => {
+    const channel = props.channel as Channel | undefined;
+    if (!isTextBasedChannel(channel)) return;
+
+    const container = findGroupChildrenByChildId("close-dm", children)
+        ?? findGroupChildrenByChildId("leave-channel", children)
+        ?? children;
+
+    container.push(
+        <Menu.MenuItem
+            id="vc-transcript-dm"
+            label="Export Transcript..."
+            action={() => openTranscriptModal({ channelId: channel.id })}
+        />
+    );
+};
+
+const messageContextPatch: NavContextMenuPatchCallback = (children, props) => {
+    const message = props.message as Message | undefined;
+    if (!message) return;
+
+    const channel = safeGetChannel(message.channel_id);
+    if (!isTextBasedChannel(channel)) return;
+
+    children.push(
+        <Menu.MenuItem
+            id={MESSAGE_ITEM_ID}
+            label="Export Transcript from here..."
+            action={() => openTranscriptModal({ channelId: channel.id, message })}
+        />
+    );
+};
+
+const contextMenus = {
+    "channel-context": channelContextPatch,
+    "thread-context": channelContextPatch,
+    "gdm-context": channelContextPatch,
+    "user-context": dmContextPatch,
+    "message": messageContextPatch
+};
+
+export { contextMenus };
+

--- a/src/plugins/chatTranscript/filters.ts
+++ b/src/plugins/chatTranscript/filters.ts
@@ -1,0 +1,45 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Message } from "@vencord/discord-types";
+
+import { NON_SYSTEM_MESSAGE_TYPES } from "./constants";
+import type { FilterOptions } from "./types";
+import { messageHasMedia, messageMatchesKeyword } from "./utils";
+
+function applyFilters(messages: Message[], options: FilterOptions): Message[] {
+    const {
+        startTs,
+        endTs,
+        includeBots,
+        includeSystem,
+        onlyPinned,
+        onlyWithMedia,
+        authorIds,
+        keyword,
+        includeAttachments,
+        includeEmbeds
+    } = options;
+
+    const trimmedKeyword = keyword.trim();
+
+    return messages.filter(message => {
+        const timestamp = Date.parse(message.timestamp);
+        if (Number.isNaN(timestamp)) return false;
+        if (startTs != null && timestamp < startTs) return false;
+        if (endTs != null && timestamp > endTs) return false;
+        if (!includeBots && message.author?.bot) return false;
+        if (!includeSystem && !NON_SYSTEM_MESSAGE_TYPES.has(message.type as number)) return false;
+        if (onlyPinned && !message.pinned) return false;
+        if (onlyWithMedia && !messageHasMedia(message)) return false;
+        if (authorIds && (!message.author || !authorIds.has(message.author.id))) return false;
+        if (trimmedKeyword && !messageMatchesKeyword(message, trimmedKeyword, includeAttachments, includeEmbeds)) return false;
+        return true;
+    });
+}
+
+export { applyFilters };
+

--- a/src/plugins/chatTranscript/formatters/html.ts
+++ b/src/plugins/chatTranscript/formatters/html.ts
@@ -1,0 +1,385 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Message } from "@vencord/discord-types";
+
+import type { FormatOptions } from "../types";
+import {
+    buildAvatarUrl,
+    escapeAttribute,
+    escapeHtml,
+    formatFileSize,
+    getChannelDisplayName,
+    getMessageDisplayName,
+    sanitizeFilename
+} from "../utils";
+
+interface HtmlResult {
+    content: string;
+    mime: string;
+    extension: string;
+    filenameHint: string;
+}
+
+function renderAttachment(attachment: NonNullable<Message["attachments"]>[number]) {
+    const url = escapeAttribute(attachment.url);
+    const name = escapeHtml(attachment.filename ?? attachment.id ?? attachment.url);
+    const size = formatFileSize(attachment.size);
+    const type = attachment.content_type ?? "";
+
+    if (type.startsWith("image/")) {
+        return `<figure class="attachment attachment-image"><img src="${url}" alt="${name}" loading="lazy" /><figcaption>${name}${size ? ` (${size})` : ""}</figcaption></figure>`;
+    }
+
+    if (type.startsWith("video/")) {
+        return `<figure class="attachment attachment-video"><video controls preload="metadata" src="${url}"></video><figcaption>${name}${size ? ` (${size})` : ""}</figcaption></figure>`;
+    }
+
+    if (type.startsWith("audio/")) {
+        return `<figure class="attachment attachment-audio"><audio controls preload="metadata" src="${url}"></audio><figcaption>${name}${size ? ` (${size})` : ""}</figcaption></figure>`;
+    }
+
+    if (type === "application/pdf") {
+        return `<figure class="attachment attachment-embed"><embed src="${url}" type="application/pdf" /><figcaption>${name}${size ? ` (${size})` : ""}</figcaption></figure>`;
+    }
+
+    return `<div class="attachment attachment-file"><a href="${url}">${name}</a>${size ? ` <span class="filesize">(${size})</span>` : ""}</div>`;
+}
+
+function renderEmbed(embed: NonNullable<Message["embeds"]>[number]) {
+    const color = embed.color != null ? `border-color: #${embed.color.toString(16).padStart(6, "0")};` : "";
+    const author = embed.author ? `
+            <div class="embed-author">
+                ${embed.author.icon_url ? `<img class="embed-author-icon" src="${escapeAttribute(embed.author.icon_url)}" alt="" loading="lazy" />` : ""}
+                <span class="embed-author-name">${escapeHtml(embed.author.name ?? "")}</span>
+                ${embed.author.url ? `<a class="embed-author-link" href="${escapeAttribute(embed.author.url)}">Open</a>` : ""}
+            </div>` : "";
+
+    const title = embed.title ? `<div class="embed-title">${embed.url ? `<a href="${escapeAttribute(embed.url)}">${escapeHtml(embed.title)}</a>` : escapeHtml(embed.title)}</div>` : "";
+    const description = embed.description ? `<div class="embed-description">${escapeHtml(embed.description).replace(/\n/g, "<br />")}</div>` : "";
+
+    const fields = embed.fields?.length ? `
+            <div class="embed-fields">
+                ${embed.fields.map(field => `
+                    <div class="embed-field${field.inline ? " inline" : ""}">
+                        <div class="embed-field-name">${escapeHtml(field.name ?? "")}</div>
+                        <div class="embed-field-value">${escapeHtml(field.value ?? "").replace(/\n/g, "<br />")}</div>
+                    </div>
+                `).join("")}
+            </div>
+        ` : "";
+
+    const image = embed.image?.url
+        ? `<div class="embed-media embed-image"><img src="${escapeAttribute(embed.image.url)}" alt="" loading="lazy" /></div>`
+        : "";
+
+    const thumbnail = embed.thumbnail?.url
+        ? `<div class="embed-thumbnail"><img src="${escapeAttribute(embed.thumbnail.url)}" alt="" loading="lazy" /></div>`
+        : "";
+
+    const video = embed.video?.url
+        ? `<div class="embed-media embed-video"><video controls preload="metadata" src="${escapeAttribute(embed.video.url)}"></video></div>`
+        : "";
+
+    const footer = embed.footer
+        ? `<div class="embed-footer">${embed.footer.icon_url ? `<img class="embed-footer-icon" src="${escapeAttribute(embed.footer.icon_url)}" alt="" loading="lazy" />` : ""}<span>${escapeHtml(embed.footer.text ?? "")}</span>${embed.timestamp ? `<span class="embed-footer-timestamp">${escapeHtml(new Date(embed.timestamp).toLocaleString())}</span>` : ""}</div>`
+        : "";
+
+    return `
+        <div class="embed" style="${color}">
+            <div class="embed-content">
+                ${author}
+                ${title}
+                ${description}
+                ${fields}
+                ${footer}
+            </div>
+            ${thumbnail}
+            ${image}
+            ${video}
+        </div>
+    `;
+}
+
+function renderReactions(message: Message) {
+    if (!message.reactions?.length) return "";
+    const items = message.reactions.map(reaction => {
+        const emoji = reaction.emoji;
+        const label = emoji.id
+            ? `<img class="reaction-emoji" src="https://cdn.discordapp.com/emojis/${emoji.id}.${emoji.animated ? "gif" : "png"}" alt="${escapeHtml(emoji.name ?? "emoji")}" />`
+            : escapeHtml(emoji.name ?? "emoji");
+        return `<span class="reaction">${label}<span class="reaction-count">${reaction.count}</span></span>`;
+    }).join("");
+
+    return `<div class="reactions">${items}</div>`;
+}
+
+function renderMentions(message: Message) {
+    if (!message.mentions?.length) return "";
+    return `
+        <div class="mention-list">
+            ${message.mentions.map(mention => {
+                const name = mention.global_name ?? mention.username ?? mention.id;
+                return `<span class="mention">@${escapeHtml(name)}<span class="mention-meta"> (${mention.id})</span></span>`;
+            }).join("")}
+        </div>
+    `;
+}
+
+function renderReply(message: Message) {
+    const ref = message.referenced_message;
+    if (!ref) return "";
+    const author = getMessageDisplayName(ref);
+    const timestamp = ref.timestamp ? new Date(ref.timestamp).toLocaleString() : "unknown";
+    const content = ref.content ? escapeHtml(ref.content).replace(/\n/g, "<br />") : "";
+    return `
+        <div class="reply">
+            <div class="reply-meta">Replying to ${escapeHtml(author)} (${escapeHtml(timestamp)})</div>
+            ${content ? `<div class="reply-content">${content}</div>` : ""}
+        </div>
+    `;
+}
+
+function buildMessageLink(message: Message, channelId: string, guildId?: string | null) {
+    const guildSegment = guildId ?? message.guild_id ?? "@me";
+    return `https://discord.com/channels/${guildSegment}/${channelId}/${message.id}`;
+}
+
+function buildHtmlTranscript(messages: Message[], options: FormatOptions): HtmlResult {
+    const {
+        channel,
+        includeAttachments,
+        includeEmbeds,
+        includeReactions,
+        includeEdits,
+        includeMentions,
+        includeReferenced,
+        groupByDay
+    } = options;
+
+    const channelName = getChannelDisplayName(channel);
+    const now = new Date();
+
+    const css = `
+        :root { color-scheme: dark; }
+        body { font-family: system-ui,-apple-system,"Segoe UI",sans-serif; background: #313338; color: #f2f3f5; margin: 0; padding: 32px; }
+        header { margin-bottom: 24px; }
+        header h1 { margin: 0 0 8px 0; font-size: 24px; }
+        header p { margin: 4px 0; color: #b5bac1; }
+        .transcript { display: flex; flex-direction: column; gap: 12px; }
+        .message { display: grid; grid-template-columns: 48px 1fr; gap: 12px; padding: 12px; border-radius: 8px; background: rgba(49, 51, 56, 0.65); position: relative; }
+        .avatar img { width: 48px; height: 48px; border-radius: 50%; object-fit: cover; }
+        .message-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; }
+        .message-author { font-weight: 600; color: #fff; cursor: pointer; }
+        .message-username { color: #b5bac1; font-size: 12px; }
+        .message-timestamp { color: #b5bac1; font-size: 12px; }
+        .message-edited { color: #949ba4; font-size: 12px; }
+        .message-pinned { margin-left: auto; color: #f1c40f; font-size: 12px; }
+        .message-content { margin-top: 4px; white-space: pre-wrap; word-break: break-word; }
+        .attachments { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; }
+        .attachment figure { margin: 0; }
+        .attachment figcaption { margin-top: 6px; color: #b5bac1; font-size: 12px; }
+        .attachment-image img, .embed-image img { max-width: 100%; border-radius: 8px; background: #1e1f22; }
+        .attachment-video video, .embed-video video { max-width: 100%; border-radius: 8px; background: #1e1f22; }
+        .attachment-audio audio { width: 100%; }
+        .attachment-file a { color: #8592ff; text-decoration: none; }
+        .attachment-file a:hover { text-decoration: underline; }
+        .filesize { color: #b5bac1; }
+        .embeds { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; }
+        .embed { border-left: 4px solid rgba(88,101,242,0.7); background: #2b2d31; padding: 12px; border-radius: 8px; display: grid; grid-template-columns: 1fr auto; gap: 12px; }
+        .embed-thumbnail img { width: 80px; height: 80px; border-radius: 8px; object-fit: cover; }
+        .embed-author { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-size: 14px; }
+        .embed-author-icon { width: 24px; height: 24px; border-radius: 50%; }
+        .embed-title { font-weight: 600; margin-bottom: 6px; }
+        .embed-title a { color: #fff; text-decoration: none; }
+        .embed-title a:hover { text-decoration: underline; }
+        .embed-description { color: #e3e5e8; font-size: 14px; }
+        .embed-fields { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 8px; margin-top: 8px; }
+        .embed-field { background: rgba(0,0,0,0.1); padding: 8px; border-radius: 4px; }
+        .embed-field.inline { grid-column: span 1; }
+        .embed-field-name { font-weight: 600; margin-bottom: 4px; font-size: 12px; text-transform: uppercase; color: #949ba4; }
+        .embed-field-value { font-size: 14px; }
+        .embed-footer { display: flex; align-items: center; gap: 6px; margin-top: 8px; font-size: 12px; color: #949ba4; }
+        .embed-footer-icon { width: 20px; height: 20px; border-radius: 50%; }
+        .reactions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+        .reaction { display: flex; align-items: center; gap: 6px; background: rgba(88,101,242,0.2); border: 1px solid rgba(88,101,242,0.5); padding: 4px 8px; border-radius: 999px; font-size: 12px; }
+        .reaction-emoji { width: 20px; height: 20px; }
+        .reaction-count { font-weight: 600; }
+        .mention-list { margin-top: 8px; color: #b5bac1; font-size: 12px; display: flex; flex-wrap: wrap; gap: 6px; }
+        .mention { background: rgba(88,101,242,0.15); padding: 4px 6px; border-radius: 6px; }
+        .mention-meta { color: #8a8e93; }
+        .reply { border-left: 2px solid rgba(255,255,255,0.2); padding-left: 12px; margin-top: 8px; color: #b5bac1; }
+        .reply-meta { font-size: 12px; margin-bottom: 4px; }
+        .day-separator { margin: 32px 0 8px 0; font-size: 14px; color: #b5bac1; position: relative; }
+        .day-separator::after { content: ""; position: absolute; left: 0; right: 0; top: 50%; height: 1px; background: rgba(255,255,255,0.08); z-index: -1; }
+        .day-separator span { background: #313338; padding-right: 8px; }
+        .context-menu { position: fixed; z-index: 9999; background: #111214; border: 1px solid rgba(255,255,255,0.1); border-radius: 8px; min-width: 180px; padding: 4px 0; box-shadow: 0 8px 24px rgba(0,0,0,0.35); display: none; }
+        .context-menu.visible { display: block; }
+        .context-menu button { width: 100%; padding: 8px 12px; background: none; border: none; color: #f2f3f5; text-align: left; font-size: 14px; cursor: pointer; }
+        .context-menu button:hover { background: rgba(88,101,242,0.3); }
+    `;
+
+    const menuHtml = `
+        <div id="transcript-context-menu" class="context-menu" role="menu">
+            <button type="button" data-action="copy-user">Copy User ID</button>
+            <button type="button" data-action="copy-message">Copy Message ID</button>
+            <button type="button" data-action="copy-link">Copy Message Link</button>
+            <button type="button" data-action="open">Open in Discord</button>
+        </div>
+    `;
+
+    const script = `
+        const ctxMenu = document.getElementById('transcript-context-menu');
+        let ctxTarget = null;
+        document.addEventListener('contextmenu', event => {
+            const message = event.target.closest('.message');
+            if (!message) return;
+            event.preventDefault();
+            ctxTarget = message;
+            ctxMenu.style.left = event.clientX + 'px';
+            ctxMenu.style.top = event.clientY + 'px';
+            ctxMenu.classList.add('visible');
+        });
+
+        document.addEventListener('click', () => {
+            ctxMenu.classList.remove('visible');
+        });
+
+        ctxMenu.addEventListener('click', async event => {
+            const button = event.target.closest('button[data-action]');
+            if (!button || !ctxTarget) return;
+            const action = button.dataset.action;
+            const userId = ctxTarget.dataset.userId;
+            const messageId = ctxTarget.dataset.messageId;
+            const link = ctxTarget.dataset.link;
+
+            async function copy(text) {
+                try {
+                    await navigator.clipboard.writeText(text);
+                } catch (error) {
+                    console.error('Clipboard error', error);
+                }
+            }
+
+            if (action === 'copy-user' && userId) {
+                copy(userId);
+            }
+
+            if (action === 'copy-message' && messageId) {
+                copy(messageId);
+            }
+
+            if (action === 'copy-link' && link) {
+                copy(link);
+            }
+
+            if (action === 'open' && link) {
+                window.open(link, '_blank');
+            }
+
+            ctxMenu.classList.remove('visible');
+        });
+    `;
+
+    const parts: string[] = [];
+    parts.push(
+        "<!DOCTYPE html>",
+        "<html lang=\"en\">",
+        "<head>",
+        "<meta charset=\"utf-8\" />",
+        `<title>${escapeHtml(channelName)} Transcript</title>`,
+        `<style>${css}</style>`,
+        "</head>",
+        "<body>",
+        "<header>",
+        `<h1>${escapeHtml(channelName)} Transcript</h1>`,
+        `<p>Exported ${escapeHtml(now.toLocaleString())}</p>`,
+        `<p>Total messages: ${messages.length}</p>`,
+        "</header>",
+        "<main class=\"transcript\">"
+    );
+
+    let currentDay = "";
+
+    for (const message of messages) {
+        const timestamp = new Date(message.timestamp);
+        const dayLabel = timestamp.toLocaleDateString();
+
+        if (groupByDay && dayLabel !== currentDay) {
+            currentDay = dayLabel;
+            parts.push(`<div class=\"day-separator\"><span>${escapeHtml(dayLabel)}</span></div>`);
+        }
+
+        const authorName = getMessageDisplayName(message);
+        const timestampLabel = timestamp.toLocaleString();
+        const avatar = buildAvatarUrl(message, 96);
+        const content = message.content ? escapeHtml(message.content).replace(/\n/g, "<br />") : "";
+        const messageLink = buildMessageLink(message, message.channel_id, channel?.guild_id ?? message.guild_id);
+
+        const attachments = includeAttachments && message.attachments?.length
+            ? `<div class="attachments">${message.attachments.map(renderAttachment).join("")}</div>`
+            : "";
+
+        const embeds = includeEmbeds && message.embeds?.length
+            ? `<div class="embeds">${message.embeds.map(renderEmbed).join("")}</div>`
+            : "";
+
+        const reactions = includeReactions ? renderReactions(message) : "";
+        const mentions = includeMentions ? renderMentions(message) : "";
+        const reply = includeReferenced ? renderReply(message) : "";
+
+        parts.push(`
+            <article
+                class="message"
+                data-message-id="${message.id}"
+                data-user-id="${message.author?.id ?? ""}"
+                data-channel-id="${message.channel_id}"
+                data-guild-id="${message.guild_id ?? channel?.guild_id ?? ""}"
+                data-link="${escapeAttribute(messageLink)}"
+            >
+                <div class="avatar"><img src="${escapeAttribute(avatar)}" alt="" loading="lazy" /></div>
+                <div class="message-body">
+                    <div class="message-header">
+                        <span class="message-author">${escapeHtml(authorName)}</span>
+                        <span class="message-username">${escapeHtml(message.author?.username ?? "")}${message.author?.discriminator && message.author.discriminator !== "0" ? `#${message.author.discriminator}` : ""}</span>
+                        <span class="message-timestamp">${escapeHtml(timestampLabel)}</span>
+                        ${includeEdits && message.edited_timestamp ? `<span class="message-edited">(edited ${escapeHtml(new Date(message.edited_timestamp).toLocaleString())})</span>` : ""}
+                        ${message.pinned ? `<span class="message-pinned">?? pinned</span>` : ""}
+                    </div>
+                    ${reply}
+                    ${content ? `<div class="message-content">${content}</div>` : ""}
+                    ${attachments}
+                    ${embeds}
+                    ${reactions}
+                    ${mentions}
+                </div>
+            </article>
+        `);
+    }
+
+    parts.push(
+        "</main>",
+        menuHtml,
+        `<script>${script}</script>`,
+        "</body>",
+        "</html>"
+    );
+
+    const firstMessage = messages[0];
+    const lastMessage = messages[messages.length - 1];
+    const rangeHint = `${firstMessage ? new Date(firstMessage.timestamp).toISOString() : "start"}_${lastMessage ? new Date(lastMessage.timestamp).toISOString() : "end"}`;
+    const filenameHint = sanitizeFilename(`${channelName}_${rangeHint}`);
+
+    return {
+        content: parts.join("\n"),
+        mime: "text/html;charset=utf-8",
+        extension: "html",
+        filenameHint
+    };
+}
+
+export { buildHtmlTranscript };
+

--- a/src/plugins/chatTranscript/formatters/index.ts
+++ b/src/plugins/chatTranscript/formatters/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Message } from "@vencord/discord-types";
+
+import type { FormatOptions } from "../types";
+import { buildHtmlTranscript } from "./html";
+import { buildJsonTranscript } from "./json";
+import { buildMarkdownTranscript } from "./markdown";
+
+interface TranscriptFile {
+    content: string;
+    mime: string;
+    extension: string;
+    filenameHint: string;
+}
+
+function formatTranscript(messages: Message[], options: FormatOptions): TranscriptFile {
+    switch (options.format) {
+        case "markdown":
+            return buildMarkdownTranscript(messages, options);
+        case "json":
+            return buildJsonTranscript(messages, options);
+        case "html":
+        default:
+            return buildHtmlTranscript(messages, options);
+    }
+}
+
+export type { TranscriptFile };
+export { formatTranscript };
+

--- a/src/plugins/chatTranscript/formatters/json.ts
+++ b/src/plugins/chatTranscript/formatters/json.ts
@@ -1,0 +1,90 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Message } from "@vencord/discord-types";
+
+import type { FormatOptions } from "../types";
+import { getChannelDisplayName, sanitizeFilename } from "../utils";
+
+interface JsonResult {
+    content: string;
+    mime: string;
+    extension: string;
+    filenameHint: string;
+}
+
+function buildJsonTranscript(messages: Message[], options: FormatOptions): JsonResult {
+    const {
+        channel,
+        includeAttachments,
+        includeEmbeds,
+        includeReactions,
+        includeEdits,
+        includeMentions,
+        includeReferenced
+    } = options;
+
+    const channelName = getChannelDisplayName(channel);
+
+    const data = {
+        channel: channel ? {
+            id: channel.id,
+            name: channel.name,
+            type: channel.type,
+            guild_id: channel.guild_id,
+            displayName: channelName
+        } : null,
+        exportedAt: new Date().toISOString(),
+        messageCount: messages.length,
+        messages: messages.map(message => {
+            const serialised: Record<string, unknown> = {
+                id: message.id,
+                timestamp: message.timestamp,
+                type: message.type,
+                pinned: message.pinned,
+                content: message.content,
+                channel_id: message.channel_id,
+                guild_id: message.guild_id,
+                author: {
+                    id: message.author?.id,
+                    username: message.author?.username,
+                    globalName: message.author?.global_name,
+                    discriminator: message.author?.discriminator,
+                    bot: message.author?.bot,
+                    avatar: message.author?.avatar
+                },
+                member: message.member ?? null
+            };
+
+            if (includeEdits) serialised.editedTimestamp = message.edited_timestamp;
+            if (includeAttachments) serialised.attachments = message.attachments;
+            if (includeEmbeds) serialised.embeds = message.embeds;
+            if (includeReactions) serialised.reactions = message.reactions;
+            if (includeMentions) {
+                serialised.mentions = message.mentions;
+                serialised.mention_roles = message.mention_roles;
+            }
+            if (includeReferenced) serialised.referencedMessage = message.referenced_message;
+
+            return serialised;
+        })
+    };
+
+    const firstMessage = messages[0];
+    const lastMessage = messages[messages.length - 1];
+    const rangeHint = `${firstMessage ? new Date(firstMessage.timestamp).toISOString() : "start"}_${lastMessage ? new Date(lastMessage.timestamp).toISOString() : "end"}`;
+    const filenameHint = sanitizeFilename(`${channelName}_${rangeHint}`);
+
+    return {
+        content: JSON.stringify(data, null, 2),
+        mime: "application/json;charset=utf-8",
+        extension: "json",
+        filenameHint
+    };
+}
+
+export { buildJsonTranscript };
+

--- a/src/plugins/chatTranscript/formatters/markdown.ts
+++ b/src/plugins/chatTranscript/formatters/markdown.ts
@@ -1,0 +1,115 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Message } from "@vencord/discord-types";
+
+import type { FormatOptions } from "../types";
+import { formatFileSize, getChannelDisplayName, getMessageDisplayName, sanitizeFilename } from "../utils";
+
+interface MarkdownResult {
+    content: string;
+    mime: string;
+    extension: string;
+    filenameHint: string;
+}
+
+function buildMarkdownTranscript(messages: Message[], options: FormatOptions): MarkdownResult {
+    const {
+        channel,
+        includeAttachments,
+        includeEmbeds,
+        includeReactions,
+        includeEdits,
+        includeMentions,
+        includeReferenced
+    } = options;
+
+    const channelName = getChannelDisplayName(channel);
+    const lines: string[] = [];
+
+    lines.push(`# Transcript for ${channelName}`);
+    lines.push(`- Exported at ${new Date().toISOString()}`);
+    lines.push(`- Message count: ${messages.length}`);
+    lines.push("");
+
+    for (const message of messages) {
+        const author = getMessageDisplayName(message);
+        const timestamp = new Date(message.timestamp).toISOString();
+        const flags: string[] = [];
+        if (message.pinned) flags.push("pinned");
+        if (includeEdits && message.edited_timestamp) flags.push(`edited ${new Date(message.edited_timestamp).toISOString()}`);
+
+        lines.push(`## ${timestamp} — ${author} (${message.author?.id ?? "unknown"})${flags.length ? ` [${flags.join(", ")}]` : ""}`);
+
+        if (message.content) {
+            lines.push(message.content);
+        }
+
+        if (includeReferenced && message.referenced_message) {
+            const ref = message.referenced_message;
+            const refAuthor = getMessageDisplayName(ref);
+            const refTimestamp = ref.timestamp ? new Date(ref.timestamp).toISOString() : "unknown";
+            lines.push(`> Replying to ${refAuthor} (${refTimestamp})`);
+            if (ref.content) lines.push(`> ${ref.content.replace(/\n/g, "\n> ")}`);
+        }
+
+        if (includeAttachments && message.attachments?.length) {
+            lines.push("Attachments:");
+            for (const attachment of message.attachments) {
+                const label = attachment.filename ?? attachment.url ?? attachment.id;
+                const size = formatFileSize(attachment.size);
+                lines.push(`- [${label}](${attachment.url})${size ? ` (${size})` : ""}`);
+            }
+        }
+
+        if (includeEmbeds && message.embeds?.length) {
+            lines.push("Embeds:");
+            for (const embed of message.embeds) {
+                const title = embed.title ?? "Untitled Embed";
+                const desc = embed.description ? ` — ${embed.description.replace(/\n/g, " ")}` : "";
+                const url = embed.url ? ` (${embed.url})` : "";
+                lines.push(`- ${title}${desc}${url}`);
+                if (embed.fields?.length) {
+                    embed.fields.forEach(field => {
+                        lines.push(`  - ${field.name ?? "Field"}: ${field.value ?? ""}`);
+                    });
+                }
+            }
+        }
+
+        if (includeReactions && message.reactions?.length) {
+            const reactionLine = message.reactions
+                .map(r => `${r.emoji.name ?? r.emoji.id ?? "emoji"} × ${r.count}`)
+                .join(", ");
+            lines.push(`Reactions: ${reactionLine}`);
+        }
+
+        if (includeMentions && message.mentions?.length) {
+            lines.push("Mentions:");
+            for (const mention of message.mentions) {
+                const name = mention.global_name ?? mention.username ?? mention.id;
+                lines.push(`- @${name} (${mention.id})`);
+            }
+        }
+
+        lines.push("");
+    }
+
+    const firstMessage = messages[0];
+    const lastMessage = messages[messages.length - 1];
+    const rangeHint = `${firstMessage ? new Date(firstMessage.timestamp).toISOString() : "start"}_${lastMessage ? new Date(lastMessage.timestamp).toISOString() : "end"}`;
+    const filenameHint = sanitizeFilename(`${channelName}_${rangeHint}`);
+
+    return {
+        content: lines.join("\n"),
+        mime: "text/markdown;charset=utf-8",
+        extension: "md",
+        filenameHint
+    };
+}
+
+export { buildMarkdownTranscript };
+

--- a/src/plugins/chatTranscript/index.tsx
+++ b/src/plugins/chatTranscript/index.tsx
@@ -1,0 +1,19 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+import { contextMenus } from "./contextMenus";
+import { settings } from "./settings";
+
+export default definePlugin({
+    name: "Chat Transcript",
+    description: "Export Discord transcripts with advanced filters, ranges and formatting options.",
+    authors: [Devs.Naseem],
+    settings,
+    contextMenus
+});

--- a/src/plugins/chatTranscript/modal.css
+++ b/src/plugins/chatTranscript/modal.css
@@ -1,0 +1,11 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+.vc-transcript-field-label {
+    margin-top: 12px;
+    margin-bottom: 6px;
+    color: var(--text-muted);
+}
+

--- a/src/plugins/chatTranscript/modal.tsx
+++ b/src/plugins/chatTranscript/modal.tsx
@@ -1,0 +1,458 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./modal.css";
+
+import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { identity } from "@utils/misc";
+import { saveFile } from "@utils/web";
+import { Channel, Message } from "@vencord/discord-types";
+import {
+    Button,
+    ChannelStore,
+    Forms,
+    GuildStore,
+    SearchableSelect,
+    Select,
+    SelectedChannelStore,
+    Switch,
+    Text,
+    TextInput,
+    Toasts,
+    showToast,
+    useCallback,
+    useMemo,
+    useState
+} from "@webpack/common";
+
+import { collectMessages } from "./collect";
+import { MAX_FETCH_LIMIT } from "./constants";
+import { applyFilters } from "./filters";
+import { formatTranscript } from "./formatters";
+import { settings } from "./settings";
+import type { ExportFormat, TranscriptRequest } from "./types";
+import {
+    extractAuthorIds,
+    getChannelDisplayName,
+    isTextBasedChannel,
+    parseDateInput,
+    safeGetChannel
+} from "./utils";
+
+interface ChannelOption {
+    label: string;
+    value: string;
+}
+
+interface TranscriptModalProps {
+    modalProps: ModalProps;
+    initialChannelId?: string;
+    pivotMessage?: Message;
+}
+
+function buildChannelOptions(): ChannelOption[] {
+    const options: ChannelOption[] = [];
+
+    const privateChannels = ChannelStore.getMutablePrivateChannels?.();
+    if (privateChannels) {
+        for (const channel of Object.values(privateChannels) as Channel[]) {
+            if (!isTextBasedChannel(channel)) continue;
+            options.push({
+                value: channel.id,
+                label: getChannelDisplayName(channel)
+            });
+        }
+    }
+
+    for (const guildId of GuildStore.getGuildIds?.() ?? []) {
+        const guild = GuildStore.getGuild(guildId);
+        const guildChannels = ChannelStore.getMutableGuildChannelsForGuild?.(guildId);
+        if (!guildChannels) continue;
+
+        const channels = (Object.values(guildChannels) as Channel[])
+            .filter(isTextBasedChannel)
+            .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+
+        for (const channel of channels) {
+            options.push({
+                value: channel.id,
+                label: `${guild?.name ?? "Unknown Guild"} - #${channel.name ?? channel.id}`
+            });
+        }
+    }
+
+    return options;
+}
+
+function TranscriptModal({ modalProps, initialChannelId, pivotMessage }: TranscriptModalProps) {
+    const [channelId, setChannelId] = useState(initialChannelId ?? SelectedChannelStore.getChannelId());
+    const [format, setFormat] = useState<ExportFormat>(settings.store.defaultFormat ?? "html");
+    const [maxMessages, setMaxMessages] = useState(String(settings.store.defaultLimit ?? 500));
+    const [startInput, setStartInput] = useState("");
+    const [fromStart, setFromStart] = useState(false);
+    const [endInput, setEndInput] = useState(pivotMessage ? new Date(pivotMessage.timestamp).toISOString() : "");
+    const [toNow, setToNow] = useState(!pivotMessage);
+    const [onlyPinned, setOnlyPinned] = useState(false);
+    const [onlyWithMedia, setOnlyWithMedia] = useState(false);
+    const [includeBots, setIncludeBots] = useState<boolean>(settings.store.includeBots ?? true);
+    const [includeSystem, setIncludeSystem] = useState<boolean>(settings.store.includeSystem ?? false);
+    const [includeAttachments, setIncludeAttachments] = useState<boolean>(settings.store.includeAttachments ?? true);
+    const [includeEmbeds, setIncludeEmbeds] = useState<boolean>(settings.store.includeEmbeds ?? true);
+    const [includeReactions, setIncludeReactions] = useState<boolean>(settings.store.includeReactions ?? true);
+    const [includeEdits, setIncludeEdits] = useState<boolean>(settings.store.includeEdits ?? true);
+    const [includeMentions, setIncludeMentions] = useState<boolean>(settings.store.includeMentions ?? false);
+    const [includeReferenced, setIncludeReferenced] = useState<boolean>(settings.store.includeReferenced ?? true);
+    const [groupByDay, setGroupByDay] = useState<boolean>(settings.store.groupByDay ?? true);
+    const [keyword, setKeyword] = useState("");
+    const [authorFilter, setAuthorFilter] = useState("");
+    const [includePivot, setIncludePivot] = useState(true);
+    const [anchorToPivot, setAnchorToPivot] = useState<boolean>(Boolean(pivotMessage));
+    const [progress, setProgress] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [busy, setBusy] = useState(false);
+
+    const channelOptions = useMemo(() => buildChannelOptions(), []);
+    const selectedChannel = safeGetChannel(channelId);
+    const channelName = getChannelDisplayName(selectedChannel);
+
+    const selectedOption = useMemo(() => {
+        if (!channelId) return undefined;
+        return channelOptions.find(option => option.value === channelId) ?? {
+            value: channelId,
+            label: channelName
+        };
+    }, [channelId, channelOptions, channelName]);
+
+    const endValue = useMemo(() => {
+        if (anchorToPivot && pivotMessage) return new Date(pivotMessage.timestamp).toISOString();
+        if (toNow) return new Date().toISOString();
+        return endInput;
+    }, [anchorToPivot, pivotMessage, toNow, endInput]);
+
+    const handleGenerate = useCallback(async () => {
+        const targetChannelId = channelId ?? "";
+        if (!targetChannelId) {
+            setError("Please select a channel to export.");
+            return;
+        }
+
+        const limit = Number.parseInt(maxMessages, 10);
+        if (!Number.isFinite(limit) || limit <= 0) {
+            setError("Message limit must be a positive number.");
+            return;
+        }
+        if (limit > MAX_FETCH_LIMIT) {
+            setError(`Message limit cannot exceed ${MAX_FETCH_LIMIT}.`);
+            return;
+        }
+
+        const startTs = fromStart ? null : parseDateInput(startInput);
+        if (!fromStart && startInput.trim() && startTs == null) {
+            setError("Invalid \"From\" value. Use ISO strings (2025-01-01) or relative expressions like -7d.");
+            return;
+        }
+
+        let endTs: number | null = null;
+        if (anchorToPivot && pivotMessage) {
+            endTs = Date.parse(pivotMessage.timestamp);
+        } else if (!toNow && endValue.trim()) {
+            endTs = parseDateInput(endValue);
+            if (endTs == null) {
+                setError("Invalid \"To\" value. Use ISO strings (2025-01-31) or relative expressions like -1d.");
+                return;
+            }
+        } else if (toNow) {
+            endTs = Date.now();
+        }
+
+        if (startTs != null && endTs != null && startTs > endTs) {
+            setError("The \"From\" timestamp must be earlier than the \"To\" timestamp.");
+            return;
+        }
+
+        const authorIds = extractAuthorIds(authorFilter);
+
+        const request: TranscriptRequest = {
+            channelId: targetChannelId,
+            limit,
+            startTs,
+            endTs,
+            fromStart,
+            includeBots,
+            includeSystem,
+            onlyPinned,
+            onlyWithMedia,
+            authorIds,
+            keyword,
+            includeAttachments,
+            includeEmbeds,
+            includeReactions,
+            includeEdits,
+            includeMentions,
+            includeReferenced,
+            groupByDay,
+            format,
+            pivotMessage,
+            includePivot
+        };
+
+        setError(null);
+        setBusy(true);
+        setProgress("Fetching messages...");
+
+        try {
+            const messages = await collectMessages(request.channelId, {
+                limit: request.limit,
+                startTs: request.startTs,
+                endTs: request.endTs,
+                pivotId: anchorToPivot && pivotMessage ? pivotMessage.id : undefined,
+                fromStart: request.fromStart,
+                onProgress: count => setProgress(`Fetched ${count}/${request.limit} messages...`)
+            });
+
+            const mergedMessages = request.includePivot && pivotMessage && !messages.some(m => m.id === pivotMessage.id)
+                ? [...messages, pivotMessage]
+                : messages;
+
+            const filtered = applyFilters(mergedMessages, {
+                startTs: request.startTs,
+                endTs: request.endTs,
+                includeBots: request.includeBots,
+                includeSystem: request.includeSystem,
+                onlyPinned: request.onlyPinned,
+                onlyWithMedia: request.onlyWithMedia,
+                authorIds: request.authorIds,
+                keyword: request.keyword,
+                includeAttachments: request.includeAttachments,
+                includeEmbeds: request.includeEmbeds
+            });
+
+            if (!filtered.length) {
+                setError("No messages matched the selected filters.");
+                setProgress(null);
+                return;
+            }
+
+            setProgress("Formatting transcript...");
+
+            const transcript = formatTranscript(filtered, {
+                format: request.format,
+                channel: selectedChannel,
+                includeAttachments: request.includeAttachments,
+                includeEmbeds: request.includeEmbeds,
+                includeReactions: request.includeReactions,
+                includeEdits: request.includeEdits,
+                includeMentions: request.includeMentions,
+                includeReferenced: request.includeReferenced,
+                groupByDay: request.groupByDay,
+                fromStart: request.fromStart
+            });
+
+            const filename = `${transcript.filenameHint}.${transcript.extension}`;
+            saveFile(new File([transcript.content], filename, { type: transcript.mime }));
+            showToast(`Saved transcript with ${filtered.length} messages.`, Toasts.Type.SUCCESS);
+            modalProps.onClose?.();
+        } catch (err) {
+            console.error("[Transcript] Failed to create transcript", err);
+            const message = err instanceof Error ? err.message : String(err);
+            setError(message);
+            showToast(`Failed to generate transcript: ${message}`, Toasts.Type.FAILURE);
+        } finally {
+            setBusy(false);
+            setProgress(null);
+        }
+    }, [
+        anchorToPivot,
+        authorFilter,
+        channelId,
+        endValue,
+        format,
+        fromStart,
+        includeAttachments,
+        includeBots,
+        includeEdits,
+        includeEmbeds,
+        includeMentions,
+        includePivot,
+        includeReactions,
+        includeReferenced,
+        includeSystem,
+        keyword,
+        maxMessages,
+        modalProps,
+        onlyPinned,
+        onlyWithMedia,
+        pivotMessage,
+        selectedChannel,
+        startInput,
+        toNow
+    ]);
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE}>
+            <ModalHeader>
+                <Text variant="heading-lg/semibold" style={{ flexGrow: 1 }}>Create Transcript</Text>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+
+            <ModalContent>
+                <Forms.FormSection>
+                    <Forms.FormTitle tag="h5">Channel or DM</Forms.FormTitle>
+                    <Forms.FormText>Select where to pull messages from. You can search by name or ID.</Forms.FormText>
+                    <SearchableSelect
+                        placeholder="Select a channel"
+                        options={channelOptions}
+                        value={selectedOption}
+                        onChange={value => setChannelId(value ?? "")}
+                        maxVisibleItems={8}
+                        closeOnSelect
+                    />
+                </Forms.FormSection>
+
+                <Forms.FormDivider />
+
+                <Forms.FormSection>
+                    <Forms.FormTitle tag="h5">Export Options</Forms.FormTitle>
+                    <Select
+                        placeholder="Export format"
+                        options={[
+                            { label: "HTML (.html)", value: "html", default: true },
+                            { label: "Markdown (.md)", value: "markdown" },
+                            { label: "JSON (.json)", value: "json" }
+                        ] satisfies Array<{ value: ExportFormat; label: string; default?: boolean; }>}
+                        select={value => setFormat(value)}
+                        isSelected={value => value === format}
+                        serialize={identity}
+                        closeOnSelect
+                    />
+
+                    <Forms.FormText className="vc-transcript-field-label">Maximum messages to fetch (1 – {MAX_FETCH_LIMIT})</Forms.FormText>
+                    <TextInput
+                        value={maxMessages}
+                        onChange={value => setMaxMessages(value.replace(/[^0-9]/g, ""))}
+                        placeholder="500"
+                    />
+                </Forms.FormSection>
+
+                <Forms.FormDivider />
+
+                <Forms.FormSection>
+                    <Forms.FormTitle tag="h5">Time Range</Forms.FormTitle>
+                    <Forms.FormText>Accepts ISO timestamps (2025-01-01T12:00) or relative shorthand like -7d (7 days ago), +2h (two hours ahead) or "now".</Forms.FormText>
+                    <Switch value={fromStart} onChange={setFromStart} hideBorder>Start from the first message</Switch>
+                    {!fromStart && (
+                        <>
+                            <Forms.FormText className="vc-transcript-field-label">From</Forms.FormText>
+                            <TextInput value={startInput} onChange={setStartInput} placeholder="2025-01-01 or -7d" />
+                        </>
+                    )}
+
+                    <Switch value={toNow} onChange={setToNow} hideBorder disabled={Boolean(pivotMessage && anchorToPivot)}>Up to now</Switch>
+                    {pivotMessage && (
+                        <Switch
+                            value={anchorToPivot}
+                            onChange={setAnchorToPivot}
+                            note="Use the clicked message as the newest entry"
+                            hideBorder
+                        >
+                            Anchor to selected message
+                        </Switch>
+                    )}
+
+                    {(!toNow || (pivotMessage && !anchorToPivot)) && (
+                        <>
+                            <Forms.FormText className="vc-transcript-field-label">To</Forms.FormText>
+                            <TextInput
+                                value={endValue}
+                                onChange={value => { setAnchorToPivot(false); setToNow(false); setEndInput(value); }}
+                                placeholder="2025-01-31 or now"
+                                editable={!anchorToPivot || !pivotMessage}
+                            />
+                        </>
+                    )}
+                </Forms.FormSection>
+
+                <Forms.FormDivider />
+
+                <Forms.FormSection>
+                    <Forms.FormTitle tag="h5">Filters</Forms.FormTitle>
+                    <Switch value={onlyPinned} onChange={setOnlyPinned} hideBorder>Only pinned messages</Switch>
+                    <Switch value={onlyWithMedia} onChange={setOnlyWithMedia} hideBorder>Only messages with attachments or embeds</Switch>
+                    <Switch value={includeBots} onChange={setIncludeBots} hideBorder>Include bot messages</Switch>
+                    <Switch value={includeSystem} onChange={setIncludeSystem} hideBorder>Include system and service messages</Switch>
+
+                    <Forms.FormText className="vc-transcript-field-label">Author filter (IDs, mentions, usernames)</Forms.FormText>
+                    <TextInput
+                        value={authorFilter}
+                        onChange={setAuthorFilter}
+                        placeholder="123456789012345678, <@987654321098765432>"
+                    />
+
+                    <Forms.FormText className="vc-transcript-field-label">Keyword filter (case insensitive)</Forms.FormText>
+                    <TextInput value={keyword} onChange={setKeyword} placeholder="error" />
+                </Forms.FormSection>
+
+                <Forms.FormDivider />
+
+                <Forms.FormSection>
+                    <Forms.FormTitle tag="h5">Included Details</Forms.FormTitle>
+                    <Switch value={includeAttachments} onChange={setIncludeAttachments} hideBorder>Include attachments</Switch>
+                    <Switch value={includeEmbeds} onChange={setIncludeEmbeds} hideBorder>Include embeds</Switch>
+                    <Switch value={includeReactions} onChange={setIncludeReactions} hideBorder>Include reactions</Switch>
+                    <Switch value={includeEdits} onChange={setIncludeEdits} hideBorder>Show edited timestamps</Switch>
+                    <Switch value={includeMentions} onChange={setIncludeMentions} hideBorder>Include mention metadata</Switch>
+                    <Switch value={includeReferenced} onChange={setIncludeReferenced} hideBorder>Include reply context</Switch>
+                    <Switch value={groupByDay} onChange={setGroupByDay} hideBorder>Group HTML exports by day</Switch>
+                    {pivotMessage && (
+                        <Switch value={includePivot} onChange={setIncludePivot} hideBorder>Include anchored message in export</Switch>
+                    )}
+                </Forms.FormSection>
+
+                {error && (
+                    <Forms.FormSection>
+                        <Forms.FormText style={{ color: "var(--status-danger-500)" }}>{error}</Forms.FormText>
+                    </Forms.FormSection>
+                )}
+
+                {progress && (
+                    <Forms.FormSection>
+                        <Forms.FormText>{progress}</Forms.FormText>
+                    </Forms.FormSection>
+                )}
+            </ModalContent>
+
+            <ModalFooter>
+                <Button
+                    color={Button.Colors.TRANSPARENT}
+                    onClick={modalProps.onClose}
+                    disabled={busy}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    color={Button.Colors.BRAND}
+                    onClick={handleGenerate}
+                    disabled={busy}
+                >
+                    {busy ? "Generating..." : "Generate Transcript"}
+                </Button>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}
+
+function openTranscriptModal(options?: { channelId?: string; message?: Message; }) {
+    openModal(modalProps => (
+        <TranscriptModal
+            modalProps={modalProps}
+            initialChannelId={options?.channelId}
+            pivotMessage={options?.message}
+        />
+    ));
+}
+
+export { openTranscriptModal };
+

--- a/src/plugins/chatTranscript/settings.ts
+++ b/src/plugins/chatTranscript/settings.ts
@@ -1,0 +1,73 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    defaultFormat: {
+        description: "Default export format when opening the transcript modal",
+        type: OptionType.SELECT,
+        options: [
+            { label: "HTML (.html)", value: "html", default: true },
+            { label: "Markdown (.md)", value: "markdown" },
+            { label: "JSON (.json)", value: "json" }
+        ]
+    },
+    defaultLimit: {
+        description: "Default maximum number of messages to fetch for a transcript",
+        type: OptionType.NUMBER,
+        default: 500
+    },
+    includeBots: {
+        description: "Include bot-authored messages by default",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    includeSystem: {
+        description: "Include system/service messages (pins, joins, boosts, etc.) by default",
+        type: OptionType.BOOLEAN,
+        default: false
+    },
+    includeAttachments: {
+        description: "Include attachment metadata in exports by default",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    includeEmbeds: {
+        description: "Include embed summaries in exports by default",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    includeReactions: {
+        description: "Include reactions in exports by default",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    includeEdits: {
+        description: "Include edited timestamps in exports by default",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    includeMentions: {
+        description: "Include mention metadata in exports by default",
+        type: OptionType.BOOLEAN,
+        default: false
+    },
+    includeReferenced: {
+        description: "Include reply context (referenced messages) by default",
+        type: OptionType.BOOLEAN,
+        default: true
+    },
+    groupByDay: {
+        description: "Group HTML transcripts by day separators by default",
+        type: OptionType.BOOLEAN,
+        default: true
+    }
+});
+
+export { settings };
+

--- a/src/plugins/chatTranscript/types.ts
+++ b/src/plugins/chatTranscript/types.ts
@@ -1,0 +1,77 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Channel, Message } from "@vencord/discord-types";
+
+type ExportFormat = "html" | "markdown" | "json";
+
+interface CollectMessagesOptions {
+    limit: number;
+    startTs: number | null;
+    endTs: number | null;
+    pivotId?: string;
+    fromStart?: boolean;
+    onProgress?: (count: number) => void;
+}
+
+interface FilterOptions {
+    startTs: number | null;
+    endTs: number | null;
+    includeBots: boolean;
+    includeSystem: boolean;
+    onlyPinned: boolean;
+    onlyWithMedia: boolean;
+    authorIds: Set<string> | null;
+    keyword: string;
+    includeAttachments: boolean;
+    includeEmbeds: boolean;
+}
+
+interface FormatOptions {
+    format: ExportFormat;
+    channel: Channel | undefined;
+    includeAttachments: boolean;
+    includeEmbeds: boolean;
+    includeReactions: boolean;
+    includeEdits: boolean;
+    includeMentions: boolean;
+    includeReferenced: boolean;
+    groupByDay: boolean;
+    fromStart: boolean;
+}
+
+interface TranscriptRequest {
+    channelId: string;
+    limit: number;
+    startTs: number | null;
+    endTs: number | null;
+    fromStart: boolean;
+    includeBots: boolean;
+    includeSystem: boolean;
+    onlyPinned: boolean;
+    onlyWithMedia: boolean;
+    authorIds: Set<string> | null;
+    keyword: string;
+    includeAttachments: boolean;
+    includeEmbeds: boolean;
+    includeReactions: boolean;
+    includeEdits: boolean;
+    includeMentions: boolean;
+    includeReferenced: boolean;
+    groupByDay: boolean;
+    format: ExportFormat;
+    pivotMessage?: Message;
+    includePivot: boolean;
+}
+
+export type {
+    CollectMessagesOptions,
+    ExportFormat,
+    FilterOptions,
+    FormatOptions,
+    TranscriptRequest
+};
+

--- a/src/plugins/chatTranscript/utils.ts
+++ b/src/plugins/chatTranscript/utils.ts
@@ -1,0 +1,232 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { ChannelStore, GuildStore, UserStore } from "@webpack/common";
+import { Channel, Message } from "@vencord/discord-types";
+
+import { RELATIVE_DATE_PATTERN, RELATIVE_UNITS, TEXT_BASED_CHANNEL_TYPES } from "./constants";
+
+function isTextBasedChannel(channel?: Channel | null): channel is Channel {
+    return !!channel && TEXT_BASED_CHANNEL_TYPES.has(channel.type as number);
+}
+
+function safeGetChannel(channelId?: string | null): Channel | undefined {
+    if (!channelId) return undefined;
+    try {
+        return ChannelStore.getChannel(channelId) as Channel;
+    } catch {
+        return undefined;
+    }
+}
+
+function safeGetUser(userId?: string | null) {
+    if (!userId) return undefined;
+    try {
+        return UserStore.getUser(userId);
+    } catch {
+        return undefined;
+    }
+}
+
+function getChannelDisplayName(channel?: Channel): string {
+    if (!channel) return "Unknown Channel";
+    const type = channel.type as number;
+
+    if (type === 1) {
+        const user = safeGetUser(channel.recipients?.[0]);
+        const name = user?.globalName ?? user?.username ?? channel.name ?? "Direct Message";
+        const suffix = user?.discriminator && user.discriminator !== "0" ? `#${user.discriminator}` : "";
+        return `Direct Message - ${name}${suffix}`;
+    }
+
+    if (type === 3) {
+        const explicitName = channel.name;
+        const participants = channel.recipients?.map(id => safeGetUser(id)?.username ?? "Unknown").join(", ");
+        return `Group DM - ${explicitName ?? participants ?? channel.id}`;
+    }
+
+    const guildName = channel.guild_id ? GuildStore.getGuild(channel.guild_id)?.name ?? "Unknown Guild" : "DM";
+    const channelName = channel.name ?? channel.id;
+    return `${guildName} - #${channelName}`;
+}
+
+function sanitizeFilename(value: string): string {
+    return value.replace(/[\\/:*?"<>|]/g, "_");
+}
+
+function formatFileSize(bytes?: number): string {
+    if (bytes == null || bytes < 0) return "";
+    const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let size = bytes;
+    let index = 0;
+    while (size >= 1024 && index < units.length - 1) {
+        size /= 1024;
+        index++;
+    }
+    const precision = index === 0 ? 0 : 2;
+    return `${size.toFixed(precision)} ${units[index]}`;
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function escapeAttribute(value: string): string {
+    return escapeHtml(value).replace(/`/g, "&#96;");
+}
+
+function messageHasMedia(message: Message): boolean {
+    return Boolean(message.attachments?.length || message.embeds?.length || message.sticker_items?.length);
+}
+
+function messageMatchesKeyword(message: Message, keyword: string, includeAttachments: boolean, includeEmbeds: boolean): boolean {
+    if (!keyword) return true;
+    const lower = keyword.toLowerCase();
+
+    if (message.content?.toLowerCase().includes(lower)) return true;
+
+    if (includeAttachments && message.attachments) {
+        for (const attachment of message.attachments) {
+            if (
+                attachment.filename?.toLowerCase().includes(lower) ||
+                attachment.url?.toLowerCase().includes(lower)
+            ) {
+                return true;
+            }
+        }
+    }
+
+    if (includeEmbeds && message.embeds) {
+        for (const embed of message.embeds) {
+            if (
+                embed.title?.toLowerCase().includes(lower) ||
+                embed.description?.toLowerCase().includes(lower) ||
+                embed.footer?.text?.toLowerCase().includes(lower) ||
+                embed.author?.name?.toLowerCase().includes(lower)
+            ) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+function parseDateInput(raw: string): number | null {
+    const value = raw.trim();
+    if (!value.length) return null;
+    if (value.toLowerCase() === "now") return Date.now();
+
+    const relative = value.match(RELATIVE_DATE_PATTERN);
+    if (relative) {
+        const [, sign, amountRaw, unitRaw] = relative;
+        const unit = RELATIVE_UNITS[unitRaw.toLowerCase()];
+        if (unit) {
+            const amount = parseInt(amountRaw, 10);
+            if (!Number.isNaN(amount)) {
+                const offset = amount * unit * (sign === "-" ? -1 : 1);
+                return Date.now() + offset;
+            }
+        }
+    }
+
+    const absolute = Date.parse(value);
+    return Number.isNaN(absolute) ? null : absolute;
+}
+
+function extractAuthorIds(raw: string): Set<string> | null {
+    const tokens = raw
+        .split(/[\s,]+/)
+        .map(t => t.trim())
+        .filter(Boolean);
+
+    if (!tokens.length) return null;
+
+    const ids = new Set<string>();
+    const users = UserStore.getUsers?.();
+
+    for (const token of tokens) {
+        const mentionMatch = token.match(/^<@!?(\d{16,22})>$/);
+        if (mentionMatch) {
+            ids.add(mentionMatch[1]);
+            continue;
+        }
+
+        if (/^\d{16,22}$/.test(token)) {
+            ids.add(token);
+            continue;
+        }
+
+        if (token.includes("#")) {
+            const [username, discrim] = token.split("#");
+            if (username && discrim) {
+                try {
+                    const user = UserStore.findByTag(username, discrim);
+                    if (user) {
+                        ids.add(user.id);
+                        continue;
+                    }
+                } catch {
+                    // ignore missing user
+                }
+            }
+        }
+
+        if (users) {
+            const lower = token.toLowerCase();
+            for (const user of Object.values(users)) {
+                if (user.username?.toLowerCase() === lower || user.globalName?.toLowerCase() === lower) {
+                    ids.add(user.id);
+                    break;
+                }
+            }
+        }
+    }
+
+    return ids.size ? ids : null;
+}
+
+function getMessageDisplayName(message: Message): string {
+    return (
+        message.member?.nick ??
+        message.author?.global_name ??
+        message.author?.username ??
+        message.author?.id ??
+        "Unknown User"
+    );
+}
+
+function buildAvatarUrl(message: Message, size = 64): string {
+    const user = message.author;
+    if (!user) return "";
+    const base = user.avatar
+        ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.${user.avatar.startsWith("a_") ? "gif" : "png"}`
+        : `https://cdn.discordapp.com/embed/avatars/${Number(user.discriminator ?? 0) % 5}.png`;
+    return `${base}?size=${size}`;
+}
+
+export {
+    buildAvatarUrl,
+    escapeAttribute,
+    escapeHtml,
+    extractAuthorIds,
+    formatFileSize,
+    getChannelDisplayName,
+    getMessageDisplayName,
+    isTextBasedChannel,
+    messageHasMedia,
+    messageMatchesKeyword,
+    parseDateInput,
+    safeGetChannel,
+    safeGetUser,
+    sanitizeFilename
+};
+


### PR DESCRIPTION
- add new Transcript plugin to export HTML, Markdown, or JSON transcripts from any text channel, thread, DM, or group DM
- render exports with Discord-like UI (avatars, nicknames, embeds, playable media) and an inline context menu for copying IDs or message links
- provide configurable time ranges (from first message, up to now, ISO/relative inputs) plus filters for bots, pinned messages, media-only, authors, and keywords