### PR TITLE
Add CleanCord plugin

### DIFF
--- a/src/plugins/cleanCord/README.md
+++ b/src/plugins/cleanCord/README.md
@@ -1,0 +1,26 @@
+# CleanCord
+
+**CleanCord** is a Vencord plugin that allows you to hide Discord’s animated decorations, role clutter, and flashy effects for a cleaner, more minimal experience.
+
+### Settings
+
+-   **Hide Nitro Nameplate Background** – Toggle hiding of Nitro nameplate gradient background.
+-   **Hide Nitro Nameplate Video** – Toggle hiding of Nitro nameplate video.
+-   **Hide Avatar Decorations (img)** – Toggle hiding of image-based avatar decorations.
+-   **Hide Avatar Decorations (svg)** – Toggle hiding of SVG-based avatar decorations.
+-   **Hide Profile Effects** – Toggle hiding of profile effects.
+-   **Hide Booster Icon** – Toggle hiding of the Nitro booster icon.
+-   **Hide Server Tag** – Toggle hiding of server tag chiplets (clan tags).
+-   **Hide Role Icons** – Toggle hiding of role icons in chat and member list.
+-   **Hide Super Reactions** – Toggle hiding of Discord’s Super Reactions (emoji + glow).
+-   **Hide Super Reactions Burst Effect** – Toggle hiding of the large burst glow animation effect.
+
+### License
+
+This plugin is licensed under **GPL-3.0-or-later**.
+
+---
+
+Report to `@minato4743 | discord` if the plugin hides something it’s not supposed to.
+
+Enjoy a cleaner Discord experience with **CleanCord**!

--- a/src/plugins/cleanCord/index.tsx
+++ b/src/plugins/cleanCord/index.tsx
@@ -1,0 +1,131 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+// Define plugin settings
+const settings = definePluginSettings({
+    hideNameplateBackground: {
+        type: OptionType.BOOLEAN,
+        description: "Hide Discord Nitro nameplate background gradient",
+        default: true,
+        restartNeeded: true
+    },
+    hideNameplateVideo: {
+        type: OptionType.BOOLEAN,
+        description: "Hide Discord Nitro nameplate video",
+        default: true,
+        restartNeeded: true
+    },
+    hideImgAvatarDecor: {
+        type: OptionType.BOOLEAN,
+        description: "Hide avatar decorations (img)",
+        default: true,
+        restartNeeded: true
+    },
+    hideSvgAvatarDecor: {
+        type: OptionType.BOOLEAN,
+        description: "Hide avatar decorations (svg)",
+        default: true,
+        restartNeeded: true
+    },
+    hideProfileEffects: {
+        type: OptionType.BOOLEAN,
+        description: "Hide profile effects",
+        default: true,
+        restartNeeded: true
+    },
+    hideBoosterIcon: {
+        type: OptionType.BOOLEAN,
+        description: "Hide boosters icon svg",
+        default: false,
+        restartNeeded: true
+    },
+    hideServerTag: {
+        type: OptionType.BOOLEAN,
+        description: "Hide server tag chiplets (clan tags)",
+        default: false,
+        restartNeeded: true
+    },
+    hideRoleIcons: {
+        type: OptionType.BOOLEAN,
+        description: "Hide role icons in chat/members list",
+        default: false,
+        restartNeeded: true
+    },
+    hideSuperReactions: {
+        type: OptionType.BOOLEAN,
+        description: "Hide Discord's Super Reactions",
+        default: false,
+        restartNeeded: true
+    },
+    hideBurstEffect: {
+        type: OptionType.BOOLEAN,
+        description: "Hide Discord's Super Reactions Burst Effect",
+        default: false,
+        restartNeeded: true
+    }
+});
+
+export default definePlugin({
+    name: "CleanCord",
+    description: "Hide Discord's visual clutter like nameplates, decorations, tags, role icons, and super reactions. Fully configurable in settings!",
+    authors: [Devs.Minato],
+    settings,
+
+    start() {
+        const selectors: string[] = [];
+
+        // Nameplate background
+        if (settings.store.hideNameplateBackground)
+            selectors.push('div[class^="container__"][style*="background: linear-gradient"]');
+
+        // Nameplate video
+        if (settings.store.hideNameplateVideo)
+            selectors.push('div[class^="container__"] video[class^="img__"]');
+
+        // Other decorations
+        if (settings.store.hideImgAvatarDecor)
+            selectors.push('img[class^="avatarDecoration_"]');
+        if (settings.store.hideSvgAvatarDecor)
+            selectors.push('svg[class^="avatarDecoration__"]');
+        if (settings.store.hideProfileEffects)
+            selectors.push('div[class^="profileEffects__"]');
+        if (settings.store.hideBoosterIcon)
+            selectors.push('svg[class^="premiumIcon__"]');
+
+        // Server Tag chiplets
+        if (settings.store.hideServerTag)
+            selectors.push('span[class^="chipletContainerInner__"][aria-label^="Server Tag:"]');
+
+        // Role icons
+        if (settings.store.hideRoleIcons)
+            selectors.push('img[class^="roleIcon__"][aria-label^="Role icon"]');
+
+        // Super Reactions
+        if (settings.store.hideSuperReactions) {
+            selectors.push('div[class^="reactionInner__"][aria-label*="super reactions"]');
+            selectors.push('div[class^="reactionInner__"][aria-label*="super reactions"] .burstGlow__');
+        }
+
+        // Super Reactions burst effect
+        if (settings.store.hideBurstEffect) {
+            selectors.push('div[class^="effectsWrapper_"]');
+        }
+
+        if (selectors.length === 0) return;
+
+        this.style = document.createElement("style");
+        this.style.textContent = `${selectors.join(", ")} { display: none !important; }`;
+        document.head.appendChild(this.style);
+    },
+
+    stop() {
+        if (this.style) this.style.remove();
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -606,6 +606,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "thororen",
         id: 848339671629299742n
     },
+    Minato: {
+        name: "Minato",
+        id: 704346785811923016n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Adds CleanCord, a Vencord plugin that cleans up Discord’s UI by hiding all the flashy stuff you might not care about.

With this plugin, you can:

- Hide Nitro nameplates
- Hide avatar decorations
- Hide profile effects
- Hide booster icons
- Hide server tags
- Hide role icons
- Hide Super Reactions and their burst effects

Everything is toggleable in the settings, so you can hide as much or as little as you like.