### PR TITLE
feat: Add Pronouns Autofetch for userMessagesPronouns

### DIFF
--- a/src/plugins/userMessagesPronouns/PronounsChatComponent.tsx
+++ b/src/plugins/userMessagesPronouns/PronounsChatComponent.tsx
@@ -18,17 +18,32 @@
 
 import { getUserSettingLazy } from "@api/UserSettings";
 import ErrorBoundary from "@components/ErrorBoundary";
-import { getIntlMessage } from "@utils/discord";
+import { fetchUserProfile, getCurrentChannel, getIntlMessage } from "@utils/discord";
 import { classes } from "@utils/misc";
 import { Message } from "@vencord/discord-types";
 import { findCssClassesLazy } from "@webpack";
-import { Tooltip, UserStore } from "@webpack/common";
+import { Tooltip, useEffect, UserProfileStore, UserStore } from "@webpack/common";
 
 import { settings } from "./settings";
 import { useFormattedPronouns } from "./utils";
 
 const TimestampClasses = findCssClassesLazy("timestampInline", "timestamp");
 const MessageDisplayCompact = getUserSettingLazy("textAndImages", "messageDisplayCompact")!;
+
+const fetchingIds = new Set<string>();
+
+async function fetchWithRetry(id: string, guildId: string | undefined) {
+    try {
+        await fetchUserProfile(id, { guild_id: guildId });
+    } catch (e: any) {
+        if (e?.status === 429) {
+            await new Promise(r => setTimeout(r, (e?.body?.retry_after ?? 10) * 1000));
+            await fetchWithRetry(id, guildId);
+        }
+    } finally {
+        fetchingIds.delete(id);
+    }
+}
 
 const AUTO_MODERATION_ACTION = 24;
 
@@ -43,6 +58,13 @@ function shouldShow(message: Message): boolean {
 
 function PronounsChatComponent({ message }: { message: Message; }) {
     const pronouns = useFormattedPronouns(message.author.id);
+
+    useEffect(() => {
+        const { id } = message.author;
+        if (!settings.store.autoFetch || UserProfileStore.getUserProfile(id) || fetchingIds.has(id)) return;
+        fetchingIds.add(id);
+        fetchWithRetry(id, getCurrentChannel()?.getGuildId());
+    }, [message.author.id]);
 
     return pronouns && (
         <Tooltip text={getIntlMessage("USER_PROFILE_PRONOUNS")}>

--- a/src/plugins/userMessagesPronouns/index.ts
+++ b/src/plugins/userMessagesPronouns/index.ts
@@ -26,7 +26,7 @@ import { settings } from "./settings";
 migratePluginSettings("UserMessagesPronouns", "PronounDB");
 export default definePlugin({
     name: "UserMessagesPronouns",
-    authors: [Devs.Tyman, Devs.TheKodeToad, Devs.Ven, Devs.Elvyra],
+    authors: [Devs.Tyman, Devs.TheKodeToad, Devs.Ven, Devs.Elvyra, Devs.pattersonuwu],
     description: "Adds pronouns to chat user messages",
     settings,
 

--- a/src/plugins/userMessagesPronouns/settings.ts
+++ b/src/plugins/userMessagesPronouns/settings.ts
@@ -44,5 +44,10 @@ export const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         description: "Enable or disable showing pronouns for yourself",
         default: true
+    },
+    autoFetch: {
+        type: OptionType.BOOLEAN,
+        description: "Automatically fetch pronouns for others when you see them in chat",
+        default: true
     }
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    pattersonuwu: {
+        name: "patty",
+        id: 843230753734918154n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Adds option for pronouns auto-fetching, as before the plugin would only work with user's profiles that you yourself clicked on and opened. 

For the plugin [userMessagesPronouns](https://github.com/Vendicated/Vencord/tree/main/src/plugins/userMessagesPronouns)