### PR TITLE
feat(plugin): add chatPopouts plugin

### DIFF
--- a/src/plugins/chatPopouts/README.md
+++ b/src/plugins/chatPopouts/README.md
@@ -1,0 +1,19 @@
+# ChatPopouts
+
+Pop out any channel/DM/thread into its own window. Preserves your Discord session (no re-login) and hides sidebars in the pop-out for a focused chat view.
+
+## Features
+
+* Toolbar button in the channel header: **Open in pop-out**
+* Context-menu entry on channels/DMs/threads: **Pop out chat**
+* Pop-outs reuse the main window’s session (no auth prompts).
+* Auto-hide guild/member sidebars in the pop-out.
+
+## Usage
+
+* **Toolbar button**: Click the external-arrow icon in the channel header.
+* **Right-click** a channel/DM/thread → **Pop out chat**.
+
+## License
+
+GPL-3.0-or-later.

--- a/src/plugins/chatPopouts/index.tsx
+++ b/src/plugins/chatPopouts/index.tsx
@@ -1,0 +1,287 @@
+/*
+ * Vencord, a Discord client mod
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import definePlugin, { PluginNative } from "@utils/types";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { Menu } from "@webpack/common";
+import { OpenExternalIcon } from "@components/Icons";
+
+// Bound native pop‑out helper.  When the plugin starts, we store a function
+// here that calls the native helper with the correct plugin context.  The
+// context menu callbacks can then call this function directly to ensure
+// the session is preserved.  When the plugin stops, this is cleared.
+let openPopoutFunc: ((url: string) => Promise<void>) | undefined;
+
+/*
+ * ChatPopouts
+ *
+ * This plugin adds a small icon to the right-hand toolbar of every text channel or
+ * direct message. Clicking the icon opens the current conversation in a separate
+ * Electron `BrowserWindow`. The pop‑out window loads the same URL as the
+ * original Discord instance and then injects a little bit of CSS to hide the
+ * server and channel sidebars so the chat can make use of the full width of the
+ * window.  The pop‑out behaves much like the chat pop‑out in Microsoft Teams
+ * and allows you to keep multiple chats open side‑by‑side.
+ */
+
+// Factory for creating context menu patches.  We define this helper
+// outside of the plugin object so that the patch functions are available
+// during plugin registration (before `start()` runs).  Each generated patch
+// computes a URL for the clicked channel and invokes the native helper to
+// open a new window.  It also decides where within the existing menu
+// groups to insert the new item based on the context menu identifier.
+const createContextMenuPatch = (navId: string): NavContextMenuPatchCallback => {
+    return (children, props) => {
+        const { channel } = props || {};
+        if (!channel) return;
+        // Use the current origin rather than hard‑coding discord.com.  Discord
+        // desktop can run on different subdomains (e.g. canary.discord.com,
+        // ptb.discord.com) depending on the release channel.  Constructing
+        // the URL from location.origin ensures we open a pop‑out on the same
+        // domain and therefore preserve cookies and auth tokens.  Without
+        // this, the new window may prompt for login when using the context
+        // menu despite being authenticated in the main window.
+        const guildId = (channel.guild_id ?? "@me") as string;
+        const origin = window.location.origin;
+        const url = `${origin}/channels/${guildId}/${channel.id}`;
+        const item = (
+            <Menu.MenuItem
+                id="vc-chatpopouts-open"
+                label="Pop out chat"
+                icon={OpenExternalIcon}
+                action={() => {
+                    // Use the bound pop‑out helper if available.  This function is
+                    // assigned in the plugin's start() method and ensures that
+                    // the native helper receives the plugin context correctly.
+                    if (openPopoutFunc) {
+                        openPopoutFunc(url).catch(() => void 0);
+                    }
+                }}
+            />
+        );
+        switch (navId) {
+            case "channel-context":
+            case "thread-context": {
+                const container = findGroupChildrenByChildId("mark-channel-read", children) ?? children;
+                container.push(item);
+                break;
+            }
+            case "gdm-context": {
+                const container = findGroupChildrenByChildId("leave-channel", children) ?? children;
+                container.unshift(item);
+                break;
+            }
+            case "user-context": {
+                const container = findGroupChildrenByChildId("close-dm", children);
+                if (container) {
+                    const idx = container.findIndex(c => c?.props?.id === "close-dm");
+                    if (idx !== -1) {
+                        container.splice(idx, 0, item);
+                    } else {
+                        container.push(item);
+                    }
+                } else {
+                    children.push(item);
+                }
+                break;
+            }
+            default:
+                children.push(item);
+                break;
+        }
+    };
+};
+
+export default definePlugin({
+    name: "ChatPopouts",
+    description: "Pop out channels and DMs into their own window",
+    authors: [
+        {
+            name: "oakytreejr",
+            id: 236691195718402048n,
+        },
+    ],
+    tags: ["desktop", "chat", "dms", "text"],
+
+    /**
+     * Context menu patches.  Each key corresponds to a particular context
+     * menu within Discord.  When the user right‑clicks on a channel in the
+     * server list, a DM in the friends list, or a thread, we insert a
+     * "Pop out chat" entry which opens the selected conversation in a new
+     * window. 
+     */
+    contextMenus: {
+        "channel-context": createContextMenuPatch("channel-context"),
+        "thread-context": createContextMenuPatch("thread-context"),
+        "gdm-context": createContextMenuPatch("gdm-context"),
+        "user-context": createContextMenuPatch("user-context"),
+    },
+
+    /**
+     * Reference to our MutationObserver so that it can be disconnected on stop.
+     */
+    _observer: null as MutationObserver | null,
+
+    /**
+     * Reference to the currently injected button so that it can be removed on stop.
+     */
+    _button: null as HTMLElement | null,
+
+    /**
+     * Called when the plugin is enabled. Sets up a MutationObserver to watch for
+     * toolbar changes and injects the pop‑out button into the current channel
+     * toolbar.
+     */
+    start() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (typeof (window as any).VencordNative === "undefined") {
+            return;
+        }
+
+        // Create a MutationObserver to watch for toolbar creation/destruction.
+        this._observer = new MutationObserver(() => {
+            this.injectButton();
+        });
+        this._observer.observe(document.body, { childList: true, subtree: true });
+        // Immediately attempt to inject the button on start.
+        this.injectButton();
+
+        // Bind the native helper to preserve the plugin context.  This allows
+        // context menu actions to call the native function without losing
+        // authentication.  The bound function is stored in a module‑level
+        // variable so that context menu patches defined outside of the plugin
+        // can access it.
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const nativeHelpers: any = (window as any).VencordNative?.pluginHelpers;
+            if (nativeHelpers) {
+                const Native = nativeHelpers.ChatPopouts as PluginNative<typeof import("./native")>;
+                if (Native && typeof Native.openPopout === "function") {
+                    // Bind a helper that resolves the native module and calls
+                    // openPopout each time it is invoked.  This avoids
+                    // capturing a stale reference to `Native`, which can be
+                    // invalidated when Discord reloads part of the UI.  It
+                    // also ensures the plugin context is correctly passed
+                    // through to the native function.  See `openPopoutWindow`
+                    // for a similar implementation.
+                    openPopoutFunc = async (url: string) => {
+                        try {
+                            // Resolve the native helper fresh from VencordNative
+                            const nativeHelpers: any = (window as any).VencordNative?.pluginHelpers;
+                            if (!nativeHelpers) return;
+                            const NativeNow = nativeHelpers.ChatPopouts as PluginNative<typeof import("./native")>;
+                            if (NativeNow && typeof NativeNow.openPopout === "function") {
+                                await NativeNow.openPopout(url);
+                            }
+                        } catch {
+                            // Ignore errors; context menu will simply do nothing
+                        }
+                    };
+                }
+            }
+        } catch {
+            // Ignore if binding fails; context menu will simply do nothing
+        }
+    },
+
+    /**
+     * Called when the plugin is disabled. Cleans up any injected buttons and
+     * disconnects the MutationObserver.
+     */
+    stop() {
+        if (this._observer) {
+            this._observer.disconnect();
+            this._observer = null;
+        }
+        if (this._button) {
+            this._button.remove();
+            this._button = null;
+        }
+
+        // Clear the bound helper when the plugin stops.
+        openPopoutFunc = undefined;
+    },
+
+    /**
+     * Attempts to find the channel toolbar and inject the pop‑out button.  If
+     * the toolbar is not found or the button is already present, this method
+     * simply returns without doing anything.
+     */
+    injectButton() {
+        // If a button already exists, do not add another one.
+        if (this._button && document.contains(this._button)) return;
+        // Attempt to find the toolbar.  Discord often changes class names; this
+        // selector matches the standard channel header toolbar used at the top
+        // right of the chat area.  We fall back to a more permissive selector
+        // that looks for any div with a class containing "toolbar".
+        const toolbar =
+            document.querySelector<HTMLElement>(
+                ".toolbar-1t6TWx, .container-1CH86i .toolbar-1t6TWx, .container-1CH86i .toolbar"
+            ) || document.querySelector<HTMLElement>('[class*="toolbar"]');
+        if (!toolbar) return;
+        // Avoid adding multiple pop‑out buttons in the same toolbar.
+        if (toolbar.querySelector(".ChatPopoutButton")) return;
+
+        // Create the button container.  Use the same classes as other toolbar
+        // buttons to ensure consistent styling.
+        const btn = document.createElement("div");
+        btn.className = "iconWrapper-2OrFZ1 clickable-3rdHwn ChatPopoutButton";
+        btn.setAttribute("role", "button");
+        btn.setAttribute("aria-label", "Pop out chat");
+        btn.style.display = "flex";
+        btn.style.alignItems = "center";
+        btn.style.justifyContent = "center";
+        btn.style.cursor = "pointer";
+
+        btn.innerHTML = `
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15 2a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v6a1 1 0 1 1-2 0V4.41l-4.3 4.3a1 1 0 1 1-1.4-1.42L19.58 3H16a1 1 0 0 1-1-1Z" />
+                <path d="M5 2a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-6a1 1 0 1 0-2 0v6a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h6a1 1 0 1 0 0-2H5Z" />
+            </svg>
+        `;
+        // Attach the click handler.
+        btn.addEventListener("click", () => {
+            this.openPopoutWindow();
+        });
+        // Insert the button at the start of the toolbar so it appears on the left
+        // of existing icons.  Prepend is supported in modern browsers.
+        toolbar.prepend(btn);
+        this._button = btn;
+    },
+
+    /**
+     * Opens the current Discord conversation in a new window via the native
+     * helper. The heavy lifting (interacting with Electron) lives in
+     * `native.ts`.  If the native helper is unavailable, nothing happens.
+     */
+    async openPopoutWindow() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const nativeHelpers: any = (window as any).VencordNative?.pluginHelpers;
+        if (!nativeHelpers) return;
+        // Acquire the native helper for this plugin.  The key must match the
+        // `name` property passed to definePlugin below.  Cast via PluginNative
+        // so TypeScript can infer the exported functions.
+        const Native = nativeHelpers.ChatPopouts as PluginNative<typeof import("./native")>;
+        if (!Native || typeof Native.openPopout !== "function") return;
+        const url = window.location.href;
+        try {
+            await Native.openPopout(url);
+        } catch (err) {
+            console.error("ChatPopouts: failed to open pop‑out", err);
+        }
+    },
+});

--- a/src/plugins/chatPopouts/native.ts
+++ b/src/plugins/chatPopouts/native.ts
@@ -1,0 +1,125 @@
+/*
+ * Vencord, a Discord client mod
+ *
+ */
+
+import { BrowserWindow, app } from "electron";
+import { join } from "path";
+
+/**
+ * Opens a new BrowserWindow displaying the same URL as the current Discord
+ * instance and hides the sidebars to maximise the chat area.  This function
+ * must be executed from the main process via the native helper bridge.
+ *
+ * @param _ctx Plugin context (unused)
+ * @param url The URL of the conversation to open
+ */
+export async function openPopout(_ctx: unknown, url: string): Promise<void> {
+    try {
+        // Compute the preload script path used by Discord.  This replicates
+        // Discord's own logic and ensures that the new window has the same
+        // context isolation and preload behaviour as the main window.
+        const appPath = app.getAppPath();
+        let preloadPath: string | undefined;
+        try {
+            // Dynamically require because node resolution may differ between
+            // environments.  common/paths exports a getModulePath() function.
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const commonPaths = require(join(appPath, "common/paths"));
+            const modulePath: string = commonPaths.getModulePath();
+            preloadPath = join(
+                modulePath,
+                "discord_desktop_core",
+                "core.asar",
+                "app",
+                "mainScreenPreload.js",
+            );
+        } catch {
+            // Fallback to the DISCORD_PRELOAD env var if present.
+            preloadPath = process.env.DISCORD_PRELOAD;
+        }
+        // Attempt to reuse the same session as the main Discord window.  This
+        // prevents Discord from asking to log in again or from detecting that
+        // you're opening a link in a browser rather than the desktop app.
+        let parentSession;
+        try {
+            const allWins = BrowserWindow.getAllWindows();
+            const parentWin = allWins.find(w => !w.isDestroyed());
+            // Use optional chaining in case the webContents or session are undefined.
+            parentSession = parentWin?.webContents?.session;
+        } catch {
+            parentSession = undefined;
+        }
+        // Create the new window.  Use a standard size and show a frame.  Use the
+        // same session as the main window if available.  Disable the sandbox to
+        // allow context isolation; this is required for Electron >= 21.
+        const win = new BrowserWindow({
+            width: 800,
+            height: 600,
+            title: "Discord",
+            frame: true,
+            webPreferences: {
+                preload: preloadPath,
+                session: parentSession,
+                sandbox: false,
+            },
+        });
+        // Remove the menu bar for a cleaner look.
+        if (typeof win.setMenu === "function") {
+            win.setMenu(null);
+        }
+        /*
+         * CSS/JS injection script to hide Discord's sidebars in the pop‑out
+         * window. Discord uses hashed class names that change frequently,
+         * which makes targeting specific elements brittle. Instead of hard‑
+         * coding the entire class name, we rely on stable selectors such as
+         * `aria-label` attributes and substring matches (e.g. `[class*="sidebar"]`).
+         * The script wraps the style injection in a function that waits for
+         * the DOM to be ready before adding the style element.  We reuse an
+         * existing `<style>` element if one is already present to avoid
+         * injecting duplicates when the user navigates between channels.
+         */
+        const injectCSS =
+            '(() => {' +
+            'const applyStyles = () => {' +
+            '  let style = document.getElementById("chat-popout-style");' +
+            '  if (!style) {' +
+            '    style = document.createElement("style");' +
+            '    style.id = "chat-popout-style";' +
+            '    document.head.appendChild(style);' +
+            '  }' +
+            '  style.innerHTML = ' +
+            '    "nav[aria-label*=\\"Servers\\"], nav[class*=\\"guilds\\"] { display: none !important; }" + ' +
+            '    "div[class*=\\"sidebar\\"], div[class*=\\"sidebarRegion\\"], div[class*=\\"membersWrap\\"] { display: none !important; }" + ' +
+            '    "div[class*=\\"base\\"] { left: 0 !important; }" + ' +
+            '    "div[class*=\\"content\\"], main[class*=\\"chatContent\\"], div[class*=\\"chatContent\\"] { margin-left: 0 !important; }";' +
+            '};' +
+            'if (document.readyState === "complete" || document.readyState === "interactive") {' +
+            '  applyStyles();' +
+            '} else {' +
+            '  document.addEventListener("DOMContentLoaded", applyStyles);' +
+            '}' +
+            '})()';
+
+        // Inject our styles when the DOM is ready for the first time and on
+        // subsequent in‑page navigations within Discord.  `dom-ready` fires
+        // when the document's DOM is fully parsed, while `did-navigate-in-page`
+        // fires when the URL changes without a full page load (e.g. when
+        // Discord navigates between channels).  We also listen for
+        // `did-finish-load` as a fallback on initial load.
+        const handleInject = () => {
+            win.webContents.executeJavaScript(injectCSS).catch(() => void 0);
+        };
+        win.webContents.on('dom-ready', handleInject);
+        win.webContents.on('did-navigate-in-page', handleInject);
+        win.webContents.on('did-finish-load', handleInject);
+
+        // Load the requested URL in the new window.  This preserves the channel
+        // or DM that the user is viewing.
+        await win.loadURL(url);
+    } catch (err) {
+        // Log any errors to the console for debugging.  Errors are swallowed
+        // because the browser context handles reporting to the user.
+        console.error("ChatPopouts native error:", err);
+    }
+}


### PR DESCRIPTION
Hello! I am submitting a PR to add my chatPopouts plugin. It's a simple plugin that allows users to pop out text chats (dm, thread, channel, etc) into its own window for seamless communication between multiple chat windows concurrently. This is inspired by how Microsoft Teams handle's its chat pop out feature.

There are no configurations, simply enable and it adds a button to the top bar of every text chat, and a context menu item to pop out any text chat!

Inspired by my friend who was frustrated with having to open a Discord browser session when he wanted to have multiple chats open at the same time. I think many people will find this plugin helpful!