### PR TITLE
Add server whitelist to MessageLogger

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -249,6 +249,11 @@ export default definePlugin({
             description: "Comma-separated list of guild IDs to ignore",
             default: ""
         },
+        allowGuilds: {
+            type: OptionType.STRING,
+            description: "Comma-separated list of guild IDs to allow",
+            default: ""
+        }
     },
 
     handleDelete(cache: any, data: { ids: string[], id: string; mlDeleted?: boolean; }, isBulk: boolean) {
@@ -286,7 +291,7 @@ export default definePlugin({
 
     shouldIgnore(message: any, isEdit = false) {
         try {
-            const { ignoreBots, ignoreSelf, ignoreUsers, ignoreChannels, ignoreGuilds, logEdits, logDeletes } = Settings.plugins.MessageLogger;
+            const { ignoreBots, ignoreSelf, ignoreUsers, ignoreChannels, ignoreGuilds, allowGuilds, logEdits, logDeletes } = Settings.plugins.MessageLogger;
             const myId = UserStore.getCurrentUser().id;
 
             return ignoreBots && message.author?.bot ||
@@ -296,6 +301,7 @@ export default definePlugin({
                 ignoreChannels.includes(ChannelStore.getChannel(message.channel_id)?.parent_id) ||
                 (isEdit ? !logEdits : !logDeletes) ||
                 ignoreGuilds.includes(ChannelStore.getChannel(message.channel_id)?.guild_id) ||
+                !allowGuilds.includes(ChannelStore.getChannel(message.channel_id)?.guild_id) ||
                 // Ignore Venbot in the support channels
                 (message.author?.id === VENBOT_USER_ID && ChannelStore.getChannel(message.channel_id)?.parent_id === SUPPORT_CATEGORY_ID);
         } catch (e) {


### PR DESCRIPTION
This feels like a necessary convenience feature for people who use MessageLogger as a moderation tool but don't want to overstep boundaries in servers they don't mod.

If this is considered redundant because of the blacklist feature, I get it, though it is annoying to blacklist every server you're in except 1.

This is my first time contributing, so I apologize for any mistakes in advance