### PR TITLE
Role color everywhere compatibility patch

### DIFF
--- a/src/plugins/roleColorEverywhere/index.tsx
+++ b/src/plugins/roleColorEverywhere/index.tsx
@@ -128,7 +128,7 @@ export default definePlugin({
             find: "#{intl::GUEST_NAME_SUFFIX})]",
             replacement: [
                 {
-                    match: /#{intl::GUEST_NAME_SUFFIX}.{0,50}?""\](?<=guildId:(\i),.+?user:(\i).+?)/,
+                    match: /#{intl::GUEST_NAME_SUFFIX}[^"]+""[^}]+(?<=guildId:(\i),.+?user:(\i).+?)/,
                     replace: "$&,style:$self.getColorStyle($2.id,$1),"
                 }
             ],


### PR DESCRIPTION
Old way not compatible with this

```js
{
  find: "#{intl::GUEST_NAME_SUFFIX})]",
  replacement: {
    match: /#{intl::GUEST_NAME_SUFFIX}[^"]+""(?<=user:(\i).+?)/,
    replace: "$&,$self.showInjection($1.id)"
  }
}
```