### PR TITLE
[feat] Added plugin to switch the discord GIF provider/search engine

### DIFF
--- a/src/plugins/gifProviderSelector/README.md
+++ b/src/plugins/gifProviderSelector/README.md
@@ -1,0 +1,20 @@
+# GifProviderSelector
+
+GifProviderSelector is a Vencord plugin that allows you to customize the GIF search provider within Discord. You can choose between several popular services, providing a more versatile search experience or preparing for future changes in Discord's default integrations.
+
+## Features
+
+- **Multiple Providers:** Switch between Discord's default, Klipy, Tenor, and Giphy.
+- **Dynamic UI:** Automatically updates the search bar placeholder to reflect your chosen provider.
+- **Future-Proofing:** Includes support for Klipy, the recommended successor to Tenor, which is scheduled for discontinuation in mid-2026.
+- **Seamless Integration:** Works directly within the existing Discord GIF picker UI.
+
+## Why Klipy?
+
+Tenor's current integration is expected to be phased out by June 30th, 2026. Klipy was created by former Tenor employees and is designed to be a robust and familiar alternative, making it the highly recommended choice for users who prefer the Tenor-style search experience.
+
+## Usage
+
+1. Enable the **GifProviderSelector** plugin in your Vencord settings.
+2. Open the plugin settings to select your desired GIF provider.
+3. Use the Discord GIF picker as usual; searches will now be routed through your selected provider.

--- a/src/plugins/gifProviderSelector/index.tsx
+++ b/src/plugins/gifProviderSelector/index.tsx
@@ -1,0 +1,207 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2026 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import { Margins } from "@components/margins";
+import { Paragraph } from "@components/Paragraph";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { find } from "@webpack";
+import { RestAPI } from "@webpack/common";
+
+const SEARCH_DELAY_MS = 500;
+
+const settings = definePluginSettings({
+    provider: {
+        type: OptionType.SELECT,
+        default: "discord",
+        description: "Select your preferred GIF search engine provider.",
+        options: [
+            { label: "Discord Default", value: "discord", default: true },
+            { label: "Klipy (Recommended)", value: "klipy" },
+            { label: "Tenor", value: "tenor" },
+            { label: "Giphy", value: "giphy" },
+        ]
+    }
+});
+
+const PROVIDER_NAMES: Record<string, string> = {
+    klipy: "Klipy",
+    tenor: "Tenor",
+    giphy: "Giphy"
+};
+
+interface DiscordGifResult {
+    id: string;
+    title: string;
+    url: string;
+    src: string;
+    gif_src: string;
+    width: number;
+    height: number;
+    preview: string;
+}
+
+export default definePlugin({
+    name: "GifProviderSelector",
+    description: "Allows switching the Discord GIF search provider to alternative services such as Klipy, Tenor, or Giphy.",
+    authors: [Devs.holygrole],
+    settings,
+    settingsAboutComponent: () => (
+        <Paragraph className={Margins.bottom16}>
+            Note: Tenor's current integration is scheduled for discontinuation by June 30th, 2026.
+            Klipy, developed by former Tenor engineers, serves as a highly compatible and recommended alternative.
+        </Paragraph>
+    ),
+    patches: [
+        {
+            find: "renderHeaderContent()",
+            replacement: [
+                {
+                    // Intercept the search function to perform custom searches when a non-default provider is selected.
+                    match: /(search\((\w+),\s*(\w+),\s*(\w+)\)\s*\{)/,
+                    replace: "$1if($self.handleSearch(this,$2,$3,$4))return;"
+                },
+                {
+                    // Inject custom results and query into the component props before rendering.
+                    match: /(renderContent\(\)\s*\{\s*let\s*\{[\s\S]*?}\s*=\s*)(this\.props)/,
+                    replace: "$1$self.getProps(this, $2)"
+                },
+                {
+                    // Update the search bar placeholder to reflect the currently selected provider.
+                    match: /(renderHeaderContent\(\).+)placeholder:\s*(\w+),\s*["']aria-label["']:\s*\2,/,
+                    replace: '$1placeholder: $self.getPlaceholder($2),"aria-label": $self.getPlaceholder($2),'
+                }
+            ]
+        }
+    ],
+
+    /**
+     * Determines the appropriate placeholder text for the GIF search bar.
+     */
+    getPlaceholder(original: string) {
+        const { provider } = settings.store;
+        if (provider === "discord") return original;
+
+        const name = PROVIDER_NAMES[provider] || "GIFs";
+        return `Search ${name}`;
+    },
+
+    /**
+     * Handles the search input by debouncing and executing custom API requests
+     * if a non-default provider is active.
+     */
+    handleSearch(instance: any, query: string, _type: string, _s: any) {
+        // If using Discord's default provider, allow the original logic to proceed.
+        if (settings.store.provider === "discord") return false;
+
+        if (instance._searchTimeout) {
+            clearTimeout(instance._searchTimeout);
+            delete instance._searchTimeout;
+        }
+
+        // Reset custom state if the query is cleared.
+        if (query === "") {
+            delete instance._customResults;
+            delete instance._customQuery;
+            delete instance._latestSearchQuery;
+            return false;
+        }
+
+        // Switch the UI to search mode immediately to show the loading state/results.
+        const GIFPickerResultTypes = find(m => m.GIFPickerResultTypes, { isIndirect: true })?.GIFPickerResultTypes;
+        const searchType = GIFPickerResultTypes?.SEARCH ?? "Search";
+        if (instance.state.resultType !== searchType) {
+            instance.setState({ resultType: searchType });
+        }
+
+        instance._searchTimeout = setTimeout(() => {
+            this.runCustomSearch(instance, query);
+            delete instance._searchTimeout;
+        }, SEARCH_DELAY_MS);
+
+        return true;
+    },
+
+    /**
+     * Executes the custom GIF search and updates the component instance with the results.
+     */
+    async runCustomSearch(instance: any, query: string) {
+        instance._latestSearchQuery = query;
+        const { provider } = settings.store;
+
+        const data = await this.fetchGifs(query, provider);
+
+        // Ensure we only update if this is still the most recent query.
+        if (instance._latestSearchQuery !== query) return;
+
+        instance._customResults = data;
+        instance._customQuery = query;
+        instance.forceUpdate();
+    },
+
+    /**
+     * Merges custom search results into the component props if available.
+     */
+    getProps(instance: any, props: any) {
+        if (instance._customResults) {
+            return {
+                ...props,
+                resultItems: instance._customResults,
+                resultQuery: instance._customQuery || props.resultQuery
+            };
+        }
+        return props;
+    },
+
+    /**
+     * Fetches GIF results from the Discord backend using the specified provider.
+     */
+    async fetchGifs(query: string, provider: string) {
+        try {
+            const response = await RestAPI.get({
+                url: "/gifs/search",
+                query: {
+                    q: query,
+                    media_format: "webm",
+                    provider: provider
+                }
+            });
+
+            if (!response.ok) {
+                console.error(`[GifProviderSelector] API request failed for provider ${provider}:`, response.text);
+                return [];
+            }
+
+            const results: DiscordGifResult[] = response.body;
+
+            return results.map(item => ({
+                id: item.id,
+                url: item.url,
+                src: item.src,
+                width: item.width,
+                height: item.height,
+                format: 2 // VIDEO (webm)
+            }));
+
+        } catch (error) {
+            console.error("[GifProviderSelector] Unexpected error during GIF fetch:", error);
+            return [];
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    holygrole: {
+        name: "holygrole",
+        id: 331102626819080193n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Change the GIF provider Discord uses in the GIF selector (choices: Discord default, Klipy, Tenor or Giphy).

**Why?**
Google is discontinuing Tenor's public API and only keeping it in Google products (of course 🙄). This means Discord's beloved GIF picker will slowly roll over to use other GIF providers, like Giphy and Klipy. Klipy is made by former Tenor employees and is amazing, but Giphy misses quite a lot of fun GIFs and doesn't feel as extensive as Tenor and Klipy. Since there is no way to change the GIF provider and my friend got selected as random user to start using Giphy, I decided to create this plugin to choose which GIF provider you like most. Still providing Tenor too till its last day (June 30th, 2026). 

And of course as we know in the OSS community, we don't like being vendor-locked, so having the ability change providers is always awesome ;)