### PR TITLE
Translate: add LibreTranslate support + native requests (CSP-safe)

### DIFF
--- a/src/plugins/translate/TranslateModal.tsx
+++ b/src/plugins/translate/TranslateModal.tsx
@@ -20,25 +20,34 @@ import { Divider } from "@components/Divider";
 import { FormSwitch } from "@components/FormSwitch";
 import { Margins } from "@utils/margins";
 import { ModalCloseButton, ModalContent, ModalHeader, ModalProps, ModalRoot } from "@utils/modal";
-import { Forms, SearchableSelect, useMemo } from "@webpack/common";
+import { Forms, SearchableSelect, useEffect, useMemo, useState } from "@webpack/common";
 
 import { settings } from "./settings";
-import { cl, getLanguages } from "./utils";
+import { cl, getLanguages, getLibreTranslateLanguages } from "./utils";
 
 const LanguageSettingKeys = ["receivedInput", "receivedOutput", "sentInput", "sentOutput"] as const;
 
 function LanguageSelect({ settingsKey, includeAuto }: { settingsKey: typeof LanguageSettingKeys[number]; includeAuto: boolean; }) {
     const currentValue = settings.use([settingsKey])[settingsKey];
+    const { service, libreTranslateUrl, libreTranslateApiKey } = settings.use(["service", "libreTranslateUrl", "libreTranslateApiKey"]);
+    const [langVersion, bumpLangVersion] = useState(0);
 
-    const options = useMemo(
-        () => {
-            const options = Object.entries(getLanguages()).map(([value, label]) => ({ value, label }));
-            if (!includeAuto)
-                options.shift();
+    useEffect(() => {
+        if (service !== "libretranslate") return;
+        let cancelled = false;
+        (async () => {
+            await getLibreTranslateLanguages();
+            if (!cancelled) bumpLangVersion(v => v + 1);
+        })();
+        return () => { cancelled = true; };
+    }, [service, libreTranslateUrl, libreTranslateApiKey]);
 
-            return options;
-        }, []
-    );
+    const options = useMemo(() => {
+        const options = Object.entries(getLanguages()).map(([value, label]) => ({ value, label }));
+        if (!includeAuto)
+            options.shift();
+        return options;
+    }, [includeAuto, service, langVersion]);
 
     return (
         <section className={Margins.bottom16}>

--- a/src/plugins/translate/native.ts
+++ b/src/plugins/translate/native.ts
@@ -6,6 +6,15 @@
 
 import { IpcMainInvokeEvent } from "electron";
 
+function canUseRemoteUrl(url: string) {
+    try {
+        const parsed = new URL(url);
+        return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+        return false;
+    }
+}
+
 export async function makeDeeplTranslateRequest(_: IpcMainInvokeEvent, pro: boolean, apiKey: string, payload: string) {
     const url = pro
         ? "https://api.deepl.com/v2/translate"
@@ -17,6 +26,39 @@ export async function makeDeeplTranslateRequest(_: IpcMainInvokeEvent, pro: bool
             headers: {
                 "Content-Type": "application/json",
                 "Authorization": `DeepL-Auth-Key ${apiKey}`
+            },
+            body: payload
+        });
+
+        const data = await res.text();
+        return { status: res.status, data };
+    } catch (e) {
+        return { status: -1, data: String(e) };
+    }
+}
+
+export async function makeLibreTranslateLanguagesRequest(_: IpcMainInvokeEvent, url: string) {
+    if (!canUseRemoteUrl(url))
+        return { status: -1, data: "Invalid URL" };
+
+    try {
+        const res = await fetch(url);
+        const data = await res.text();
+        return { status: res.status, data };
+    } catch (e) {
+        return { status: -1, data: String(e) };
+    }
+}
+
+export async function makeLibreTranslateRequest(_: IpcMainInvokeEvent, url: string, payload: string) {
+    if (!canUseRemoteUrl(url))
+        return { status: -1, data: "Invalid URL" };
+
+    try {
+        const res = await fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
             },
             body: payload
         });

--- a/src/plugins/translate/settings.ts
+++ b/src/plugins/translate/settings.ts
@@ -52,7 +52,8 @@ export const settings = definePluginSettings({
         options: [
             { label: "Google Translate", value: "google", default: true },
             { label: "DeepL Free", value: "deepl" },
-            { label: "DeepL Pro", value: "deepl-pro" }
+            { label: "DeepL Pro", value: "deepl-pro" },
+            { label: "LibreTranslate", value: "libretranslate" }
         ] as const,
         onChange: resetLanguageDefaults
     },
@@ -62,6 +63,20 @@ export const settings = definePluginSettings({
         default: "",
         placeholder: "Get your API key from https://deepl.com/your-account",
         disabled: () => IS_WEB
+    },
+    libreTranslateUrl: {
+        type: OptionType.STRING,
+        description: "LibreTranslate instance URL",
+        default: "https://libretranslate.com",
+        placeholder: "https://libretranslate.com",
+        disabled: () => IS_WEB || settings.store.service !== "libretranslate"
+    },
+    libreTranslateApiKey: {
+        type: OptionType.STRING,
+        description: "LibreTranslate API key (optional for self-hosted instances)",
+        default: "",
+        placeholder: "Only needed if your instance requires it",
+        disabled: () => IS_WEB || settings.store.service !== "libretranslate"
     },
     autoTranslate: {
         type: OptionType.BOOLEAN,
@@ -78,7 +93,7 @@ export const settings = definePluginSettings({
 }>();
 
 export function resetLanguageDefaults() {
-    if (IS_WEB || settings.store.service === "google") {
+    if (IS_WEB || settings.store.service === "google" || settings.store.service === "libretranslate") {
         settings.store.receivedInput = "auto";
         settings.store.receivedOutput = "en";
         settings.store.sentInput = "auto";

--- a/src/plugins/translate/utils.ts
+++ b/src/plugins/translate/utils.ts
@@ -40,19 +40,120 @@ interface DeeplData {
     }[];
 }
 
+interface LibreTranslateData {
+    translatedText: string;
+    detectedLanguage?: {
+        confidence: number;
+        language: string;
+    };
+}
+
+interface LibreLanguageEntry {
+    code: string;
+    name: string;
+    targets?: string[];
+}
+
+type LibreLanguagesMap = Record<string, string>;
+
+let cachedLibreLanguages: LibreLanguagesMap | null = null;
+let cachedLibreBaseUrl: string | null = null;
+let cachedLibreLanguagesPromise: Promise<LibreLanguagesMap | null> | null = null;
+
+function normalizeLibreBaseUrl(url: string) {
+    return url.replace(/\/+$/, "");
+}
+
+export async function getLibreTranslateLanguages(): Promise<LibreLanguagesMap | null> {
+    if (IS_WEB) return null;
+
+    const baseUrl = normalizeLibreBaseUrl(settings.store.libreTranslateUrl || "https://libretranslate.com");
+    if (cachedLibreLanguages && cachedLibreBaseUrl === baseUrl) return cachedLibreLanguages;
+    if (cachedLibreLanguagesPromise && cachedLibreBaseUrl === baseUrl)
+        return cachedLibreLanguagesPromise.then(() => cachedLibreLanguages);
+
+    cachedLibreBaseUrl = baseUrl;
+    cachedLibreLanguagesPromise = (async () => {
+        try {
+            const { status, data } = await Native.makeLibreTranslateLanguagesRequest(`${baseUrl}/languages`);
+            if (status === -1)
+                throw new Error(`Failed to connect to LibreTranslate API: ${data}`);
+            if (status !== 200)
+                throw new Error(`Failed to fetch /languages: ${status}${data ? `\n${data}` : ""}`);
+
+            const list: LibreLanguageEntry[] = JSON.parse(data);
+            const entries = list
+                .map(l => [l.code, l.name] as const)
+                .sort((a, b) => a[1].localeCompare(b[1]));
+
+            cachedLibreLanguages = {
+                auto: "Detect language",
+                ...Object.fromEntries(entries)
+            };
+        } catch (e) {
+            // Non-blocking: translation can still work and we fall back to raw codes if needed.
+            console.warn("[Translate] Failed to load LibreTranslate languages:", e);
+            cachedLibreLanguages = null;
+        }
+        return cachedLibreLanguages;
+    })();
+
+    return cachedLibreLanguagesPromise;
+}
+
+function googleLanguageToLibreLanguage(language: string) {
+    switch (language) {
+        case "auto":
+            return "auto";
+        case "iw":
+            return "he";
+        case "jw":
+            return "jv";
+        case "zh-CN":
+        case "zh-TW":
+            return "zh";
+        default:
+            return language.split("-")[0].toLowerCase();
+    }
+}
+
+function libreLanguageToGoogleLanguage(language: string) {
+    switch (language) {
+        case "he":
+            return "iw";
+        case "jv":
+            return "jw";
+        case "zh":
+            return "zh-CN";
+        default:
+            return language;
+    }
+}
+
 export interface TranslationValue {
     sourceLanguage: string;
     text: string;
 }
 
-export const getLanguages = () => IS_WEB || settings.store.service === "google"
-    ? GoogleLanguages
-    : DeeplLanguages;
+export const getLanguages = () => {
+    if (settings.store.service === "deepl" || settings.store.service === "deepl-pro")
+        return DeeplLanguages;
+
+    if (settings.store.service === "libretranslate") {
+        // Fire-and-forget (the modal also triggers the fetch).
+        void getLibreTranslateLanguages();
+        return cachedLibreLanguages ?? GoogleLanguages;
+    }
+
+    return GoogleLanguages;
+};
 
 export async function translate(kind: "received" | "sent", text: string): Promise<TranslationValue> {
     const translate = IS_WEB || settings.store.service === "google"
         ? googleTranslate
-        : deeplTranslate;
+        : settings.store.service === "libretranslate"
+            ? libreTranslate
+            : deeplTranslate;
 
     try {
         return await translate(
@@ -95,6 +196,43 @@ async function googleTranslate(text: string, sourceLang: string, targetLang: str
     return {
         sourceLanguage: GoogleLanguages[sourceLanguage] ?? sourceLanguage,
         text: translation
+    };
+}
+
+async function libreTranslate(text: string, sourceLang: string, targetLang: string): Promise<TranslationValue> {
+    const baseUrl = normalizeLibreBaseUrl(settings.store.libreTranslateUrl || "https://libretranslate.com");
+
+    const body: Record<string, string> = {
+        q: text,
+        source: googleLanguageToLibreLanguage(sourceLang || "auto"),
+        target: googleLanguageToLibreLanguage(targetLang),
+        format: "text"
+    };
+
+    // api_key is optional for self-hosted instances, but required on some public ones.
+    if (settings.store.libreTranslateApiKey)
+        body.api_key = settings.store.libreTranslateApiKey;
+
+    const { status, data } = await Native.makeLibreTranslateRequest(`${baseUrl}/translate`, JSON.stringify(body));
+    if (status === -1)
+        throw new Error(`Failed to connect to LibreTranslate API: ${data}`);
+    if (status !== 200)
+        throw new Error(
+            `Failed to translate "${text}" (${sourceLang} -> ${targetLang})`
+            + `\n${status}${data ? `\n${data}` : ""}`
+        );
+
+    const parsed: LibreTranslateData = JSON.parse(data);
+    const langCode = parsed.detectedLanguage?.language ?? body.source;
+
+    const langs = await getLibreTranslateLanguages();
+    const prettyName = langs?.[langCode]
+        ?? GoogleLanguages[libreLanguageToGoogleLanguage(langCode)]
+        ?? langCode;
+
+    return {
+        sourceLanguage: prettyName,
+        text: parsed.translatedText
     };
 }
 


### PR DESCRIPTION
## Summary

This PR adds LibreTranslate support to the Translate plugin and makes LibreTranslate requests CSP-safe by sending them through native plugin helpers (IPC) instead of renderer `fetch`.

## Changes

- Added `LibreTranslate` as a translation service option.
- Added LibreTranslate settings:
  - `libreTranslateUrl` (instance base URL)
  - `libreTranslateApiKey` (optional)
- Added LibreTranslate language loading (`/languages`) with caching per base URL.
- Added Google <-> Libre language code normalization/mapping.
- Added native helper requests in `src/plugins/translate/native.ts`:
  - `makeLibreTranslateLanguagesRequest`
  - `makeLibreTranslateRequest`
  - URL protocol validation (`http`/`https`)
- Updated Translate modal language selectors to refresh when Libre settings change.

## Why

Renderer-side requests to local/self-hosted LibreTranslate instances can be blocked by CSP (example: `Refused to connect because it violates the document's Content Security Policy.`).  
Routing LibreTranslate requests through native helpers fixes this while keeping the existing UX.

## Validation

- `pnpm build` succeeds.
- Verified in app:
  - `Translate -> service -> LibreTranslate` is available.
  - Local instance URL works for both language fetch and translation.
  - Existing Google/DeepL behavior remains unchanged.
