### PR TITLE
Fix: Use cancelText intead of secondaryConfirmText, because it does not show.

### DIFF
--- a/src/plugins/_core/supportHelper.tsx
+++ b/src/plugins/_core/supportHelper.tsx
@@ -227,8 +227,8 @@ export default definePlugin({
                         <Text variant="text-md/bold" className={Margins.top8}>You will be banned from receiving support if you ignore this rule.</Text>
                     </div>,
                     confirmText: "Understood",
-                    secondaryConfirmText: "Don't show again",
-                    onConfirmSecondary: () => settings.store.dismissedDevBuildWarning = true
+                    cancelText: "Don't show again",
+                    onCancel: () => settings.store.dismissedDevBuildWarning = true
                 });
             }
         }


### PR DESCRIPTION
Fix: Use cancelText intead of secondaryConfirmText, because it does not show.
New:
<img width="411" height="280" alt="image" src="https://github.com/user-attachments/assets/9039004e-94bd-455e-9fba-dc4170a18d5a" />
Old:
<img width="408" height="276" alt="image" src="https://github.com/user-attachments/assets/69193dfd-9678-4c62-b533-9c10173fc81b" />
