### PR TITLE
feat(notrack): make launch signature clean

### DIFF
--- a/src/plugins/_core/noTrack.ts
+++ b/src/plugins/_core/noTrack.ts
@@ -140,5 +140,16 @@ export default definePlugin({
                 Reflect.deleteProperty(window, "DiscordSentry");
             }
         });
+        const originalReflectGet = Reflect.get;
+        Reflect.get = function (target, prop, receiver) {
+            if (target === window) {
+                const { stack } = new Error("");
+                // return undefined if requested by discord generateLaunchSignature function
+                if (stack?.includes?.("libdiscore")) {
+                    return undefined as any;
+                }
+            }
+            return originalReflectGet(target, prop, receiver);
+        };
     }
 });


### PR DESCRIPTION
[Launch signature](https://docs.discord.food/reference#launch-signature) is a way that discord can tell if you are using client mods.

It basically goes through each client mod, checking a list of properties tied to that mod on window["..."]. I changed it so all those checks just return undefined, keeping Vencord hidden.

since I couldn't find a working patch, I used a monkey patch
