### PR TITLE
fix(FixYoutubeEmbed): Fix Error 15 in Youtube Embeds

### DIFF
--- a/src/plugins/fixYoutubeEmbeds.desktop/index.ts
+++ b/src/plugins/fixYoutubeEmbeds.desktop/index.ts
@@ -10,5 +10,5 @@ import definePlugin from "@utils/types";
 export default definePlugin({
     name: "FixYoutubeEmbeds",
     description: "Bypasses youtube videos being blocked from display on Discord (for example by UMG)",
-    authors: [Devs.coolelectronics]
+    authors: [Devs.coolelectronics, Devs.cutestbunny],
 });

--- a/src/plugins/fixYoutubeEmbeds.desktop/index.ts
+++ b/src/plugins/fixYoutubeEmbeds.desktop/index.ts
@@ -11,5 +11,5 @@ export default definePlugin({
     name: "FixYoutubeEmbeds",
     description: "Bypasses youtube videos being blocked from display on Discord (for example by UMG)",
     tags: ["Media", "Utility"],
-    authors: [Devs.coolelectronics]
+    authors: [Devs.coolelectronics, Devs.cutestbunny],
 });

--- a/src/plugins/fixYoutubeEmbeds.desktop/native.ts
+++ b/src/plugins/fixYoutubeEmbeds.desktop/native.ts
@@ -4,24 +4,66 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { RendererSettings } from "@main/settings";
-import { app } from "electron";
+import { NativeSettings, RendererSettings } from "@main/settings";
+import { app, BrowserWindow, WebFrameMain } from "electron";
 
-app.on("browser-window-created", (_, win) => {
-    win.webContents.on("frame-created", (_, { frame }) => {
+app.on("browser-window-created", (_, window) => {
+    window.webContents.on("frame-created", (_, { frame: frame }) => {
+        if (!RendererSettings.store.plugins?.FixYoutubeEmbeds?.enabled) return;
+
+        ensureCSPRulesExist();
+        modifyIframeSrcAttributes(window);
         frame?.once("dom-ready", () => {
-            if (frame.url.startsWith("https://www.youtube.com/")) {
-                const settings = RendererSettings.store.plugins?.FixYoutubeEmbeds;
-                if (!settings?.enabled) return;
-
-                frame.executeJavaScript(`
-                new MutationObserver(() => {
-                    if(
-                        document.querySelector('div.ytp-error-content-wrap-subreason a[href*="www.youtube.com/watch?v="]')
-                    ) location.reload()
-                }).observe(document.body, { childList: true, subtree:true });
-                `);
-            }
+            reloadFrameOnError(frame);
         });
     });
 });
+
+function ensureCSPRulesExist() {
+    const yt_domain = new URL("https://*.youtube-nocookie.com/").hostname;
+    const required_csp_directives = ["frame-src"];
+
+    const current_rules = NativeSettings.store.customCspRules[yt_domain];
+
+    if (!required_csp_directives.every(directive => current_rules.includes(directive))) {
+        const new_unique_rules = new Set(...current_rules, ...required_csp_directives);
+        NativeSettings.store.customCspRules[yt_domain] = [...new_unique_rules];
+    }
+}
+
+function modifyIframeSrcAttributes(window: BrowserWindow) {
+
+    const youtubeVideoIdPattern: RegExp = /(?:youtube(?:-nocookie)?\.com\/(?:[^/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
+    window.webContents.executeJavaScript(`
+        new MutationObserver(() => {
+            document.querySelectorAll('iframe').forEach(iframe => {
+                if (iframe.src && iframe.src.startsWith("https://www.youtube.com/")) {
+                    const pattern_match = iframe.src.match(${youtubeVideoIdPattern});
+                    if (pattern_match && pattern_match.length >= 2) {
+                        const video_id = pattern_match[1];
+                        const params = new URL(iframe.src).search;
+                        iframe.src = "https://www.youtube-nocookie.com/embed/" + video_id + params;
+                    }
+                }
+            });
+        }).observe(document.body, { childList: true, subtree:true });
+    `);
+}
+
+function reloadFrameOnError(frame: WebFrameMain) {
+    if (frame.url.startsWith("https://www.youtube.com/") || frame.url.startsWith("https://www.youtube-nocookie.com/")) {
+        frame.executeJavaScript(`
+            new MutationObserver(() => {
+                if (document.querySelector('div.ytp-error-content-wrap-subreason a[href*="www.youtube.com/watch?v="]')) {
+                    // Reload if we see the UMG style block
+                    location.reload();
+                }
+                if (document.querySelector('div.ytp-error-content-wrap-reason span')) {
+                    // Attempt to reload if we see a generic error (may solve "please sign in" error but usually does not)
+                    location.reload();
+                }
+            }).observe(document.body, { childList: true, subtree: true });
+        `);
+    }
+}

--- a/src/plugins/youtubeAdblock.desktop/index.ts
+++ b/src/plugins/youtubeAdblock.desktop/index.ts
@@ -11,5 +11,5 @@ import definePlugin from "@utils/types";
 export default definePlugin({
     name: "YoutubeAdblock",
     description: "Block ads in YouTube embeds and the WatchTogether activity via AdGuard",
-    authors: [Devs.ImLvna, Devs.Ven],
+    authors: [Devs.ImLvna, Devs.Ven, Devs.cutestbunny],
 });

--- a/src/plugins/youtubeAdblock.desktop/native.ts
+++ b/src/plugins/youtubeAdblock.desktop/native.ts
@@ -13,10 +13,13 @@ app.on("browser-window-created", (_, win) => {
         frame?.once("dom-ready", () => {
             if (!RendererSettings.store.plugins?.YoutubeAdblock?.enabled) return;
 
-            if (frame.url.includes("youtube.com/embed/")) {
-                frame.executeJavaScript(adguard);
-            } else if (frame.parent?.url.includes("youtube.com/embed/")) {
-                frame.parent.executeJavaScript(adguard);
+            for (const context of [frame, frame.parent]) {
+                for (const domain of ["https://www.youtube.com/embed/", "https://www.youtube-nocookie.com/embed/"]) {
+                    if (context?.url.includes(domain)) {
+                        context.executeJavaScript(`${adguard}`);
+                        break;
+                    }
+                }
             }
         });
     });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -613,6 +613,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "thororen",
         id: 848339671629299742n
     },
+    cutestbunny: {
+        name: "CutestBunny",
+        id: 281346733068255232n
+    },
     alfred: {
         name: "alfred",
         id: 1038466644353232967n

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -622,6 +622,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "thororen",
         id: 848339671629299742n
     },
+    cutestbunny: {
+        name: "CutestBunny",
+        id: 281346733068255232n
+    },
     alfred: {
         name: "alfred",
         id: 1038466644353232967n


### PR DESCRIPTION
**TLDR:**
This should fix the "Error 15" in youtube embeds related to youtube identity verification. This also adds detection and workaround for the Youtube "you look like a bot" blocks and attempts to reload the embed in that case. Also modifes the adblock plugin to be aware of the non-standard (but google official) `youtube-nocookie` domain used to bypass the identity error.

**More in depth:**
When attempting to play [a blocked video](https://www.youtube.com/watch?v=qXRCe0njp3I) with the FixYoutubeEmbed plugin, I kept getting error despite the plugin technically "working" (as in, the UMG block was bypassed but the video still would not play).
<img width="465" height="382" alt="Image showing error 15" src="https://github.com/user-attachments/assets/9e43869a-d483-491c-833d-939f0aa2460f" />

Upon investigation, this was related to Youtube's identity verification policies as shown in the debug message for the javascript player:

```
"debug_error": "{\"errorCode\":\"embedder.identity.denied\",\"errorDetail\":\"0\",\"errorMessage\":\"This video is unavailable\",\"hF\":\"Error code: 15\",\"ZV\":\"0;a6s.0\",\"BE\":2,\"cpn\":\"\"}"
```

Internet research revealed that Youtube is looking for a cookie to be set in order to validate age, and it defaults to failing you if the hueristics that generate the cookie have not run and provided you an identity cookie. After switching to the `youtube-nocookie.com` domain, which is Youtube's official GDPR compliant replacement for `youtube.com`, I was able to solve this problem because in that environment no cookie can be expected, which side steps the issue entirely. However, I also needed to add it to the CSP for Vencord to prevent `frame-src` mismatch related CSP errors. After fixing that problem, I ran into a new issue - Youtube was repeatedly detecting me as a bot and refusing to play the video without login (which is impossible, or at minimum extremely difficult in the embedded context). I added additional code to handle the bot blocking in addition to the original block workaround for the UMG style blocks. Finally, I noticed that the ad blocking wasn't always working because of the new domain, so I modified the youtubeAdblock plugin to be aware of the possibility of the `youtube-nocookie.com` domain.