### PR TITLE
feat(UserVoiceShow): highlight indicator when user is in the same voice channel

### DIFF
--- a/src/plugins/userVoiceShow/components.tsx
+++ b/src/plugins/userVoiceShow/components.tsx
@@ -121,12 +121,17 @@ export interface VoiceChannelIndicatorProps {
     isProfile?: boolean;
     isActionButton?: boolean;
     shouldHighlight?: boolean;
+    highlightSameChannel?: boolean;
 }
 
 const clickTimers = new Map<string, any>();
 
-export const VoiceChannelIndicator = ErrorBoundary.wrap(({ userId, isProfile, isActionButton, shouldHighlight }: VoiceChannelIndicatorProps) => {
+export const VoiceChannelIndicator = ErrorBoundary.wrap(({ userId, isProfile, isActionButton, shouldHighlight, highlightSameChannel = true }: VoiceChannelIndicatorProps) => {
     const channelId = useStateFromStores([VoiceStateStore], () => VoiceStateStore.getVoiceStateForUser(userId)?.channelId);
+
+    const currentUserId = UserStore.getCurrentUser()?.id;
+    const currentUserChannelId = useStateFromStores([VoiceStateStore], () => VoiceStateStore.getVoiceStateForUser(currentUserId)?.channelId);
+    const isInSameChannel = highlightSameChannel && channelId != null && channelId === currentUserChannelId;
 
     const { isMuted, isDeaf } = useStateFromStores([VoiceStateStore], () => {
         const voiceState = VoiceStateStore.getVoiceStateForUser(userId);
@@ -193,7 +198,8 @@ export const VoiceChannelIndicator = ErrorBoundary.wrap(({ userId, isProfile, is
                         cl("clickable"),
                         isActionButton && ActionButtonClasses.actionButton,
                         isActionButton && shouldHighlight && ActionButtonClasses.highlight,
-                        cl(isProfile && "profile-speaker")
+                        cl(isProfile && "profile-speaker"),
+                        isInSameChannel && cl("same-channel")
                     )}
                     size={isActionButton ? 20 : 16}
                 />

--- a/src/plugins/userVoiceShow/index.tsx
+++ b/src/plugins/userVoiceShow/index.tsx
@@ -44,6 +44,11 @@ const settings = definePluginSettings({
         description: "Show a user's Voice Channel indicator in messages",
         default: true,
         restartNeeded: true
+    },
+    highlightSameChannel: {
+        type: OptionType.BOOLEAN,
+        description: "Highlight the indicator in green when the user is in the same voice channel as you",
+        default: true
     }
 });
 
@@ -96,10 +101,10 @@ export default definePlugin({
 
     start() {
         if (settings.store.showInMemberList) {
-            addMemberListDecorator("UserVoiceShow", ({ user }) => user == null ? null : <VoiceChannelIndicator userId={user.id} />);
+            addMemberListDecorator("UserVoiceShow", ({ user }) => user == null ? null : <VoiceChannelIndicator userId={user.id} highlightSameChannel={settings.store.highlightSameChannel} />);
         }
         if (settings.store.showInMessages) {
-            addMessageDecoration("UserVoiceShow", ({ message }) => message?.author == null ? null : <VoiceChannelIndicator userId={message.author.id} />);
+            addMessageDecoration("UserVoiceShow", ({ message }) => message?.author == null ? null : <VoiceChannelIndicator userId={message.author.id} highlightSameChannel={settings.store.highlightSameChannel} />);
         }
     },
 
@@ -108,5 +113,5 @@ export default definePlugin({
         removeMessageDecoration("UserVoiceShow");
     },
 
-    VoiceChannelIndicator
+    VoiceChannelIndicator: (props: any) => <VoiceChannelIndicator {...props} highlightSameChannel={settings.store.highlightSameChannel} />
 });

--- a/src/plugins/userVoiceShow/style.css
+++ b/src/plugins/userVoiceShow/style.css
@@ -5,6 +5,14 @@
     justify-content: center;
 }
 
+.vc-uvs-same-channel {
+    color: var(--status-positive) !important;
+}
+
+.vc-uvs-same-channel:hover {
+    color: var(--green-400) !important;
+}
+
 .vc-uvs-clickable {
     cursor: pointer;
 }


### PR DESCRIPTION
## summary

this pr adds an optional visual tweak to the **uservoiceshow** plugin.

if you are in the same voice channel as another user, their indicator can be shown in **green**, making it easier to see who you’re currently in a call with.

## notes

- existing behavior is kept as-is  
- a separate setting was added so users can choose between the old and new behavior  
- nothing changes unless the setting is enabled  

i went with an opt-in approach to avoid changing visuals for people who are already used to the current indicator.

## technical details

- uses existing voice state information  
- no dom hacks or new dependencies  
- only applies when both users are in the same voice channel  

## screenshots
<img width="178" height="123" alt="image" src="https://github.com/user-attachments/assets/39e68a35-3021-49c5-ab9b-de8c92129a51" />

