### PR TITLE
ShowAllMessageButtons: add setting to show frequently used reactions

### DIFF
--- a/src/plugins/showAllMessageButtons/index.ts
+++ b/src/plugins/showAllMessageButtons/index.ts
@@ -46,11 +46,10 @@ export default definePlugin({
                     replace: "isExpanded:$1,"
                 },
                 {
-                    predicate: () => settings.store.showFrequentlyUsedReactions,
-                    match: /function \i\(\i\){let{[^}]+}=function\(\i\).*?}(?=function \i\(\i\))/,
-                    replace: func => {
+                    match: /function \i\(\i\){let{(?:\i:\i,)*canReact:(\i)(?:,\i:\i)*}=function\(\i\).*?}(?=function \i\(\i\))/,
+                    replace: (func, canReactVar) => {
                         const reactionsElement = canonicalizeMatch(/(?<=\?null:)\(0,[^)]+\)\(\i\.Fragment,{children:\[[^\]]+\]}\)/).exec(func)![0];
-                        return func.replace(/children:\[/, children => children + reactionsElement + ",");
+                        return func.replace(/children:\[/, children => `${children}!${canReactVar}||!$self.settings.store.showFrequentlyUsedReactions?null:${reactionsElement},`);
                     }
                 }
             ]

--- a/src/plugins/showAllMessageButtons/index.ts
+++ b/src/plugins/showAllMessageButtons/index.ts
@@ -16,23 +16,45 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
-import definePlugin from "@utils/types";
+import { canonicalizeMatch } from "@utils/patches";
+import definePlugin, { OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    showFrequentlyUsedReactions: {
+        description: "Show frequently used reactions",
+        type: OptionType.BOOLEAN,
+        default: true
+    }
+})
 
 export default definePlugin({
     name: "ShowAllMessageButtons",
     description: "Always show all message buttons no matter if you are holding the shift key or not.",
     tags: ["Chat", "Utility"],
-    authors: [Devs.Nuckyz],
+    authors: [Devs.Nuckyz, Devs.LoganDark],
+
+    settings,
 
     patches: [
         {
             find: "#{intl::MESSAGE_UTILITIES_A11Y_LABEL}",
-            replacement: {
-                // isExpanded: isShiftPressed && other conditions...
-                match: /isExpanded:\i&&(.+?),/,
-                replace: "isExpanded:$1,"
-            }
+            replacement: [
+                {
+                    // isExpanded: isShiftPressed && other conditions...
+                    match: /isExpanded:\i&&(.+?),/,
+                    replace: "isExpanded:$1,"
+                },
+                {
+                    predicate: () => settings.store.showFrequentlyUsedReactions,
+                    match: /function \i\(\i\){let{[^}]+}=function\(\i\).*?}(?=function \i\(\i\))/,
+                    replace: func => {
+                        const reactionsElement = canonicalizeMatch(/(?<=\?null:)\(0,[^)]+\)\(\i\.Fragment,{children:\[[^\]]+\]}\)/).exec(func)![0];
+                        return func.replace(/children:\[/, children => children + reactionsElement + ",");
+                    }
+                }
+            ]
         }
     ]
 });

--- a/src/plugins/showAllMessageButtons/index.ts
+++ b/src/plugins/showAllMessageButtons/index.ts
@@ -47,11 +47,10 @@ export default definePlugin({
                     replace: "isExpanded:$1,"
                 },
                 {
-                    predicate: () => settings.store.showFrequentlyUsedReactions,
-                    match: /function \i\(\i\){let{[^}]+}=function\(\i\).*?}(?=function \i\(\i\))/,
-                    replace: func => {
+                    match: /function \i\(\i\){let{(?:\i:\i,)*canReact:(\i)(?:,\i:\i)*}=function\(\i\).*?}(?=function \i\(\i\))/,
+                    replace: (func, canReactVar) => {
                         const reactionsElement = canonicalizeMatch(/(?<=\?null:)\(0,[^)]+\)\(\i\.Fragment,{children:\[[^\]]+\]}\)/).exec(func)![0];
-                        return func.replace(/children:\[/, children => children + reactionsElement + ",");
+                        return func.replace(/children:\[/, children => `${children}!${canReactVar}||!$self.settings.store.showFrequentlyUsedReactions?null:${reactionsElement},`);
                     }
                 }
             ]

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    LoganDark: {
+        name: "LoganDark",
+        id: 250345382226296833n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    LoganDark: {
+        name: "LoganDark",
+        id: 250345382226296833n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
<img width="580" height="56" alt="image" src="https://github.com/user-attachments/assets/7cf95e98-719c-43cf-bbdf-4b68c0a05119" />

This new setting copies the JSX element from the non-expanded path used to show the frequently used reactions and pastes it into the expanded path as well.

<img width="396" height="65" alt="image" src="https://github.com/user-attachments/assets/c82947a3-803c-4dc7-9129-8466702774fe" />