### PR TITLE
Fix: Allow users to specify a custom path name within the vencloud instance

### DIFF
--- a/src/api/SettingsSync/cloudSetup.tsx
+++ b/src/api/SettingsSync/cloudSetup.tsx
@@ -93,7 +93,7 @@ export async function authorizeCloud() {
     if (!await checkCloudUrlCsp()) return;
 
     try {
-        const oauthConfiguration = await fetch(new URL("/v1/oauth/settings", getCloudUrl()));
+        const oauthConfiguration = await fetch(new URL("v1/oauth/settings", getCloudUrl()));
         var { clientId, redirectUri } = await oauthConfiguration.json();
     } catch {
         showNotification({

--- a/src/api/SettingsSync/cloudSync.ts
+++ b/src/api/SettingsSync/cloudSync.ts
@@ -28,7 +28,7 @@ export async function putCloudSettings(manual?: boolean) {
     if (!await checkCloudUrlCsp()) return;
 
     try {
-        const res = await fetch(new URL("/v1/settings", getCloudUrl()), {
+        const res = await fetch(new URL("v1/settings", getCloudUrl()), {
             method: "PUT",
             headers: {
                 Authorization: await getCloudAuth(),
@@ -76,7 +76,7 @@ export async function getCloudSettings(shouldNotify = true, force = false) {
     if (!await checkCloudUrlCsp()) return;
 
     try {
-        const res = await fetch(new URL("/v1/settings", getCloudUrl()), {
+        const res = await fetch(new URL("v1/settings", getCloudUrl()), {
             method: "GET",
             headers: {
                 Authorization: await getCloudAuth(),
@@ -169,7 +169,7 @@ export async function deleteCloudSettings() {
     if (!await checkCloudUrlCsp()) return;
 
     try {
-        const res = await fetch(new URL("/v1/settings", getCloudUrl()), {
+        const res = await fetch(new URL("v1/settings", getCloudUrl()), {
             method: "DELETE",
             headers: { Authorization: await getCloudAuth() },
         });
@@ -203,7 +203,7 @@ export async function deleteCloudSettings() {
 export async function eraseAllCloudData() {
     if (!await checkCloudUrlCsp()) return;
 
-    const res = await fetch(new URL("/v1/", getCloudUrl()), {
+    const res = await fetch(new URL("v1/", getCloudUrl()), {
         method: "DELETE",
         headers: { Authorization: await getCloudAuth() }
     });

--- a/src/components/settings/tabs/sync/CloudTab.tsx
+++ b/src/components/settings/tabs/sync/CloudTab.tsx
@@ -39,8 +39,17 @@ import { Alerts, Select, Tooltip } from "@webpack/common";
 
 function validateUrl(url: string) {
     try {
-        new URL(url);
-        return true;
+        const u = new URL(url);
+
+        /*
+        * We ensure the user's provided URL (if valid) contains a trailing slash
+        * This gives us the possibility to remove the leading slash when calling new URL("v1/foo/bar", getCloudUrl())
+        * It allows users to run self-hosted Vencloud instances under a custom path name, thus avoiding monopolizing a single subdomain.
+        */
+        if (!u.pathname.endsWith("/")) {
+            u.pathname += "/";
+            return u.toString();
+        }
     } catch {
         return "Invalid URL";
     }


### PR DESCRIPTION
While attempting to self-host a Vencloud instance, I realised that I could not specify a backend API in the following format: `https://foo.bar/vencloud/`

Despite the backend API URL being stored locally properly by Vencord, the call to Vencloud would be: `https://foo.bar/v1/oauth/settings`. 

<img width="1568" height="548" alt="/vencloud/ path getting stripped" src="https://github.com/user-attachments/assets/e365c0c3-abfa-4ec2-97c5-95d30a43cd65" />

Due to the current structure of the code, the path is always removed because the following calls begin with a leading slash: 

https://github.com/Vendicated/Vencord/blob/c123efd65923bb183850242affdb1d7b0d228e50/src/api/SettingsSync/cloudSetup.tsx#L17
```js
new URL("/v1/foo/bar", getCloudUrl())
// returns https://foo.bar/v1/foo/bar because of leading slash
```

https://github.com/Vendicated/Vencord/blob/c123efd65923bb183850242affdb1d7b0d228e50/src/api/SettingsSync/cloudSetup.tsx#L96
```js
export const getCloudUrl = () => new URL(Settings.cloud.url);
// returns https://foo.bar/vencloud/
```

In order to allow users to specify a custom path in the API backend URL, I've enforced the addition of a slash at the end of the URL submitted by the user if it was omitted and removed the slashes when calling the Vencloud API. 