### PR TITLE
Add channelId optional parameter and activeChannelId key in ExpressionPickerStore types

### DIFF
--- a/packages/discord-types/src/utils.d.ts
+++ b/packages/discord-types/src/utils.d.ts
@@ -214,10 +214,10 @@ export interface ExpressionPickerStoreState extends Record<PropertyKey, any> {
 }
 
 export interface ExpressionPickerStore {
-    openExpressionPicker(activeView: ActiveView, activeViewType?: any): void;
-    closeExpressionPicker(activeViewType?: any): void;
-    toggleMultiExpressionPicker(activeViewType?: any): void;
-    toggleExpressionPicker(activeView: ActiveView, activeViewType?: any): void;
+    openExpressionPicker(activeView: ActiveView, activeViewType?: any, channelId?: string): void;
+    closeExpressionPicker(activeViewType?: any, channelId?: string): void;
+    toggleMultiExpressionPicker(activeViewType?: any, channelId?: string): void;
+    toggleExpressionPicker(activeView: ActiveView, activeViewType?: any, channelId?: string): void;
     setExpressionPickerView(activeView: ActiveView): void;
     setSearchQuery(searchQuery: string, isSearchSuggestion?: boolean): void;
     useExpressionPickerStore(): ExpressionPickerStoreState;

--- a/packages/discord-types/src/utils.d.ts
+++ b/packages/discord-types/src/utils.d.ts
@@ -208,6 +208,7 @@ export interface ExpressionPickerStoreState extends Record<PropertyKey, any> {
     activeView: ActiveView | null;
     lastActiveView: ActiveView | null;
     activeViewType: any | null;
+    activeChannelId: string | null;
     searchQuery: string;
     isSearchSuggestion: boolean,
     pickerId: string;


### PR DESCRIPTION
Needed it for a custom plugin of mine so I figured I'd PR it back here.

Discord code for reference:
<img width="782" height="587" alt="image" src="https://github.com/user-attachments/assets/0d6043aa-bd2b-49d6-9428-6e7378f7980b" />
<img width="206" height="127" alt="image" src="https://github.com/user-attachments/assets/35251f32-04fa-4945-b6e1-340e11ab344c" />
