### PR TITLE
Add a "MuteSync" plugin

### DIFF
--- a/src/plugins/muteSync/README.md
+++ b/src/plugins/muteSync/README.md
@@ -1,0 +1,4 @@
+# MuteSync
+
+Mutes a microphone when it's physically muted.
+

--- a/src/plugins/muteSync/index.ts
+++ b/src/plugins/muteSync/index.ts
@@ -1,0 +1,42 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { FluxDispatcher } from "@webpack/common";
+
+
+export default definePlugin({
+    name: "MuteSync",
+    description: "Mutes a microphone when it's physically muted",
+    authors: [Devs.roli2py],
+    // Due to how is the `AUDIO_INPUT_DETECTED` Flux event works, we're
+    // patching instead of subscribing to the event
+    patches: [
+        {
+            find: "handleNoInput",
+            replacement: {
+                match: /(?<=\i\.emit\(\i\.\i\.Silence,!(\i)\))/,
+                replace: ";$self.checkInputDetection(e)",
+            },
+        },
+    ],
+
+    // A variable to indicate that the plugin caught the initial wrong
+    // input detection
+    isInitialized: false,
+    checkInputDetection(inputDetected: boolean) {
+        if (this.isInitialized && !inputDetected) {
+            FluxDispatcher.dispatch({
+                type: "AUDIO_SET_SELF_MUTE",
+                context: "default",
+                mute: true,
+                playSoundEffect: true,
+            });
+        }
+        this.isInitialized = true;
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -612,6 +612,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     alfred: {
         name: "alfred",
         id: 1038466644353232967n
+    },
+    roli2py: {
+        name: "roli2py",
+        id: 403229667093512194n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
Made a plugin that mutes a microphone when it's physically muted. A main idea is to show for other members that you can't talk without a need of always remember to mute yourself in the app.

Not fully tested, because firstly it was the plugin to satisfy my need, but then I decide to open a PR.