### PR TITLE
FakeNitro: Enable toggling Favorites server

### DIFF
--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -370,6 +370,14 @@ export default definePlugin({
                 match: /(?<=type:"(?:SOUNDBOARD_SOUNDS_RECEIVED|GUILD_SOUNDBOARD_SOUND_CREATE|GUILD_SOUNDBOARD_SOUND_UPDATE|GUILD_SOUNDBOARD_SOUNDS_UPDATE)".+?available:)\i\.available/g,
                 replace: "true"
             }
+        },
+        // Patch to enable toggling Favorites server
+        {
+            find: "={isPremium",
+            replacement: {
+                match: /(isPremiumExactly:)\i/,
+                replace: "$1() => true"
+            }
         }
     ],
 


### PR DESCRIPTION
With Discord making changes to the Favorites experiment and planning to release it to Nitro Standard, this patch makes the function `isPremiumExactly` always return true, enabling both the Show Favorites Server setting in User Settings > Chat and the server appearing in the server list.

Currently, you'd need the experiment enabled, but it should hopefully work if they roll things out as they are, since it's just modifying what that function returns, not the actual Favorites logic. However, I wouldn't be surprised if they change how the client handles making sure people without Standard won't be able to access it, lol

Do tell if I shouldn't PR patches for experiments that haven't rolled out yet though