### PR TITLE
fix(ShowMeYourName): add optional chaining to nick

### DIFF
--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -97,7 +97,7 @@ export default definePlugin({
 
             const prefix = withMentionPrefix ? "@" : "";
 
-            if (isRepliedMessage && !inReplies || username.toLowerCase() === nick.toLowerCase())
+            if ((isRepliedMessage && !inReplies) || username.toLowerCase() === nick?.toLowerCase())
                 return <>{prefix}{nick}</>;
 
             if (mode === "user-nick")


### PR DESCRIPTION
just added ?. on nick so it wont crash if it’s missing and wrapped the condition in parentheses to make it easier to read.