### PR TITLE
feat: actually add LlamaScribe (AI Grammar correction) to plugins

### DIFF
--- a/src/plugins/LlamaScribe/index.ts
+++ b/src/plugins/LlamaScribe/index.ts
@@ -1,14 +1,13 @@
 /*
- * LlamaScribe - AI Grammar & Style
- * Copyright (c) 2026 Caeden
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 import { definePluginSettings } from "@api/Settings";
-import definePlugin from "@utils/types";
-import { OptionType } from "@utils/types";
+import { Devs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
-
+import definePlugin, { OptionType } from "@utils/types";
 const logger = new Logger("LlamaScribe");
 
 const settings = definePluginSettings({
@@ -34,7 +33,7 @@ let styleElement: HTMLStyleElement | null = null;
 export default definePlugin({
     name: "LlamaScribe",
     description: "Instant AI text improvement. Press Alt + G. Requires a Groq API Key.",
-    authors: [{ name: "Caeden", id: 832663333529845772n }],
+    authors: [Devs.caeden],
     settings,
 
     start() {
@@ -70,7 +69,7 @@ export default definePlugin({
             const text = target.innerText;
             if (!text || text.trim().length < 2) return;
 
-            const apiKey = settings.store.apiKey;
+            const { apiKey } = settings.store;
             if (!apiKey) {
                 logger.error("Set your Groq API Key in settings!");
                 return;
@@ -104,7 +103,7 @@ export default definePlugin({
                 const data = await response.json();
                 target.classList.remove("polishing-active");
 
-                let fixedText = data.choices[0].message.content.trim().replace(/^"|"$/g, '');
+                const fixedText = data.choices[0].message.content.trim().replace(/^"|"$/g, "");
                 if (!fixedText || fixedText === text) return;
 
                 target.focus();
@@ -115,16 +114,16 @@ export default definePlugin({
                 sel?.addRange(range);
 
                 const dataTransfer = new DataTransfer();
-                dataTransfer.setData('text/plain', fixedText);
+                dataTransfer.setData("text/plain", fixedText);
 
-                const pasteEvent = new ClipboardEvent('paste', {
+                const pasteEvent = new ClipboardEvent("paste", {
                     clipboardData: dataTransfer,
                     bubbles: true,
                     cancelable: true
                 });
 
                 target.dispatchEvent(pasteEvent);
-                target.dispatchEvent(new Event('input', { bubbles: true }));
+                target.dispatchEvent(new Event("input", { bubbles: true }));
 
             } catch (err) {
                 target.classList.remove("polishing-active");

--- a/src/plugins/LlamaScribe/native.ts
+++ b/src/plugins/LlamaScribe/native.ts
@@ -1,3 +1,9 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { ConnectSrc, CspPolicies } from "@main/csp";
 
 CspPolicies["api.groq.com"] = ConnectSrc;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    caeden: {
+        name: "caedencode",
+        id: 832663333529845772n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This pull request introduces the new `LlamaScribe` plugin, which provides instant AI-powered grammar and style improvements for editable text fields using Groq's API. The plugin features a keyboard shortcut (Alt + G) to trigger text polishing, customizable model selection, and visual feedback during processing. Additionally, it updates the content security policy to permit connections to Groq's API endpoint.

**LlamaScribe plugin implementation:**

* Added the main plugin logic in `src/plugins/LlamaScribe/index.ts`, including settings for Groq API key and model selection, event handling for Alt + G shortcut.

**Security and API integration:**

* Updated `src/plugins/LlamaScribe/native.ts` to allow network requests to `api.groq.com` by modifying the content security policy.