### PR TITLE
fix reporter on canary

### DIFF
--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -174,14 +174,13 @@ export async function loadLazyChunks() {
         const chunkMap = getWebpackChunkMap();
         if (!chunkMap) throw new Error("Failed to get chunk map");
 
-        const allChunks = Object.keys(chunkMap);
+        const allChunks = Object.keys(chunkMap).map(id => Number.isNaN(Number(id)) ? id : Number(id));
         if (allChunks.length === 0) throw new Error("Failed to get all chunks");
 
         // Chunks which our regex could not catch to load
         // It will always contain WebWorker assets, and also currently contains some language packs which are loaded differently
         const chunksLeft = allChunks.filter(id => {
-            const key = Number.isNaN(Number(id)) ? id : Number(id);
-            return !(validChunks.has(key) || invalidChunks.has(key));
+            return !(validChunks.has(id) || invalidChunks.has(id));
         });
 
         await Promise.all(chunksLeft.map(async id => {

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -180,7 +180,8 @@ export async function loadLazyChunks() {
         // Chunks which our regex could not catch to load
         // It will always contain WebWorker assets, and also currently contains some language packs which are loaded differently
         const chunksLeft = allChunks.filter(id => {
-            return !(validChunks.has(id) || invalidChunks.has(id));
+            const key = Number.isNaN(Number(id)) ? id : Number(id);
+            return !(validChunks.has(key) || invalidChunks.has(key));
         });
 
         await Promise.all(chunksLeft.map(async id => {

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -11,6 +11,24 @@ import * as Webpack from "@webpack";
 import { wreq } from "@webpack";
 import { AnyModuleFactory } from "webpack";
 
+function getWebpackChunkMap() {
+    const sym = Symbol();
+    let v: Record<PropertyKey, string> | null = null;
+
+    Object.defineProperty(Object.prototype, sym, {
+        get() {
+            v = this;
+            return "";
+        },
+        configurable: true
+    });
+
+    wreq.u(sym);
+    delete Object.prototype[sym];
+
+    return v;
+}
+
 export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");
 
@@ -153,17 +171,10 @@ export async function loadLazyChunks() {
         }
 
         // All chunks Discord has mapped to asset files, even if they are not used anymore
-        const allChunks = [] as PropertyKey[];
+        const chunkMap = getWebpackChunkMap();
+        if (!chunkMap) throw new Error("Failed to get chunk map");
 
-        // Matches "id" or id:
-        for (const currentMatch of String(wreq.u).matchAll(/(?:"([\deE]+?)"(?![,}]))|(?:([\deE]+?):)/g)) {
-            const id = currentMatch[1] ?? currentMatch[2];
-            if (id == null) continue;
-
-            const numId = Number(id);
-            allChunks.push(Number.isNaN(numId) ? id : numId);
-        }
-
+        const allChunks = Object.keys(chunkMap);
         if (allChunks.length === 0) throw new Error("Failed to get all chunks");
 
         // Chunks which our regex could not catch to load


### PR DESCRIPTION
The old code stringifies wreq.u to get the export map

But it now is a wrapper function so it doesn't include the object inline anymore

<img width="947" height="666" alt="image" src="https://github.com/user-attachments/assets/c0ebed26-e12f-4054-9052-eff3131db4f4" />

Simple solution is to just use a getter on the `Object.prototype` for a unique symbol, then call the method with that symbol to get the object it's using. Compatible with both the new and old code