### PR TITLE
Make native title bar option work on Linux

### DIFF
--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -31,7 +31,7 @@ export { PlainSettings, Settings };
 import { addVencordUiStyles } from "@components/css";
 import { openSettingsTabModal, UpdaterTab } from "@components/settings";
 import { debounce } from "@shared/debounce";
-import { IS_WINDOWS } from "@utils/constants";
+import { IS_WINDOWS, IS_LINUX } from "@utils/constants";
 import { createAndAppendStyle } from "@utils/css";
 import { StartAt } from "@utils/types";
 
@@ -183,7 +183,7 @@ document.addEventListener("DOMContentLoaded", () => {
     startAllPlugins(StartAt.DOMContentLoaded);
 
     // FIXME
-    if (IS_DISCORD_DESKTOP && Settings.winNativeTitleBar && IS_WINDOWS) {
+    if (IS_DISCORD_DESKTOP && Settings.winNativeTitleBar && (IS_WINDOWS || IS_LINUX)) {
         createAndAppendStyle("vencord-native-titlebar-style").textContent = "[class*=titleBar]{display: none!important}";
     }
 }, { once: true });

--- a/src/components/settings/tabs/vencord/index.tsx
+++ b/src/components/settings/tabs/vencord/index.tsx
@@ -67,7 +67,7 @@ function Switches() {
             restartRequired: true
         } : {
             key: "winNativeTitleBar",
-            title: "Use operating system's native title bar instead of Discord's custom one",
+            title: "Use the operating system's native title bar instead of Discord's custom one",
             restartRequired: true
         }),
         !IS_WEB && {

--- a/src/components/settings/tabs/vencord/index.tsx
+++ b/src/components/settings/tabs/vencord/index.tsx
@@ -27,7 +27,7 @@ import { SettingsTab, wrapTab } from "@components/settings/tabs/BaseTab";
 import { openContributorModal } from "@components/settings/tabs/plugins/ContributorModal";
 import { openPluginModal } from "@components/settings/tabs/plugins/PluginModal";
 import { gitRemote } from "@shared/vencordUserAgent";
-import { IS_MAC, IS_WINDOWS } from "@utils/constants";
+import { IS_MAC, IS_WINDOWS, IS_LINUX } from "@utils/constants";
 import { Margins } from "@utils/margins";
 import { isPluginDev } from "@utils/misc";
 import { relaunch } from "@utils/native";
@@ -61,13 +61,13 @@ function Switches() {
             title: "Enable React Developer Tools",
             restartRequired: true
         },
-        !IS_WEB && (!IS_DISCORD_DESKTOP || !IS_WINDOWS ? {
+        !IS_WEB && (!IS_DISCORD_DESKTOP || !(IS_WINDOWS || IS_LINUX) ? {
             key: "frameless",
             title: "Disable the window frame",
             restartRequired: true
         } : {
             key: "winNativeTitleBar",
-            title: "Use Windows' native title bar instead of Discord's custom one",
+            title: "Use operating system's native title bar instead of Discord's custom one",
             restartRequired: true
         }),
         !IS_WEB && {

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -78,7 +78,7 @@ if (!IS_VANILLA) {
 
                 if (settings.frameless) {
                     options.frame = false;
-                } else if (process.platform === "win32" && settings.winNativeTitleBar) {
+                } else if ((process.platform === "win32" || process.platform === "linux") && settings.winNativeTitleBar) {
                     delete options.frame;
                 }
 


### PR DESCRIPTION
Recent update to Discord Canary on Linux stopped using system's native title bar. This pull request makes already existing option to force native frame also work on Linux.