### PR TITLE
feat(plugin) IaCorrector — message correction via Mistral AI

### DIFF
--- a/src/plugins/IaCorrector/ApiKeyHelpButton.tsx
+++ b/src/plugins/IaCorrector/ApiKeyHelpButton.tsx
@@ -1,0 +1,30 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Button, React } from "@webpack/common";
+
+const API_KEY_VIDEO_URL = "https://www.youtube.com/watch?v=h4BgFXWKMvQ";
+
+export function ApiKeyHelpButton() {
+    return (
+        <Button onClick={() => VencordNative.native.openExternal(API_KEY_VIDEO_URL)}>
+            How to get a Mistral API key (video)
+        </Button>
+    );
+}
+

--- a/src/plugins/IaCorrector/IaCorrectorIcon.tsx
+++ b/src/plugins/IaCorrector/IaCorrectorIcon.tsx
@@ -1,0 +1,68 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
+import { classes } from "@utils/misc";
+import { IconComponent } from "@utils/types";
+
+import { settings } from "./settings";
+import { showSuccess } from "./utils";
+
+export const IaCorrectorIcon: IconComponent = ({ height = 20, width = 20, className }) => (
+    <svg
+        viewBox="0 0 24 24"
+        height={height}
+        width={width}
+        className={className}
+        fill="currentColor"
+    >
+        <path d="M4 4h9v2H6v4h5v2H6v6H4V4Zm11.5 0H20v2h-1.8l-3.7 12H14L17 6H13.5V4Z" />
+    </svg>
+);
+
+export const IaCorrectorChatBarButton: ChatBarButtonFactory = ({ isMainChat }) => {
+    const { autoCorrect } = settings.use(["autoCorrect"]);
+
+    if (!isMainChat) return null;
+
+    const toggleAutoCorrect = () => {
+        const enabled = !autoCorrect;
+        settings.store.autoCorrect = enabled;
+        showSuccess(
+            enabled
+                ? "IaCorrector enabled: your messages will be corrected before sending."
+                : "IaCorrector disabled: your messages will no longer be corrected."
+        );
+    };
+
+    return (
+        <ChatBarButton
+            tooltip={autoCorrect ? "Disable auto-correct" : "Enable auto-correct"}
+            onClick={toggleAutoCorrect}
+            onContextMenu={toggleAutoCorrect}
+            buttonProps={{ "aria-label": "IaCorrector" }}
+        >
+            <IaCorrectorIcon
+                className={classes(
+                    "vc-iacorrector-icon",
+                    autoCorrect ? "vc-iacorrector-on" : "vc-iacorrector-off"
+                )}
+            />
+        </ChatBarButton>
+    );
+};

--- a/src/plugins/IaCorrector/README.md
+++ b/src/plugins/IaCorrector/README.md
@@ -1,0 +1,20 @@
+# IaCorrector
+
+Correct your messages before sending using Mistral AI.
+
+## Usage
+
+- Click the `IaCorrector` chat bar button to toggle auto-correct.
+- Right click the button does the same (toggle).
+
+## Configuration
+
+Open the plugin settings and configure:
+
+- **Mistral API key**: required.
+- **Target language**: `auto` or an ISO code (e.g. `en`, `fr`, `es`).
+- **Show success toast**: show a toast after the message is processed.
+
+## Privacy
+
+When enabled, your message content is sent to Mistral's API to be processed.

--- a/src/plugins/IaCorrector/index.tsx
+++ b/src/plugins/IaCorrector/index.tsx
@@ -1,0 +1,61 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import "./styles.css";
+
+import definePlugin from "@utils/types";
+
+import { IaCorrectorChatBarButton, IaCorrectorIcon } from "./IaCorrectorIcon";
+import { settings } from "./settings";
+import { assertApiKey, callMistral, logger, showError, showSuccess } from "./utils";
+
+export default definePlugin({
+    name: "IaCorrector",
+    description: "Correct your messages before sending using Mistral AI.",
+    authors: [{ name: "HyperBeats", id: 768230588971745321n }],
+    settings,
+
+    chatBarButton: {
+        icon: IaCorrectorIcon,
+        render: IaCorrectorChatBarButton
+    },
+
+    async onBeforeMessageSend(_, message) {
+        if (!(settings.store.autoCorrect ?? false)) return;
+
+        const content = message.content?.trim();
+        if (!content) return;
+
+        const apiKey = (settings.store.apiKey ?? "").trim();
+        if (!assertApiKey(apiKey)) return;
+
+        try {
+            const targetLanguage = settings.store.targetLanguage ?? "auto";
+
+            logger.debug("Intercepting message before send", { length: content.length });
+            const result = await callMistral(content, targetLanguage, apiKey);
+            message.content = result.text;
+            logger.debug("Replaced message content", { newLength: result.text.length });
+            if (settings.store.showSuccessToast ?? true) showSuccess("Message corrected by IaCorrector.");
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            logger.error("IaCorrector failed", err);
+            showError(`Mistral error: ${errorMessage}`);
+        }
+    }
+});

--- a/src/plugins/IaCorrector/native.ts
+++ b/src/plugins/IaCorrector/native.ts
@@ -1,0 +1,37 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { IpcMainInvokeEvent } from "electron";
+
+export async function makeMistralRequest(_: IpcMainInvokeEvent, apiKey: string, payload: string) {
+    try {
+        const res = await fetch("https://api.mistral.ai/v1/chat/completions", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${apiKey}`
+            },
+            body: payload
+        });
+
+        const data = await res.text();
+        return { status: res.status, data };
+    } catch (e) {
+        return { status: -1, data: String(e) };
+    }
+}

--- a/src/plugins/IaCorrector/settings.ts
+++ b/src/plugins/IaCorrector/settings.ts
@@ -1,0 +1,51 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+
+import { ApiKeyHelpButton } from "./ApiKeyHelpButton";
+
+export const settings = definePluginSettings({
+    apiKey: {
+        type: OptionType.STRING,
+        description: "Mistral API key",
+        default: "",
+        placeholder: "Get your API key from https://console.mistral.ai/"
+    },
+    apiKeyHelp: {
+        type: OptionType.COMPONENT,
+        component: ApiKeyHelpButton
+    },
+    autoCorrect: {
+        type: OptionType.BOOLEAN,
+        description: "Automatically correct messages before sending",
+        default: false
+    },
+    showSuccessToast: {
+        type: OptionType.BOOLEAN,
+        description: "Show a success toast after correcting",
+        default: true
+    },
+    targetLanguage: {
+        type: OptionType.STRING,
+        description: "Target language (\"auto\" or ISO code like en, fr, es)",
+        default: "auto",
+        placeholder: "auto"
+    }
+});

--- a/src/plugins/IaCorrector/styles.css
+++ b/src/plugins/IaCorrector/styles.css
@@ -1,0 +1,17 @@
+.vc-iacorrector-icon {
+    transition: color 0.2s ease, transform 0.2s ease, filter 0.2s ease;
+}
+
+.vc-iacorrector-on {
+    color: var(--status-positive, var(--green-360, #3ba55c));
+    fill: var(--status-positive, var(--green-360, #3ba55c));
+    transform: scale(1.05);
+    filter: drop-shadow(0 0 4px rgb(59 165 92 / 50%));
+}
+
+.vc-iacorrector-off {
+    color: var(--text-muted, var(--interactive-muted, #b5bac1));
+    fill: var(--text-muted, var(--interactive-muted, #b5bac1));
+    filter: drop-shadow(0 0 4px rgb(0 0 0 / 20%));
+    opacity: 0.85;
+}

--- a/src/plugins/IaCorrector/utils.ts
+++ b/src/plugins/IaCorrector/utils.ts
@@ -1,0 +1,103 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Logger } from "@utils/Logger";
+import { PluginNative } from "@utils/types";
+import { showToast, Toasts } from "@webpack/common";
+
+const Native = VencordNative.pluginHelpers.IaCorrector as PluginNative<typeof import("./native")>;
+
+export const logger = new Logger("IaCorrector");
+
+export interface IaResult {
+    text: string;
+}
+
+export function showError(message: string) {
+    showToast(message, Toasts.Type.FAILURE);
+}
+
+export function showSuccess(message: string) {
+    showToast(message, Toasts.Type.SUCCESS);
+}
+
+export function assertApiKey(apiKey: string) {
+    if (!apiKey.trim()) {
+        showError("Mistral API key is missing in the plugin settings.");
+        return false;
+    }
+
+    return true;
+}
+
+function normalizeTargetLanguage(targetLanguage: string) {
+    const normalized = (targetLanguage || "auto").trim().toLowerCase();
+    if (normalized === "auto") return "auto";
+    if (/^[a-z]{2}(-[a-z]{2})?$/.test(normalized)) return normalized;
+    return "auto";
+}
+
+export async function callMistral(text: string, targetLanguage: string, apiKey: string): Promise<IaResult> {
+    const target = normalizeTargetLanguage(targetLanguage);
+    const targetInstr = target === "auto"
+        ? "Detect the language of the text and reply in that same language."
+        : `Reply in ${target} only.`;
+
+    const systemPrompt = `You are a spelling and grammar corrector. Correct only the provided text and reply with only the corrected text, without explanations. ${targetInstr}`;
+
+    logger.debug("Calling Mistral", { hasApiKey: Boolean(apiKey), textPreview: text.slice(0, 80) });
+
+    const payload = JSON.stringify({
+        model: "mistral-small",
+        messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: text }
+        ]
+    });
+
+    const { status, data } = await Native.makeMistralRequest(apiKey, payload);
+
+    switch (status) {
+        case 200:
+            break;
+        case -1:
+            throw new Error(`Failed to connect to Mistral API: ${data}`);
+        case 401:
+            throw new Error("Invalid Mistral API key.");
+        default:
+            throw new Error(`Mistral API error (${status}): ${data}`);
+    }
+
+    let json: any;
+    try {
+        json = JSON.parse(data);
+    } catch (err) {
+        logger.error("Failed to parse Mistral response", err);
+        throw new Error("Invalid Mistral response.");
+    }
+
+    const content: string | undefined = json?.choices?.[0]?.message?.content;
+    if (!content) {
+        logger.error("Mistral returned an empty response", json);
+        throw new Error("Invalid Mistral response.");
+    }
+
+    const cleaned = content.trim();
+    logger.debug("Mistral response OK", { length: cleaned.length, preview: cleaned.slice(0, 80) });
+    return { text: cleaned };
+}


### PR DESCRIPTION
Adds the IaCorrector plugin (src/plugins/IaCorrector) to correct spelling/grammar right before a message is sent using the Mistral API.

Features

Chat bar button to enable/disable auto-correct (click or right-click) with a clear on/off visual state.
Settings: Mistral API key, target language (auto or ISO code), optional success toast.
Error handling (missing/invalid key, network/API failures).
Privacy
When enabled, message content is sent to Mistral’s API for processing.

How to test

Enable IaCorrector and set a valid Mistral API key in plugin settings.
Toggle auto-correct from the chat bar button.
Send a message with mistakes → it should be corrected before sending.
Try an invalid API key → you should get an error toast.