### PR TITLE
feat(plugins): add InvisibleMessage plugin

### DIFF
--- a/src/plugins/invisibleMessage/README.md
+++ b/src/plugins/invisibleMessage/README.md
@@ -1,0 +1,34 @@
+# Invisible Message
+
+Send secret messages that are **completely invisible** to people without this
+plugin!
+
+## How to Use
+
+Wrap the secret part with `>` and `<`:
+
+```
+Hey everyone! >This is my secret message< How are you?
+```
+
+**What others see:**
+
+- **Without plugin:** "Hey everyone! How are you?" _(secret is invisible)_
+- **With plugin:** "Hey everyone! **Encrypted message: This is my secret
+  message** How are you?"
+
+---
+##  Examples
+**Secret Plans:**
+```
+Meeting at 3pm >bring the documents<
+```
+- Without plugin: "Meeting at 3pm"
+- With plugin: "Meeting at 3pm **Encrypted message: bring the documents**"
+**Hidden Jokes:**
+```
+>I secretly love pineapple on pizza< What's your favorite food?
+```
+- Without plugin: "What's your favorite food?"
+- With plugin: See the confession!
+---

--- a/src/plugins/invisibleMessage/encoding.ts
+++ b/src/plugins/invisibleMessage/encoding.ts
@@ -1,0 +1,86 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Encoding/Decoding utilities for invisible messages
+ * Uses zero-width Unicode characters that Discord preserves
+ */
+
+// Zero-width characters that Discord doesn't filter
+const ZWSP = "\u200b"; // Zero Width Space
+const ZWNJ = "\u200c"; // Zero Width Non-Joiner
+const ZWJ = "\u200d";  // Zero Width Joiner
+
+// Markers for start and end of encoded message
+export const PADDING_START = ZWNJ + ZWSP;
+export const PADDING_END = ZWSP + ZWNJ;
+
+// Pattern to detect text that should be encoded: >text<
+export const SHOULD_ENCODE_PATTERN = / *>(.+?)< */;
+
+// Pattern to detect encoded text
+export const ENCODED_PATTERN = new RegExp(`${ZWNJ}${ZWSP}([${ZWSP}${ZWNJ}${ZWJ}]+?)${ZWSP}${ZWNJ}`, "g");
+
+/**
+ * Encode a string to binary using zero-width characters
+ * Each character is converted to binary, then binary is encoded as ZWSP (0) and ZWJ (1)
+ */
+export const encode = (s: string): string => {
+    let result = PADDING_START;
+
+    for (let i = 0; i < s.length; i++) {
+        const charCode = s.charCodeAt(i);
+        const binary = charCode.toString(2).padStart(16, "0");
+
+        for (const bit of binary) {
+            result += bit === "0" ? ZWSP : ZWJ;
+        }
+    }
+
+    result += PADDING_END;
+    return result;
+};
+
+/**
+ * Decode an invisible message
+ */
+export const decode = (s: string): string => {
+    ENCODED_PATTERN.lastIndex = 0;
+
+    const match = ENCODED_PATTERN.exec(s);
+    if (!match) {
+        return "";
+    }
+
+    const encoded = match[1];
+    let result = "";
+    let binary = "";
+
+    for (const char of encoded) {
+        if (char === ZWSP) {
+            binary += "0";
+        } else if (char === ZWJ) {
+            binary += "1";
+        }
+
+        // Every 16 bits = 1 character
+        if (binary.length === 16) {
+            const charCode = parseInt(binary, 2);
+            result += String.fromCharCode(charCode);
+            binary = "";
+        }
+    }
+
+    return result;
+};
+
+/**
+ * Check if a string contains encoded text
+ */
+export const checkEncode = (s: string): boolean => {
+    ENCODED_PATTERN.lastIndex = 0;
+    return ENCODED_PATTERN.test(s);
+};

--- a/src/plugins/invisibleMessage/index.tsx
+++ b/src/plugins/invisibleMessage/index.tsx
@@ -6,8 +6,12 @@
 
 import { addMessageAccessory, removeMessageAccessory } from "@api/MessageAccessories";
 import { addMessagePreSendListener, removeMessagePreSendListener } from "@api/MessageEvents";
+import { Divider } from "@components/Divider";
 import { Devs } from "@utils/constants";
-import definePlugin from "@utils/types";
+import { Margins } from "@utils/margins";
+import { classes } from "@utils/misc";
+import definePlugin, { OptionType } from "@utils/types";
+import { Forms } from "@webpack/common";
 
 import { encode, decode, checkEncode, SHOULD_ENCODE_PATTERN } from "./encoding";
 
@@ -27,11 +31,44 @@ const preSendListener = (channelId: string, msg: any) => {
     }
 };
 
+function SettingsComponent() {
+    return (
+        <section>
+            <Forms.FormTitle tag="h3">Usage</Forms.FormTitle>
+            <Forms.FormText>
+                Wrap text with <code>&gt;</code> and <code>&lt;</code> to make it invisible.
+            </Forms.FormText>
+            <Forms.FormText className={Margins.top8}>
+                <strong>Example:</strong>
+                <ul>
+                    <li>You type: <code>hello &gt;secret&lt; world</code></li>
+                    <li>Others see: <code>hello  world</code> (invisible gap)</li>
+                    <li>Plugin users see: <code>hello Encrypted message: secret world</code></li>
+                </ul>
+            </Forms.FormText>
+            <Divider className={classes(Margins.top8, Margins.bottom8)} />
+            <Forms.FormTitle tag="h3">Note</Forms.FormTitle>
+            <Forms.FormText>
+                This is <strong>NOT</strong> real encryption! Anyone with this plugin can decode messages.
+                Perfect for fun secrets with friends.
+            </Forms.FormText>
+        </section>
+    );
+}
+
 export default definePlugin({
     name: "InvisibleMessage",
-    description: "Hide secret messages in plain sight! Wrap text with >< to make it invisible. Example: 'hello >secret< world' - only users with this plugin can see the hidden text.",
+    description: "Send invisible messages using zero-width characters. Wrap text with >< to hide it.",
     authors: [Devs.nyankoiscat],
     dependencies: ["MessageAccessoriesAPI"],
+
+    options: {
+        usage: {
+            type: OptionType.COMPONENT,
+            description: "",
+            component: SettingsComponent
+        }
+    },
 
     start() {
         addMessagePreSendListener(preSendListener);

--- a/src/plugins/invisibleMessage/index.tsx
+++ b/src/plugins/invisibleMessage/index.tsx
@@ -1,0 +1,71 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { addMessageAccessory, removeMessageAccessory } from "@api/MessageAccessories";
+import { addMessagePreSendListener, removeMessagePreSendListener } from "@api/MessageEvents";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+import { encode, decode, checkEncode, SHOULD_ENCODE_PATTERN } from "./encoding";
+
+const ACCESSORY_KEY = "invisible-message-accessory";
+
+// Pre-send listener to encode messages
+const preSendListener = (channelId: string, msg: any) => {
+    try {
+        const matches = SHOULD_ENCODE_PATTERN.exec(msg.content);
+
+        if (matches) {
+            const encoded = encode(matches[1]);
+            msg.content = msg.content.replace(SHOULD_ENCODE_PATTERN, ` ${encoded}`);
+        }
+    } catch (err) {
+        console.error("[InvisibleMessage] Encode error:", err);
+    }
+};
+
+export default definePlugin({
+    name: "InvisibleMessage",
+    description: "Hide secret messages in plain sight! Wrap text with >< to make it invisible. Example: 'hello >secret< world' - only users with this plugin can see the hidden text.",
+    authors: [Devs.nyankoiscat],
+    dependencies: ["MessageAccessoriesAPI"],
+
+    start() {
+        addMessagePreSendListener(preSendListener);
+
+        addMessageAccessory(ACCESSORY_KEY, (props: any) => {
+            const { message } = props;
+
+            if (!message?.content || typeof message.content !== "string") {
+                return null;
+            }
+
+            if (!checkEncode(message.content)) {
+                return null;
+            }
+
+            try {
+                const decoded = decode(message.content);
+
+                if (!decoded) return null;
+
+                return (
+                    <span style={{ color: "#b5bac1" }}>
+                        Encrypted message: {decoded}
+                    </span>
+                );
+            } catch (err) {
+                console.error("[InvisibleMessage] Decode error:", err);
+                return null;
+            }
+        });
+    },
+
+    stop() {
+        removeMessagePreSendListener(preSendListener);
+        removeMessageAccessory(ACCESSORY_KEY);
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    nyankoiscat: {
+        name: "nyankoiscat",
+        id: 680719551830556688n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
A fun plugin to share hidden notes with friends. It automatically hides any text wrapped in > < syntax using invisible Unicode characters.

How to use: Hello >  I love you  :3 <

Others see: "Hello"
Plugin users see: "Hello Encrypted message: I love you  :3 "
Messages remain fully invisible on mobile and for anyone not using the plugin.

<img width="453" height="91" alt="d1" src="https://github.com/user-attachments/assets/e3d04238-29b4-48a7-a288-6c47976ef7fa" />

<img width="405" height="112" alt="d2" src="https://github.com/user-attachments/assets/2b8510f0-e4d8-4646-9e10-74f3380b0402" />

<img width="1221" height="122" alt="d3" src="https://github.com/user-attachments/assets/d0b21878-a991-48ce-b12f-48afeb66c4d4" />

