### PR TITLE
fix(betterFolders): fix broken guildsnav regex

### DIFF
--- a/src/plugins/betterFolders/index.tsx
+++ b/src/plugins/betterFolders/index.tsx
@@ -149,7 +149,7 @@ export default definePlugin({
                 // Create the isBetterFolders and betterFoldersExpandedIds variables in the GuildsBar component
                 // Needed because we access this from a non-arrow closure so we can't use arguments[0]
                 {
-                    match: /let{disableAppDownload:\i=\i\.isPlatformEmbedded,isOverlay:.+?(?=}=\i,)/,
+                    match: /let\s*\{\s*disableAppDownload:\s*\w+\s*=\s*\w+\.isPlatformEmbedded,\s*isOverlay:\s*\w+\s*=\s*!1[^}]*}/,
                     replace: "$&,isBetterFolders,betterFoldersExpandedIds"
                 },
                 // Export the isBetterFolders and betterFoldersExpandedIds variable to the Guild List component


### PR DESCRIPTION
fixed BetterFolders failing to inject vars into guildsnav
it was causes because discord updated `guildsnav` which added className and themeOverride 
in this commit, i updated the regex to use `[^}]*` and it fixes the issue.
(I reopened this because my last PR was a disaster and had messed up)