### PR TITLE
fix(openInApp): Tidal regex

### DIFF
--- a/src/plugins/openInApp/index.ts
+++ b/src/plugins/openInApp/index.ts
@@ -52,7 +52,7 @@ const UrlReplacementRules: Record<string, URLReplacementRule> = {
         description: "Open Epic Games links in the Epic Games Launcher",
     },
     tidal: {
-        match: /^https:\/\/tidal\.com\/(?:browse\/)?(track|album|artist|playlist|user|video|mix)\/([^/?]+)(?:[/?].*)?$/,
+        match: /^https:\/\/tidal\.com\/(?:browse\/)?(track|album|artist|playlist|user|video|mix)\/(.+)(?:\?.+?)?$/,
         replace: (_, type, id) => `tidal://${type}/${id}`,
         description: "Open Tidal links in the Tidal app",
     },


### PR DESCRIPTION
Tidal has changed their link format recently and it broke the open in app plugin this PR simply update the regex to the new format.