### PR TITLE
feat: add LatexMath plugin

### DIFF
--- a/src/plugins/latexMath/index.tsx
+++ b/src/plugins/latexMath/index.tsx
@@ -1,0 +1,127 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 watchthelight
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./latex.css";
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+import { isLoaded, loadKaTeX, renderToString, unloadKaTeX } from "./katex";
+import { settings } from "./settings";
+
+const BLOCK_MATH_RE = /\$\$([\s\S]+?)\$\$/g;
+const INLINE_MATH_RE = /(?<![\\$\d])\$(?!\$)(.+?)(?<![\\$])\$/g;
+
+function extractText(node: any): string {
+    if (typeof node === "string") return node;
+    if (Array.isArray(node)) return node.map(extractText).join("");
+    if (!node?.props) return "";
+
+    const children = extractText(node.props.children);
+
+    if (node.type === "em" || node.type === "i") return `_${children}_`;
+    if (node.type === "strong" || node.type === "b") return `**${children}**`;
+    if (node.type === "u") return `__${children}__`;
+    if (node.type === "del" || node.type === "s") return `~~${children}~~`;
+
+    return children;
+}
+
+function buildLatexContent(fullText: string, enableBlock: boolean, enableInline: boolean): any[] | null {
+    const fragments: { start: number; end: number; latex: string; display: boolean; }[] = [];
+
+    if (enableBlock) {
+        BLOCK_MATH_RE.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = BLOCK_MATH_RE.exec(fullText)) !== null) {
+            fragments.push({
+                start: match.index,
+                end: match.index + match[0].length,
+                latex: match[1].trim(),
+                display: true,
+            });
+        }
+    }
+
+    if (enableInline) {
+        const occupied = fragments.map(f => [f.start, f.end] as const);
+        INLINE_MATH_RE.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = INLINE_MATH_RE.exec(fullText)) !== null) {
+            const s = match.index;
+            const e = match.index + match[0].length;
+            if (!occupied.some(([os, oe]) => s < oe && e > os)) {
+                fragments.push({ start: s, end: e, latex: match[1].trim(), display: false });
+            }
+        }
+    }
+
+    if (fragments.length === 0) return null;
+    fragments.sort((a, b) => a.start - b.start);
+
+    const result: any[] = [];
+    let lastIdx = 0;
+
+    for (const f of fragments) {
+        if (f.start > lastIdx) {
+            result.push(fullText.slice(lastIdx, f.start));
+        }
+
+        const html = renderToString(f.latex, f.display);
+        result.push(
+            <span
+                className={f.display ? "vc-latex-block" : "vc-latex-inline"}
+                dangerouslySetInnerHTML={{ __html: html }}
+            />
+        );
+
+        lastIdx = f.end;
+    }
+
+    if (lastIdx < fullText.length) {
+        result.push(fullText.slice(lastIdx));
+    }
+
+    return result;
+}
+
+export default definePlugin({
+    name: "LatexMath",
+    description: "Renders LaTeX math expressions in Discord messages using $$ and $ delimiters",
+    authors: [Devs.watchthelight],
+    settings,
+
+    patches: [
+        {
+            find: '["strong","em","u","text","inlineCode","s","spoiler"]',
+            replacement: {
+                match: /(?=return{hasSpoilerEmbeds:\i,hasBailedAst:\i,content:(\i)})/,
+                replace: (_, content: string) => `${content}=$self.processLatex(${content});`,
+            },
+        },
+    ],
+
+    async start() {
+        await loadKaTeX(settings.store.cdnUrl || undefined);
+    },
+
+    stop() {
+        unloadKaTeX();
+    },
+
+    processLatex(content: any[]): any[] {
+        if (!isLoaded()) return content;
+
+        const enableBlock = settings.store.enableBlockMath;
+        const enableInline = settings.store.enableInlineMath;
+        if (!enableBlock && !enableInline) return content;
+
+        const fullText = content.map(extractText).join("");
+        if (!fullText.includes("$")) return content;
+
+        return buildLatexContent(fullText, enableBlock, enableInline) ?? content;
+    },
+});

--- a/src/plugins/latexMath/katex.ts
+++ b/src/plugins/latexMath/katex.ts
@@ -1,0 +1,69 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 watchthelight
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Logger } from "@utils/Logger";
+
+const logger = new Logger("LatexMath");
+const DEFAULT_CDN = "https://cdn.jsdelivr.net/npm/katex@0.16.11/dist";
+
+let katexInstance: any = null;
+let loadPromise: Promise<void> | null = null;
+let linkEl: HTMLLinkElement | null = null;
+
+export async function loadKaTeX(cdnBase?: string): Promise<void> {
+    if (katexInstance) return;
+    if (loadPromise) return loadPromise;
+
+    const base = cdnBase || DEFAULT_CDN;
+
+    loadPromise = (async () => {
+        try {
+            linkEl = document.createElement("link");
+            linkEl.rel = "stylesheet";
+            linkEl.href = `${base}/katex.min.css`;
+            document.head.appendChild(linkEl);
+
+            const res = await fetch(`${base}/katex.min.js`);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const js = await res.text();
+            (0, eval)(js);
+
+            katexInstance = (window as any).katex;
+            if (!katexInstance) throw new Error("KaTeX global not found after eval");
+
+            logger.info("KaTeX loaded successfully");
+        } catch (e) {
+            logger.error("Failed to load KaTeX:", e);
+            loadPromise = null;
+            throw e;
+        }
+    })();
+
+    return loadPromise;
+}
+
+export function unloadKaTeX(): void {
+    linkEl?.remove();
+    linkEl = null;
+    katexInstance = null;
+    loadPromise = null;
+    delete (window as any).katex;
+}
+
+export function isLoaded(): boolean {
+    return katexInstance != null;
+}
+
+export function renderToString(latex: string, displayMode: boolean): string {
+    if (!katexInstance) return latex;
+    return katexInstance.renderToString(latex, {
+        displayMode,
+        throwOnError: false,
+        errorColor: "#cc0000",
+        trust: true,
+        strict: false,
+    });
+}

--- a/src/plugins/latexMath/latex.css
+++ b/src/plugins/latexMath/latex.css
@@ -1,0 +1,33 @@
+.vc-latex-block {
+    display: block;
+    text-align: left;
+    margin: 8px 0;
+    overflow-x: auto;
+    padding: 4px;
+}
+
+.vc-latex-inline {
+    display: inline;
+    vertical-align: middle;
+}
+
+.vc-latex-block .katex-display {
+    text-align: left !important;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+.vc-latex-block .katex-display > .katex {
+    text-align: left !important;
+}
+
+.vc-latex-block .katex,
+.vc-latex-inline .katex {
+    color: var(--text-normal);
+    font-size: 1.1em;
+}
+
+.vc-latex-block .katex-error,
+.vc-latex-inline .katex-error {
+    color: var(--text-danger);
+}

--- a/src/plugins/latexMath/settings.ts
+++ b/src/plugins/latexMath/settings.ts
@@ -1,0 +1,26 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 watchthelight
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    enableBlockMath: {
+        type: OptionType.BOOLEAN,
+        description: "Render $$...$$ as display (block) math",
+        default: true,
+    },
+    enableInlineMath: {
+        type: OptionType.BOOLEAN,
+        description: "Render $...$ as inline math (may conflict with currency symbols)",
+        default: false,
+    },
+    cdnUrl: {
+        type: OptionType.STRING,
+        description: "Custom KaTeX CDN base URL (leave blank for default)",
+        default: "",
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    watchthelight: {
+        name: "watchthelight",
+        id: 697169405422862417n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Summary

- Adds a new plugin that renders LaTeX math expressions in Discord messages using KaTeX
- Detects `$$...$$` delimiters for display (block) math, with optional `$...$` for inline math
- Loads KaTeX from jsDelivr CDN at runtime via `fetch()` (same pattern as ShikiCodeblocks)
- Patches the markdown parser output to intercept the content array and replace LaTeX expressions with rendered math elements
- Reconstructs original text from the content array, reinserting `_` for `<em>` nodes to handle Discord's markdown converting LaTeX subscript underscores into italic formatting

## Settings

| Setting | Default | Description |
|---------|---------|-------------|
| Block math (`$$...$$`) | Enabled | Renders display math |
| Inline math (`$...$`) | Disabled | Opt-in to avoid currency symbol conflicts |
| Custom CDN URL | Empty | Override KaTeX CDN source |

## Test plan

- [ ] `$$E = mc^2$$` renders as block math
- [ ] `$$\frac{\text{Area}(\gamma_A)}{4\,G_N}$$` renders fractions and subscripts correctly
- [ ] `$$\partial_i\partial_j E_{ij}$$` renders correctly despite underscores being parsed as italic by Discord
- [ ] `I paid $5` does NOT render as math
- [ ] `` `$$code$$` `` does NOT render inside code blocks
- [ ] `$$invalid \command$$` shows KaTeX error inline, does not crash
- [ ] Toggling settings on/off works correctly
- [ ] Plugin start/stop lifecycle loads and cleans up KaTeX properly