### PR TITLE
add tabs to notification log modal

### DIFF
--- a/src/api/Notifications/NotificationComponent.tsx
+++ b/src/api/Notifications/NotificationComponent.tsx
@@ -27,6 +27,7 @@ import { NotificationData } from "./Notifications";
 
 export default ErrorBoundary.wrap(function NotificationComponent({
     title,
+    category,
     body,
     richBody,
     color,
@@ -38,6 +39,7 @@ export default ErrorBoundary.wrap(function NotificationComponent({
     className,
     dismissOnClick
 }: NotificationData & { className?: string; }) {
+    const displayTitle = title || category || "";
     const { timeout, position } = useSettings(["notifications.timeout", "notifications.position"]).notifications;
     const hasFocus = useStateFromStores([WindowStore], () => WindowStore.isFocused());
 
@@ -83,7 +85,7 @@ export default ErrorBoundary.wrap(function NotificationComponent({
                 {icon && <img className="vc-notification-icon" src={icon} alt="" />}
                 <div className="vc-notification-content">
                     <div className="vc-notification-header">
-                        <h2 className="vc-notification-title">{title}</h2>
+                        <h2 className="vc-notification-title">{displayTitle}</h2>
                         <button
                             className="vc-notification-close-btn"
                             onClick={e => {

--- a/src/api/Notifications/Notifications.tsx
+++ b/src/api/Notifications/Notifications.tsx
@@ -41,7 +41,7 @@ function getRoot() {
 }
 
 export interface NotificationData {
-    title: string;
+    title?: string;
     body: string;
     /**
      * Same as body but can be a custom component.
@@ -61,6 +61,8 @@ export interface NotificationData {
     noPersist?: boolean;
     /** Whether this notification should be dismissed when clicked (defaults to true) */
     dismissOnClick?: boolean;
+    /** Category for filtering in Notification Log */
+    category?: string;
 }
 
 function _showNotification(notification: NotificationData, id: number) {
@@ -96,8 +98,8 @@ export async function showNotification(data: NotificationData) {
     persistNotification(data);
 
     if (shouldBeNative() && await requestPermission()) {
-        const { title, body, icon, image, onClick = null, onClose = null } = data;
-        const n = new Notification(title, {
+        const { title = data.category, body, icon, image, onClick = null, onClose = null } = data;
+        const n = new Notification(title || "", {
             body,
             icon,
             // @ts-expect-error ts is drunk

--- a/src/plugins/betterSessions/index.tsx
+++ b/src/plugins/betterSessions/index.tsx
@@ -60,11 +60,6 @@ export default definePlugin({
 
     settings: settings,
 
-    notificationLogTab: {
-        label: "BetterSessions",
-        filter: (notification) => notification.title === "BetterSessions"
-    },
-
     patches: [
         {
             find: "#{intl::AUTH_SESSIONS_SESSION_LOG_OUT}",
@@ -177,7 +172,7 @@ export default definePlugin({
 
             savedSessionsCache.set(session.id_hash, { name: "", isNew: true });
             showNotification({
-                title: "BetterSessions",
+                category: "BetterSessions",
                 body: `New session:\n${session.client_info.os} · ${session.client_info.platform} · ${session.client_info.location}`,
                 permanent: true,
                 onClick: () => UserSettingsModal.open("Sessions")

--- a/src/plugins/relationshipNotifier/index.ts
+++ b/src/plugins/relationshipNotifier/index.ts
@@ -29,11 +29,6 @@ export default definePlugin({
     authors: [Devs.nick],
     settings,
 
-    notificationLogTab: {
-        label: "RelationshipNotifier",
-        filter: (notification) => notification.title === "Relationship Notifier"
-    },
-
     patches: [
         {
             find: "removeRelationship:(",

--- a/src/plugins/relationshipNotifier/utils.ts
+++ b/src/plugins/relationshipNotifier/utils.ts
@@ -115,7 +115,7 @@ export function notify(text: string, icon?: string, onClick?: () => void) {
         showNotice(text, "OK", () => popNotice());
 
     showNotification({
-        title: "Relationship Notifier",
+        category: "RelationshipNotifier",
         body: text,
         icon,
         onClick

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -174,20 +174,6 @@ export interface PluginDef {
      */
     toolboxActions?: Record<string, () => void> | (() => ReactNode);
 
-    /**
-     * Adds a custom tab to the Notification Log modal.
-     *
-     * @example
-     * notificationLogTab: {
-     *   label: "CutePlugin",
-     *   filter: (notification) => notification.title === "CutePlugin"
-     * }
-     */
-    notificationLogTab?: {
-        label: string;
-        filter: (notification: { title: string; }) => boolean;
-    };
-
     tags?: string[];
 
     /**


### PR DESCRIPTION
adds tabs to the notification log so plugins can have their own filtered view. plugins can register a tab via the notificationLogTab property

already added it to betterSessions and relationshipNotifier as examples

<img width="889" height="835" alt="Screenshot 2025-11-24 141611" src="https://github.com/user-attachments/assets/45436623-b4ea-4a38-a947-9977c0cda6ca" />