### PR TITLE
feat: add FakeVoiceState plugin

### DIFF
--- a/src/plugins/FakeVoiceState/index.tsx
+++ b/src/plugins/FakeVoiceState/index.tsx
@@ -52,7 +52,7 @@ const fakeVoiceState = {
 
 const StateKeys = ["selfDeaf", "selfMute", "selfVideo"];
 export default definePlugin({
-    name: "sFakeMuteAndDeafen",
+    name: "FakeMuteAndDeafen",
     description: "Kendinizi sahte olarak susturabilir ve sağırlaştırabilirsiniz. Bu sırada konuşmaya devam edebilir ve duyulabilirsiniz.",
     authors: [{
         name: "kramo",


### PR DESCRIPTION
I've added a new plugin called FakeVoiceState. It allows users to spoof their mute, deafen, and video states locally and to others. This is a helpful feature for privacy and testing.