### PR TITLE
TypingTweaks: make the username clickable

### DIFF
--- a/src/plugins/typingTweaks/style.css
+++ b/src/plugins/typingTweaks/style.css
@@ -1,5 +1,9 @@
-.vc-typing-user [class^="wrapper"] {
-    display: inline-block;
-    margin-right: 0.25em;
-    vertical-align: -4px;
+.vc-typing-user {
+    cursor: pointer;
+    [class^="wrapper"] {
+        display: inline-block;
+        margin-right: 0.25em;
+        vertical-align: -4px;
+    }
 }
+


### PR DESCRIPTION
clicking the user opens their profile modal, but the cursor doesn't change to reflect the fact that it's clickable