### PR TITLE
feat: add QuestCompleter plugin

### DIFF
--- a/src/plugins/questCompleter/index.tsx
+++ b/src/plugins/questCompleter/index.tsx
@@ -1,0 +1,513 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import definePlugin from "@utils/types";
+import { findByPropsLazy, findComponentByCodeLazy } from "@webpack";
+import { ChannelStore, FluxDispatcher, GuildChannelStore, Popout, RestAPI, RunningGameStore, useEffect, useRef, useState } from "@webpack/common";
+import type { PropsWithChildren } from "react";
+
+const HeaderBarIcon = findComponentByCodeLazy(".HEADER_BAR_BADGE_BOTTOM,", 'position:"bottom"');
+
+const QuestsStore = findByPropsLazy("getQuest", "quests");
+const ApplicationStreamingStore = findByPropsLazy("getStreamerActiveStreamMetadata");
+
+const SUPPORTED_TASKS = ["WATCH_VIDEO", "PLAY_ON_DESKTOP", "STREAM_ON_DESKTOP", "PLAY_ACTIVITY", "WATCH_VIDEO_ON_MOBILE"];
+
+const globalProgress: QuestProgress = {};
+const progressListeners = new Set<() => void>();
+
+function setGlobalProgress(questId: string, update: Partial<QuestProgressEntry>) {
+    globalProgress[questId] = { ...globalProgress[questId], ...update } as QuestProgressEntry;
+    progressListeners.forEach(fn => fn());
+}
+
+function useGlobalProgress(): QuestProgress {
+    const [, forceUpdate] = useState(0);
+    useEffect(() => {
+        const listener = () => forceUpdate(n => n + 1);
+        progressListeners.add(listener);
+        return () => { progressListeners.delete(listener); };
+    }, []);
+    return { ...globalProgress };
+}
+
+interface CancelToken {
+    cancelled: boolean;
+    cleanup?: () => void;
+}
+
+const cancelTokens = new Map<string, CancelToken>();
+
+function cancelQuest(questId: string) {
+    const token = cancelTokens.get(questId);
+    if (token) {
+        token.cancelled = true;
+        token.cleanup?.();
+        cancelTokens.delete(questId);
+    }
+}
+
+interface QuestProgressEntry {
+    status: "idle" | "running" | "done" | "error" | "paused";
+    progress: number;
+    total: number;
+    message: string;
+}
+
+interface QuestProgress {
+    [questId: string]: QuestProgressEntry;
+}
+
+function getQuests() {
+    try {
+        const quests = [...QuestsStore.quests.values()];
+        return quests.filter((x: any) =>
+            x.userStatus?.enrolledAt &&
+            !x.userStatus?.completedAt &&
+            new Date(x.config.expiresAt).getTime() > Date.now() &&
+            SUPPORTED_TASKS.find(y => Object.keys((x.config.taskConfig ?? x.config.taskConfigV2).tasks).includes(y))
+        );
+    } catch {
+        return [];
+    }
+}
+
+function getTaskName(quest: any): string {
+    const taskConfig = quest.config.taskConfig ?? quest.config.taskConfigV2;
+    return SUPPORTED_TASKS.find(x => taskConfig.tasks[x] != null) ?? "UNKNOWN";
+}
+
+function getTaskLabel(taskName: string): string {
+    switch (taskName) {
+        case "WATCH_VIDEO":
+        case "WATCH_VIDEO_ON_MOBILE":
+            return "Watch Video";
+        case "PLAY_ON_DESKTOP": return "Play Game";
+        case "STREAM_ON_DESKTOP": return "Stream";
+        case "PLAY_ACTIVITY": return "Play Activity";
+        default: return taskName;
+    }
+}
+
+function formatTime(seconds: number): string {
+    const mins = Math.ceil(seconds / 60);
+    if (mins < 60) return `${mins}m`;
+    const hours = Math.floor(mins / 60);
+    const remainMins = mins % 60;
+    return `${hours}h ${remainMins}m`;
+}
+
+function getExpiryText(expiresAt: string): string {
+    const diff = new Date(expiresAt).getTime() - Date.now();
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    if (days > 0) return `${days}d ${hours}h left`;
+    return `${hours}h left`;
+}
+
+function getQuestImageUrl(quest: any): string | null {
+    const { application, assets } = quest.config;
+    if (assets?.hero) {
+        return `https://cdn.discordapp.com/${assets.hero}?format=webp&width=128&height=128`;
+    }
+    if (assets?.questBarHero) {
+        return `https://cdn.discordapp.com/${assets.questBarHero}?format=webp&width=128&height=128`;
+    }
+    if (application?.icon) {
+        return `https://cdn.discordapp.com/app-icons/${application.id}/${application.icon}.webp?size=64`;
+    }
+    return null;
+}
+
+type UpdateFn = (questId: string, update: Partial<QuestProgressEntry>) => void;
+
+async function completeQuest(quest: any, updateProgress: UpdateFn) {
+    const questId = quest.id;
+    const taskConfig = quest.config.taskConfig ?? quest.config.taskConfigV2;
+    const taskName = getTaskName(quest);
+    const secondsNeeded = taskConfig.tasks[taskName].target;
+    let secondsDone = quest.userStatus?.progress?.[taskName]?.value ?? 0;
+    const applicationId = quest.config.application.id;
+    const applicationName = quest.config.application.name;
+    const pid = Math.floor(Math.random() * 30000) + 1000;
+
+    const token: CancelToken = { cancelled: false };
+    cancelTokens.set(questId, token);
+
+    updateProgress(questId, { status: "running", progress: secondsDone, total: secondsNeeded, message: "Starting..." });
+
+    try {
+        if (taskName === "WATCH_VIDEO" || taskName === "WATCH_VIDEO_ON_MOBILE") {
+            const maxFuture = 10, speed = 7, interval = 1;
+            const enrolledAt = new Date(quest.userStatus.enrolledAt).getTime();
+            let completed = false;
+
+            while (true) {
+                if (token.cancelled) {
+                    updateProgress(questId, { status: "paused", message: "Paused" });
+                    return;
+                }
+                const maxAllowed = Math.floor((Date.now() - enrolledAt) / 1000) + maxFuture;
+                const diff = maxAllowed - secondsDone;
+                const timestamp = secondsDone + speed;
+                if (diff >= speed) {
+                    const res = await RestAPI.post({
+                        url: `/quests/${questId}/video-progress`,
+                        body: { timestamp: Math.min(secondsNeeded, timestamp + Math.random()) }
+                    });
+                    completed = res.body.completed_at != null;
+                    secondsDone = Math.min(secondsNeeded, timestamp);
+                    updateProgress(questId, { progress: secondsDone, message: `Watching video... ${formatTime(secondsNeeded - secondsDone)}` });
+                }
+                if (timestamp >= secondsNeeded) break;
+                await new Promise(resolve => setTimeout(resolve, interval * 1000));
+            }
+            if (!completed) {
+                await RestAPI.post({ url: `/quests/${questId}/video-progress`, body: { timestamp: secondsNeeded } });
+            }
+            updateProgress(questId, { status: "done", progress: secondsNeeded, message: "Completed!" });
+
+        } else if (taskName === "PLAY_ON_DESKTOP") {
+            if (typeof DiscordNative === "undefined") {
+                updateProgress(questId, { status: "error", message: "Requires desktop app" });
+                return;
+            }
+            const res = await RestAPI.get({ url: `/applications/public?application_ids=${applicationId}` });
+            const appData = res.body[0];
+            const exeName = appData.executables?.find((x: any) => x.os === "win32")?.name?.replace(">", "") ?? appData.name.replace(/[/\\:*?"<>|]/g, "");
+
+            const fakeGame = {
+                cmdLine: `C:\\Program Files\\${appData.name}\\${exeName}`,
+                exeName,
+                exePath: `c:/program files/${appData.name.toLowerCase()}/${exeName}`,
+                hidden: false,
+                isLauncher: false,
+                id: applicationId,
+                name: appData.name,
+                pid,
+                pidPath: [pid],
+                processName: appData.name,
+                start: Date.now(),
+                distributor: null,
+                lastFocused: Date.now(),
+                lastLaunched: Date.now(),
+                nativeProcessObserverId: 0,
+            } as any;
+
+            const realGames = RunningGameStore.getRunningGames();
+            const fakeGames = [fakeGame] as any;
+            const realGetRunningGames = RunningGameStore.getRunningGames;
+            const realGetGameForPID = RunningGameStore.getGameForPID;
+            RunningGameStore.getRunningGames = () => fakeGames;
+            RunningGameStore.getGameForPID = (p: number) => fakeGames.find((x: any) => x.pid === p) ?? null;
+            FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: realGames, added: [fakeGame], games: fakeGames } as any);
+
+            updateProgress(questId, { message: `Spoofing ${applicationName}... ${formatTime(secondsNeeded - secondsDone)}` });
+
+            const restoreGames = () => {
+                RunningGameStore.getRunningGames = realGetRunningGames;
+                RunningGameStore.getGameForPID = realGetGameForPID;
+                FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: [fakeGame], added: [], games: [] } as any);
+            };
+
+            await new Promise<void>((resolve, reject) => {
+                const fn = (data: any) => {
+                    const progress = quest.config.configVersion === 1
+                        ? data.userStatus.streamProgressSeconds
+                        : Math.floor(data.userStatus.progress.PLAY_ON_DESKTOP.value);
+                    updateProgress(questId, { progress, message: `Playing ${applicationName}... ${formatTime(secondsNeeded - progress)}` });
+
+                    if (progress >= secondsNeeded) {
+                        restoreGames();
+                        FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", fn);
+                        resolve();
+                    }
+                };
+                token.cleanup = () => {
+                    restoreGames();
+                    FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", fn);
+                    reject(new Error("paused"));
+                };
+                FluxDispatcher.subscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", fn);
+            });
+            updateProgress(questId, { status: "done", progress: secondsNeeded, message: "Completed!" });
+
+        } else if (taskName === "STREAM_ON_DESKTOP") {
+            if (typeof DiscordNative === "undefined") {
+                updateProgress(questId, { status: "error", message: "Requires desktop app" });
+                return;
+            }
+            const realFunc = ApplicationStreamingStore.getStreamerActiveStreamMetadata;
+            ApplicationStreamingStore.getStreamerActiveStreamMetadata = () => ({
+                id: applicationId,
+                pid,
+                sourceName: null
+            });
+
+            updateProgress(questId, { message: `Stream spoofed to ${applicationName}. Stream any window in VC!` });
+
+            const restoreStream = () => {
+                ApplicationStreamingStore.getStreamerActiveStreamMetadata = realFunc;
+            };
+
+            await new Promise<void>((resolve, reject) => {
+                const fn = (data: any) => {
+                    const progress = quest.config.configVersion === 1
+                        ? data.userStatus.streamProgressSeconds
+                        : Math.floor(data.userStatus.progress.STREAM_ON_DESKTOP.value);
+                    updateProgress(questId, { progress, message: `Streaming... ${formatTime(secondsNeeded - progress)}` });
+
+                    if (progress >= secondsNeeded) {
+                        restoreStream();
+                        FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", fn);
+                        resolve();
+                    }
+                };
+                token.cleanup = () => {
+                    restoreStream();
+                    FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", fn);
+                    reject(new Error("paused"));
+                };
+                FluxDispatcher.subscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", fn);
+            });
+            updateProgress(questId, { status: "done", progress: secondsNeeded, message: "Completed!" });
+
+        } else if (taskName === "PLAY_ACTIVITY") {
+            const channels = ChannelStore.getSortedPrivateChannels?.() ?? [];
+            let channelId = channels[0]?.id;
+            if (!channelId) {
+                const guilds = Object.values(GuildChannelStore.getAllGuilds()).find((x: any) => x != null && x.VOCAL?.length > 0) as any;
+                channelId = guilds?.VOCAL?.[0]?.channel?.id;
+            }
+            if (!channelId) {
+                updateProgress(questId, { status: "error", message: "No channel found" });
+                return;
+            }
+            const streamKey = `call:${channelId}:1`;
+
+            while (true) {
+                if (token.cancelled) {
+                    updateProgress(questId, { status: "paused", message: "Paused" });
+                    return;
+                }
+                const heartbeatRes = await RestAPI.post({
+                    url: `/quests/${questId}/heartbeat`,
+                    body: { stream_key: streamKey, terminal: false }
+                });
+                const progress = heartbeatRes.body.progress.PLAY_ACTIVITY.value;
+                updateProgress(questId, { progress, message: `Activity... ${formatTime(secondsNeeded - progress)}` });
+
+                if (progress >= secondsNeeded) {
+                    await RestAPI.post({
+                        url: `/quests/${questId}/heartbeat`,
+                        body: { stream_key: streamKey, terminal: true }
+                    });
+                    break;
+                }
+                await new Promise(resolve => setTimeout(resolve, 20 * 1000));
+            }
+            updateProgress(questId, { status: "done", progress: secondsNeeded, message: "Completed!" });
+        }
+    } catch (e: any) {
+        if (e?.message === "paused") {
+            updateProgress(questId, { status: "paused", message: "Paused" });
+        } else {
+            updateProgress(questId, { status: "error", message: e?.message ?? "Error" });
+        }
+    } finally {
+        cancelTokens.delete(questId);
+    }
+}
+
+const QUEST_ICON_PATH = "M7.5 21.7a8.95 8.95 0 0 1 9 0 1 1 0 0 0 1-1.73c-.6-.35-1.24-.64-1.9-.87.54-.3 1.05-.65 1.52-1.07a3.98 3.98 0 0 0 5.49-1.8.77.77 0 0 0-.24-.95 3.98 3.98 0 0 0-2.02-.76A4 4 0 0 0 23 10.47a.76.76 0 0 0-.71-.71 4.06 4.06 0 0 0-1.6.22 3.99 3.99 0 0 0 .54-5.35.77.77 0 0 0-.95-.24c-.75.36-1.37.95-1.77 1.67V6a4 4 0 0 0-4.9-3.9.77.77 0 0 0-.6.72 4 4 0 0 0 3.7 4.17c.89 1.3 1.3 2.95 1.3 4.51 0 3.66-2.75 6.5-6 6.5s-6-2.84-6-6.5c0-1.56.41-3.21 1.3-4.51A4 4 0 0 0 11 2.82a.77.77 0 0 0-.6-.72 4.01 4.01 0 0 0-4.9 3.96A4.02 4.02 0 0 0 3.73 4.4a.77.77 0 0 0-.95.24 3.98 3.98 0 0 0 .55 5.35 4 4 0 0 0-1.6-.22.76.76 0 0 0-.72.71l-.01.28a4 4 0 0 0 2.65 3.77c-.75.06-1.45.33-2.02.76-.3.22-.4.62-.24.95a4 4 0 0 0 5.49 1.8c.47.42.98.78 1.53 1.07-.67.23-1.3.52-1.91.87a1 1 0 1 0 1 1.73Z";
+
+function QuestIcon({ className }: { className?: string; }) {
+    return (
+        <svg viewBox="0 0 24 24" width={20} height={20} fill="none" className={className ?? "vc-quest-header-icon"}>
+            <path fill="currentColor" d={QUEST_ICON_PATH} />
+        </svg>
+    );
+}
+
+function QuestCard({ quest, progressData, onComplete, onPause }: {
+    quest: any;
+    progressData?: QuestProgressEntry;
+    onComplete: () => void;
+    onPause: () => void;
+}) {
+    const taskName = getTaskName(quest);
+    const taskConfig = quest.config.taskConfig ?? quest.config.taskConfigV2;
+    const secondsNeeded = taskConfig.tasks[taskName].target;
+    const secondsDone = progressData?.progress ?? quest.userStatus?.progress?.[taskName]?.value ?? 0;
+    const pct = Math.min(100, (secondsDone / secondsNeeded) * 100);
+    const status = progressData?.status ?? "idle";
+    const imageUrl = getQuestImageUrl(quest);
+
+    return (
+        <div className="vc-quest-card">
+            <div className="vc-quest-card-hero">
+                {imageUrl && <img className="vc-quest-card-hero-img" src={imageUrl} alt="" />}
+                <div className="vc-quest-card-hero-overlay" />
+                <div className="vc-quest-card-hero-info">
+                    <div className="vc-quest-card-name">{quest.config.messages.questName}</div>
+                    <div className="vc-quest-card-expires">{getExpiryText(quest.config.expiresAt)}</div>
+                </div>
+            </div>
+            <div className="vc-quest-card-body">
+                <div className="vc-quest-card-meta">
+                    <div className="vc-quest-card-app">{quest.config.application.name}</div>
+                    <div className="vc-quest-card-task">{getTaskLabel(taskName)}</div>
+                </div>
+                <div className="vc-quest-progress-wrap">
+                    <div className="vc-quest-progress-bar">
+                        <div className="vc-quest-progress-fill" style={{ width: `${pct}%` }} />
+                    </div>
+                    <div className="vc-quest-progress-text">
+                        <span>{formatTime(secondsDone)} / {formatTime(secondsNeeded)}</span>
+                        <span className="vc-quest-progress-pct">{Math.round(pct)}%</span>
+                    </div>
+                </div>
+                {status === "running" && (
+                    <div className="vc-quest-status">
+                        <div className="vc-quest-status-dot" />
+                        <span className="vc-quest-status-text">{progressData?.message}</span>
+                    </div>
+                )}
+                {status === "paused" && (
+                    <div className="vc-quest-status-paused">
+                        <span>PAUSED // click resume to continue</span>
+                    </div>
+                )}
+                {status === "error" && (
+                    <div className="vc-quest-status-error">
+                        <span>{progressData?.message}</span>
+                    </div>
+                )}
+                <button
+                    className={`vc-quest-complete-btn ${status === "running" ? "vc-quest-running" : ""} ${status === "done" ? "vc-quest-done" : ""} ${status === "paused" ? "vc-quest-paused" : ""}`}
+                    disabled={status === "done"}
+                    onClick={status === "running" ? onPause : onComplete}
+                >
+                    {status === "idle" && ">> EXECUTE"}
+                    {status === "running" && "|| PAUSE"}
+                    {status === "done" && "// DONE"}
+                    {status === "error" && ">> RETRY"}
+                    {status === "paused" && "> RESUME"}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+function QuestPopout() {
+    const [quests, setQuests] = useState<any[]>([]);
+    const progress = useGlobalProgress();
+
+    useEffect(() => {
+        setQuests(getQuests());
+    }, []);
+
+    return (
+        <div className="vc-quest-popout">
+            <div className="vc-quest-header">
+                <QuestIcon />
+                <span className="vc-quest-header-title">Quests</span>
+                {quests.length > 0 && (
+                    <span className="vc-quest-header-count">{quests.length}</span>
+                )}
+            </div>
+            <div className="vc-quest-list">
+                {quests.length === 0 ? (
+                    <div className="vc-quest-empty">
+                        <div className="vc-quest-empty-icon">
+                            <QuestIcon />
+                        </div>
+                        <div className="vc-quest-empty-text">No Quests Available</div>
+                        <div className="vc-quest-empty-sub">Check back later for new quests</div>
+                    </div>
+                ) : (
+                    quests.map((quest: any) => (
+                        <QuestCard
+                            key={quest.id}
+                            quest={quest}
+                            progressData={progress[quest.id]}
+                            onComplete={() => completeQuest(quest, setGlobalProgress)}
+                            onPause={() => cancelQuest(quest.id)}
+                        />
+                    ))
+                )}
+            </div>
+            <div className="vc-quest-footer">
+                <a
+                    className="vc-quest-footer-link"
+                    href="https://www.kirakohler.es"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    by Kira Kohler
+                </a>
+            </div>
+        </div>
+    );
+}
+
+function QuestPopoutButton() {
+    const buttonRef = useRef(null);
+    const [show, setShow] = useState(false);
+
+    return (
+        <Popout
+            position="bottom"
+            align="right"
+            animation={Popout.Animation.NONE}
+            shouldShow={show}
+            onRequestClose={() => setShow(false)}
+            targetElementRef={buttonRef}
+            renderPopout={() => <QuestPopout />}
+        >
+            {(_, { isShown }) => (
+                <HeaderBarIcon
+                    ref={buttonRef}
+                    className="vc-quest-btn"
+                    onClick={() => setShow(v => !v)}
+                    tooltip={isShown ? null : "Quest Completer"}
+                    icon={() => <QuestIcon className="vc-quest-icon" />}
+                    selected={isShown}
+                />
+            )}
+        </Popout>
+    );
+}
+
+export default definePlugin({
+    name: "QuestCompleter",
+    description: "Adds a toolbar button to view and auto-complete Discord Quests",
+    authors: [{ name: "kira_kohler", id: 839217437383983184n }],
+
+    patches: [
+        {
+            find: '?"BACK_FORWARD_NAVIGATION":',
+            replacement: {
+                match: /(?<=trailing:.{0,50})\i\.Fragment,(?=\{children:\[)/,
+                replace: "$self.TrailingWrapper,"
+            }
+        }
+    ],
+
+    TrailingWrapper({ children }: PropsWithChildren) {
+        return (
+            <>
+                {children}
+                <ErrorBoundary key="vc-quest-completer" noop>
+                    <QuestPopoutButton />
+                </ErrorBoundary>
+            </>
+        );
+    },
+});

--- a/src/plugins/questCompleter/style.css
+++ b/src/plugins/questCompleter/style.css
@@ -1,0 +1,588 @@
+.vc-quest-btn,
+.vc-quest-icon {
+    -webkit-app-region: no-drag;
+}
+
+.vc-quest-icon {
+    color: var(--interactive-icon-default);
+    transition: color 0.2s ease, filter 0.2s ease;
+}
+
+.vc-quest-btn[class*="selected"] .vc-quest-icon {
+    color: #c77dff;
+    filter: drop-shadow(0 0 8px #b44affaa);
+}
+
+.vc-quest-btn:hover .vc-quest-icon {
+    color: #c77dff;
+    filter: drop-shadow(0 0 6px #b44aff88);
+}
+
+.vc-quest-popout {
+    width: 420px;
+    max-height: 560px;
+    background: #08060f;
+    border: 1px solid #b44aff30;
+    border-radius: 14px;
+    box-shadow:
+        0 0 40px rgb(180 74 255 / 12%),
+        0 12px 48px rgb(0 0 0 / 80%);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    animation: vc-quest-popout-in 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    transform-origin: top right;
+}
+
+@keyframes vc-quest-popout-in {
+    0% {
+        opacity: 0;
+        transform: scale(0.92) translateY(-8px);
+    }
+
+    100% {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
+}
+
+.vc-quest-popout::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+        repeating-linear-gradient(0deg,
+            transparent,
+            transparent 3px,
+            rgb(180 74 255 / 1.2%) 3px,
+            rgb(180 74 255 / 1.2%) 4px),
+        radial-gradient(ellipse at 20% 0%, rgb(180 74 255 / 4%) 0%, transparent 60%),
+        radial-gradient(ellipse at 80% 100%, rgb(123 47 255 / 3%) 0%, transparent 60%);
+    pointer-events: none;
+    z-index: 1;
+}
+
+.vc-quest-popout::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, #7b2fff, #b44aff, #e040fb, #b44aff, #7b2fff, transparent);
+    z-index: 3;
+    animation: vc-quest-border-flow 3s linear infinite;
+    background-size: 200% 100%;
+}
+
+@keyframes vc-quest-border-flow {
+    0% {
+        background-position: 0% 0;
+    }
+
+    100% {
+        background-position: 200% 0;
+    }
+}
+
+.vc-quest-header {
+    padding: 16px 20px 14px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    border-bottom: 1px solid #b44aff15;
+    background: linear-gradient(180deg, rgb(180 74 255 / 5%) 0%, transparent 100%);
+    position: relative;
+    z-index: 2;
+}
+
+.vc-quest-header-icon {
+    width: 24px;
+    height: 24px;
+    color: #b44aff;
+    filter: drop-shadow(0 0 10px #b44aff88);
+    animation: vc-quest-icon-pulse 3s ease-in-out infinite;
+}
+
+@keyframes vc-quest-icon-pulse {
+    0%,
+    100% {
+        filter: drop-shadow(0 0 8px #b44aff66);
+    }
+
+    50% {
+        filter: drop-shadow(0 0 14px #b44affbb);
+    }
+}
+
+.vc-quest-header-title {
+    font-size: 14px;
+    font-weight: 800;
+    color: #e2daf0;
+    text-transform: uppercase;
+    letter-spacing: 4px;
+    text-shadow: 0 0 15px rgb(180 74 255 / 50%);
+}
+
+.vc-quest-header-count {
+    margin-left: auto;
+    background: rgb(180 74 255 / 15%);
+    color: #c77dff;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 12px;
+    border: 1px solid #b44aff30;
+    box-shadow: 0 0 10px rgb(180 74 255 / 10%);
+}
+
+.vc-quest-list {
+    padding: 10px;
+    overflow-y: auto;
+    flex: 1;
+    scrollbar-width: none;
+    position: relative;
+    z-index: 2;
+}
+
+.vc-quest-list::-webkit-scrollbar {
+    display: none;
+}
+
+.vc-quest-card {
+    background: #0d0a18;
+    border: 1px solid #1e1735;
+    border-radius: 12px;
+    margin-bottom: 10px;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+    animation: vc-quest-card-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.vc-quest-card:nth-child(1) {
+    animation-delay: 0.05s;
+}
+
+.vc-quest-card:nth-child(2) {
+    animation-delay: 0.1s;
+}
+
+.vc-quest-card:nth-child(3) {
+    animation-delay: 0.15s;
+}
+
+.vc-quest-card:nth-child(4) {
+    animation-delay: 0.2s;
+}
+
+.vc-quest-card:nth-child(5) {
+    animation-delay: 0.25s;
+}
+
+.vc-quest-card:nth-child(6) {
+    animation-delay: 0.3s;
+}
+
+@keyframes vc-quest-card-in {
+    0% {
+        opacity: 0;
+        transform: translateX(-12px);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+.vc-quest-card:hover {
+    border-color: #b44aff40;
+    box-shadow: 0 0 25px rgb(180 74 255 / 8%);
+    transform: translateY(-2px);
+}
+
+.vc-quest-card:last-child {
+    margin-bottom: 0;
+}
+
+.vc-quest-card-hero {
+    position: relative;
+    height: 80px;
+    overflow: hidden;
+}
+
+.vc-quest-card-hero-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: brightness(0.4) saturate(1.2);
+    transition: filter 0.4s ease, transform 0.4s ease;
+}
+
+.vc-quest-card:hover .vc-quest-card-hero-img {
+    filter: brightness(0.5) saturate(1.4);
+    transform: scale(1.03);
+}
+
+.vc-quest-card-hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg,
+            rgb(13 10 24 / 20%) 0%,
+            rgb(13 10 24 / 95%) 100%);
+}
+
+.vc-quest-card-hero-info {
+    position: absolute;
+    bottom: 10px;
+    left: 14px;
+    right: 14px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+}
+
+.vc-quest-card-name {
+    font-size: 14px;
+    font-weight: 700;
+    color: #fff;
+    text-shadow: 0 1px 8px rgb(0 0 0 / 60%);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 70%;
+}
+
+.vc-quest-card-expires {
+    font-size: 10px;
+    color: #c77dff;
+    background: rgb(180 74 255 / 15%);
+    padding: 2px 8px;
+    border-radius: 8px;
+    border: 1px solid #b44aff25;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.vc-quest-card-body {
+    padding: 12px 14px 14px;
+}
+
+.vc-quest-card-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
+
+.vc-quest-card-app {
+    font-size: 11px;
+    color: #6a5d85;
+}
+
+.vc-quest-card-task {
+    font-size: 9px;
+    font-weight: 700;
+    color: #e040fb;
+    background: rgb(224 64 251 / 8%);
+    padding: 3px 8px;
+    border-radius: 4px;
+    border: 1px solid #e040fb20;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.vc-quest-progress-wrap {
+    margin-bottom: 12px;
+}
+
+.vc-quest-progress-bar {
+    height: 6px;
+    background: #130f22;
+    border-radius: 3px;
+    overflow: hidden;
+    position: relative;
+    border: 1px solid #1e173520;
+}
+
+.vc-quest-progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #7b2fff, #b44aff, #e040fb);
+    border-radius: 3px;
+    transition: width 0.5s ease;
+    box-shadow: 0 0 12px rgb(180 74 255 / 60%);
+    position: relative;
+}
+
+.vc-quest-progress-fill::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg,
+            transparent 0%,
+            rgb(255 255 255 / 30%) 50%,
+            transparent 100%);
+    animation: vc-quest-shimmer 1.5s infinite;
+}
+
+@keyframes vc-quest-shimmer {
+    0% {
+        transform: translateX(-100%);
+    }
+
+    100% {
+        transform: translateX(100%);
+    }
+}
+
+.vc-quest-progress-text {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 11px;
+    color: #6a5d85;
+    margin-top: 6px;
+}
+
+.vc-quest-progress-pct {
+    color: #c77dff;
+    font-weight: 700;
+    font-size: 12px;
+    text-shadow: 0 0 8px rgb(180 74 255 / 30%);
+}
+
+.vc-quest-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 10px;
+    margin-bottom: 10px;
+    padding: 6px 10px;
+    background: rgb(224 64 251 / 4%);
+    border-radius: 6px;
+    border: 1px solid #e040fb15;
+    animation: vc-quest-status-in 0.3s ease;
+}
+
+@keyframes vc-quest-status-in {
+    0% {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.vc-quest-status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #e040fb;
+    box-shadow: 0 0 8px #e040fb;
+    animation: vc-quest-blink 1.2s infinite;
+    flex-shrink: 0;
+}
+
+@keyframes vc-quest-blink {
+    0%,
+    100% {
+        opacity: 1;
+        box-shadow: 0 0 8px #e040fb;
+    }
+
+    50% {
+        opacity: 0.3;
+        box-shadow: 0 0 2px #e040fb;
+    }
+}
+
+.vc-quest-status-text {
+    color: #c77dff;
+}
+
+.vc-quest-status-paused {
+    padding: 6px 10px;
+    background: rgb(180 74 255 / 4%);
+    border-radius: 6px;
+    border: 1px solid #b44aff15;
+    margin-bottom: 10px;
+    animation: vc-quest-status-in 0.3s ease;
+}
+
+.vc-quest-status-paused span {
+    color: #8a7da8;
+    font-size: 10px;
+}
+
+.vc-quest-status-error {
+    padding: 6px 10px;
+    background: rgb(248 81 73 / 4%);
+    border-radius: 6px;
+    border: 1px solid #f8514920;
+    margin-bottom: 10px;
+    animation: vc-quest-status-in 0.3s ease;
+}
+
+.vc-quest-status-error span {
+    color: #f85149;
+    font-size: 10px;
+}
+
+.vc-quest-complete-btn {
+    width: 100%;
+    padding: 10px 0;
+    border: 1px solid #b44aff40;
+    border-radius: 8px;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 2.5px;
+    cursor: pointer;
+    transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(135deg, #7b2fff, #b44aff);
+    color: #fff;
+}
+
+.vc-quest-complete-btn::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg,
+            rgb(255 255 255 / 0%) 0%,
+            rgb(255 255 255 / 10%) 50%,
+            rgb(255 255 255 / 0%) 100%);
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+
+.vc-quest-complete-btn:hover::before {
+    opacity: 1;
+}
+
+.vc-quest-complete-btn:hover {
+    box-shadow:
+        0 0 30px rgb(180 74 255 / 40%),
+        0 4px 20px rgb(123 47 255 / 30%);
+    transform: translateY(-2px);
+    border-color: #b44aff66;
+}
+
+.vc-quest-complete-btn:active {
+    transform: translateY(0) scale(0.97);
+    transition: transform 0.1s ease;
+}
+
+.vc-quest-complete-btn:disabled {
+    background: #130f22;
+    color: #3a2d55;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
+    border-color: #1e173540;
+}
+
+.vc-quest-complete-btn:disabled::before {
+    display: none;
+}
+
+.vc-quest-complete-btn.vc-quest-running {
+    background: linear-gradient(135deg, #e040fb, #b44aff);
+    color: #fff;
+    border-color: #e040fb50;
+    animation: vc-quest-pulse 2s infinite;
+}
+
+@keyframes vc-quest-pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 8px rgb(224 64 251 / 30%);
+    }
+
+    50% {
+        box-shadow: 0 0 30px rgb(224 64 251 / 50%);
+    }
+}
+
+.vc-quest-complete-btn.vc-quest-done {
+    background: linear-gradient(135deg, #1a1230, #251a40);
+    color: #7b2fff;
+    border-color: #7b2fff25;
+}
+
+.vc-quest-complete-btn.vc-quest-paused {
+    background: #0d0a18;
+    color: #8a7da8;
+    border-color: #b44aff25;
+}
+
+.vc-quest-complete-btn.vc-quest-paused:hover {
+    color: #c77dff;
+    border-color: #b44aff40;
+    box-shadow: 0 0 20px rgb(180 74 255 / 20%);
+}
+
+.vc-quest-empty {
+    padding: 50px 20px;
+    text-align: center;
+    color: #6a5d85;
+    animation: vc-quest-card-in 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.vc-quest-empty-icon {
+    margin-bottom: 16px;
+    opacity: 0.2;
+}
+
+.vc-quest-empty-icon .vc-quest-header-icon {
+    width: 40px;
+    height: 40px;
+    color: #6a5d85;
+    filter: none;
+    animation: none;
+}
+
+.vc-quest-empty-text {
+    font-size: 13px;
+    font-weight: 700;
+    color: #6a5d85;
+    margin-bottom: 6px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+}
+
+.vc-quest-empty-sub {
+    font-size: 11px;
+    color: #3a2d55;
+}
+
+.vc-quest-footer {
+    padding: 10px 20px;
+    border-top: 1px solid #b44aff10;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    position: relative;
+    z-index: 2;
+    background: rgb(8 6 15 / 80%);
+}
+
+.vc-quest-footer-link {
+    font-size: 10px;
+    color: #5a4d75;
+    text-decoration: none;
+    letter-spacing: 1px;
+    transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+.vc-quest-footer-link:hover {
+    color: #c77dff;
+    text-shadow: 0 0 12px rgb(180 74 255 / 40%);
+    text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- Adds a toolbar button (quest icon) in the header bar to view and auto-complete enrolled Discord Quests
- Supports all quest types: video watching, game playing, streaming, and activities
- Includes pause/resume functionality and real-time progress tracking
- Quests are only fetched once when the popout is opened, no background polling