### PR TITLE
feat(GifProviderSelector): Add GIF provider selector plugin

### DIFF
--- a/src/plugins/gifProviderSelector/index.tsx
+++ b/src/plugins/gifProviderSelector/index.tsx
@@ -1,0 +1,244 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { definePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { type React, Select } from "@webpack/common";
+
+// consts and types
+const PROVIDERS = {
+    TENOR: "tenor",
+    GIPHY: "giphy",
+    KLIPY: "klipy"
+} as const;
+
+type Provider = typeof PROVIDERS[keyof typeof PROVIDERS];
+
+const PROVIDER_OPTIONS = [
+    { label: "Tenor", value: PROVIDERS.TENOR },
+    { label: "Giphy", value: PROVIDERS.GIPHY },
+    { label: "Klipy", value: PROVIDERS.KLIPY }
+];
+
+export const settings = definePluginSettings({
+    provider: {
+        type: OptionType.SELECT,
+        description: "Default GIF provider to use for searches",
+        options: [
+            { label: "Tenor", value: PROVIDERS.TENOR, default: true },
+            { label: "Giphy", value: PROVIDERS.GIPHY },
+            { label: "Klipy", value: PROVIDERS.KLIPY }
+        ] as const
+    }
+});
+
+
+function ProviderSelector() {
+    // Use settings.use() for reactivity - component re-renders when settings change
+    const currentProvider = settings.use(["provider"]).provider ?? PROVIDERS.TENOR;
+
+    const handleClick = (e: React.MouseEvent) => {
+        // Prevent click from bubbling up and closing the GIF picker
+        e.stopPropagation();
+    };
+
+    return (
+        <div
+            className="vc-gif-provider-selector"
+            onClick={handleClick}
+            onMouseDown={handleClick}
+        >
+            <Select
+                options={PROVIDER_OPTIONS}
+                isSelected={(v: string) => v === currentProvider}
+                select={(v: Provider) => { settings.store.provider = v; }}
+                serialize={(v: string) => v}
+                popoutPosition="bottom"
+                closeOnSelect={true}
+            />
+        </div>
+    );
+}
+
+
+interface WrapperProps {
+    searchBar: React.ReactNode;
+}
+
+function HeaderWrapper({ searchBar }: WrapperProps) {
+    return (
+        <ErrorBoundary noop>
+            <div className="vc-gif-provider-header">
+                <div className="vc-gif-provider-search">{searchBar}</div>
+                <ProviderSelector />
+            </div>
+        </ErrorBoundary>
+    );
+}
+
+let originalFetch: typeof fetch;
+let originalXHROpen: typeof XMLHttpRequest.prototype.open;
+
+function getProvider(): Provider {
+    return settings.store.provider ?? PROVIDERS.TENOR;
+}
+
+function patchUrl(url: string): string {
+    if (url.includes("/gifs/search") && url.includes("provider=")) {
+        const provider = getProvider();
+        const newUrl = url.replace(/provider=\w+/, `provider=${provider}`);
+        if (newUrl !== url) {
+            return newUrl;
+        }
+    }
+    return url;
+}
+
+function patchFetch() {
+    originalFetch = window.fetch;
+
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        let url: string;
+
+        if (typeof input === "string") {
+            url = input;
+        } else if (input instanceof URL) {
+            url = input.toString();
+        } else if (input instanceof Request) {
+            url = input.url;
+        } else {
+            return originalFetch.call(window, input, init);
+        }
+
+        const patchedUrl = patchUrl(url);
+        if (patchedUrl !== url) {
+            if (input instanceof Request) {
+                return originalFetch.call(window, new Request(patchedUrl, input), init);
+            }
+            return originalFetch.call(window, patchedUrl, init);
+        }
+
+        return originalFetch.call(window, input, init);
+    };
+}
+
+function patchXHR() {
+    originalXHROpen = XMLHttpRequest.prototype.open;
+
+    XMLHttpRequest.prototype.open = function (
+        method: string,
+        url: string | URL,
+        async: boolean = true,
+        user?: string | null,
+        password?: string | null
+    ) {
+        const urlStr = url.toString();
+        const patchedUrl = patchUrl(urlStr);
+
+        return originalXHROpen.call(this, method, patchedUrl, async, user, password);
+    };
+}
+
+function unpatchFetch() {
+    if (originalFetch) {
+        window.fetch = originalFetch;
+    }
+}
+
+function unpatchXHR() {
+    if (originalXHROpen) {
+        XMLHttpRequest.prototype.open = originalXHROpen;
+    }
+}
+
+export default definePlugin({
+    name: "GifProviderSelector",
+    description: "Adds a dropdown to select between Giphy, Klipy, and Tenor for GIF searches",
+    authors: [Devs.Thereallo],
+    settings,
+
+    /**
+     * Patches to inject our component into the GIF picker header.
+     *
+     * Based on actual Discord code (Module 855057):
+     *
+     * renderHeaderContent(){
+     *   ...
+     *   default:{
+     *     let t=(0,m.cf)(),n=(0,h.w)(t);
+     *     return(0,r.jsx)(l.IWV,{query:e,onChange:this.handleChangeQuery,
+     *            onClear:this.handleClearQuery,placeholder:n,"aria-label":n,
+     *            ref:this.props.searchBarRef,autoFocus:!0})
+     *   }
+     * }
+     *
+     * Strategy: Capture "return" separately from the JSX call, then wrap
+     * only the JSX call with our wrapper function.
+     */
+    patches: [
+        // Patch 1: Change placeholder - replace all provider-specific search text
+        // Discord may show "Search Tenor", "Search Giphy", or "Search Klipy"
+        {
+            find: "Search Tenor",
+            replacement: {
+                match: /"Search Tenor"/g,
+                replace: '"Search GIFs"'
+            }
+        },
+        {
+            find: "Search Giphy",
+            replacement: {
+                match: /"Search Giphy"/g,
+                replace: '"Search GIFs"'
+            }
+        },
+        {
+            find: "Search Klipy",
+            replacement: {
+                match: /"Search Klipy"/g,
+                replace: '"Search GIFs"'
+            }
+        },
+
+        // Patch 2: Inject ProviderSelector into the GIF picker header
+        //
+        // Original: return(0,r.jsx)(l.IWV,{...autoFocus:!0})
+        // After:    return $self.wrapWithSelector((0,r.jsx)(l.IWV,{...autoFocus:!0}))
+        //
+        // We use capture groups:
+        // $1 = "return"
+        // $2 = "(0,r.jsx)(l.IWV,{...autoFocus:!0})"
+        {
+            find: "renderHeaderContent()",
+            replacement: {
+                // Match the return statement with the IWV (SearchBar) component
+                // Capture groups:
+                // $1 = "return"
+                // $2 = the jsx call "(0,r.jsx)(l.IWV,{...})"
+                match: /(return)(\(0,i\.jsx\)\(\i\.IWV,\{[^}]+autoFocus:!0\}\))/,
+                replace: "$1 $self.wrapWithSelector($2)"
+            }
+        }
+    ],
+
+    wrapWithSelector(searchBarElement: React.ReactNode): React.ReactNode {
+        return <HeaderWrapper searchBar={searchBarElement} />;
+    },
+
+    start() {
+        patchFetch();
+        patchXHR();
+    },
+
+    stop() {
+        unpatchFetch();
+        unpatchXHR();
+    }
+});

--- a/src/plugins/gifProviderSelector/style.css
+++ b/src/plugins/gifProviderSelector/style.css
@@ -1,0 +1,15 @@
+.vc-gif-provider-header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 8px;
+}
+
+.vc-gif-provider-search {
+    flex-grow: 1;
+}
+
+.vc-gif-provider-selector {
+    flex-shrink: 0;
+    min-width: 90px;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    Thereallo: {
+        name: "Thereallo",
+        id: 896388612764090448n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Summary

Adds a new plugin that allows users to switch between different GIF providers (Tenor, Giphy, Klipy) directly from the GIF picker UI.

## Features

- **Provider Selector Dropdown**: Injects a dropdown into the GIF picker header next to the search bar
- **Seamless Integration**: Uses React component patching to wrap Discord's SearchBar component
- **API Interception**: Patches fetch/XHR requests to modify the `provider` parameter in GIF search requests
- **Persistent Settings**: Selected provider is saved and persists across sessions
- **Generic Placeholder**: Replaces "Search Tenor/Giphy/Klipy" with "Search GIFs" for consistency

## Technical Details

- Patches `renderHeaderContent()` in the GIF picker to inject the selector
- Uses Vencord's reactive settings (`settings.use()`) for state management
- Handles event propagation to prevent dropdown clicks from closing the GIF picker

## Screenshots

The dropdown appears in the GIF picker header, allowing quick provider switching without leaving the picker.

## Checklist

- [x] Code compiles without errors
- [x] All tests pass (`pnpm test`)
- [x] ESLint passes
- [x] Follows Vencord plugin conventions