### PR TITLE
CtrlEnterSend: add option to disable call keybind

### DIFF
--- a/src/plugins/ctrlEnterSend/index.ts
+++ b/src/plugins/ctrlEnterSend/index.ts
@@ -36,6 +36,12 @@ export default definePlugin({
             description: "Whether to send a message in the middle of a code block",
             type: OptionType.BOOLEAN,
             default: true,
+        },
+        disableCallKeybind: {
+            description: "Whether the default call keybind should be disabled to prevent misclicks",
+            type: OptionType.BOOLEAN,
+            restartNeeded: true,
+            default: false,
         }
     }),
     patches: [
@@ -53,6 +59,13 @@ export default definePlugin({
             replacement: {
                 match: /!(\i).shiftKey&&!(this.hasOpenCodeBlock\(\))&&\(.{0,100}?\)/,
                 replace: "$self.shouldSubmit($1, $2)"
+            }
+        },
+        {
+            find: 'binds:["ctrl\+\'',
+            replacement: {
+                match: /binds:\["ctrl\+'",\s*"ctrl\+shift\+'"\]/,
+                replace: 'binds:$self.getCallKeybinds()'
             }
         }
     ],
@@ -73,5 +86,8 @@ export default definePlugin({
             result &&= !codeblock;
         }
         return result;
+    },
+    getCallKeybinds(): string[] {
+        return this.settings.store.disableCallKeybind ? ['disabled by ctrlentersend'] : ["ctrl+'", "ctrl+shift+'"];
     }
 });


### PR DESCRIPTION
Problem:
<img width="1280" height="720" src="https://github.com/user-attachments/assets/b14a62ce-84ad-4620-a74c-7ca94729fc18" />
Misclicking Ctrl + ' and starting a call accidentally when trying to send a message
It might be bit niche but also might just be the most annoying "feature" I've ever seen

Solution:
<img width="2610" height="307" src="https://github.com/user-attachments/assets/f4bf1110-5eb8-4d18-b5d7-6dc31ab579ed" />