### PR TITLE
feat: add ExpandedReply plugin

### DIFF
--- a/src/plugins/expandedReply/index.tsx
+++ b/src/plugins/expandedReply/index.tsx
@@ -1,0 +1,207 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2026 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import "./style.css";
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import { copyWithToast, openImageModal } from "@utils/discord";
+import { classes } from "@utils/misc";
+import definePlugin from "@utils/types";
+import type { Message } from "@vencord/discord-types";
+import { findCssClassesLazy } from "@webpack";
+import { Parser, useEffect, useRef, useState } from "@webpack/common";
+
+const MarkupClasses = findCssClassesLazy("markup", "codeContainer");
+const MessageClasses = findCssClassesLazy("messageContent", "markupRtl");
+
+const enum ReferencedMessageState {
+    LOADED = 0,
+    NOT_LOADED = 1,
+    DELETED = 2,
+}
+
+type ReferencedMessage =
+    | { state: ReferencedMessageState.LOADED; message: Message; }
+    | { state: ReferencedMessageState.NOT_LOADED | ReferencedMessageState.DELETED; };
+
+interface ReplyProps {
+    referencedMessage: ReferencedMessage;
+    baseMessage: Message;
+}
+
+function ExpandedReplyBtn({ referencedMessage, baseMessage }: ReplyProps) {
+    const [expanded, setExpanded] = useState(false);
+    const wrapperRef = useRef<HTMLSpanElement>(null);
+    const popupRef = useRef<HTMLDivElement>(null);
+
+    if (referencedMessage.state !== ReferencedMessageState.LOADED) return null;
+
+    const msg = referencedMessage.message;
+    if (!msg.content && msg.attachments?.length === 0 && msg.embeds?.length === 0) return null;
+
+    useEffect(() => {
+        if (!expanded) return;
+
+        const handler = (e: MouseEvent) => {
+            if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+                setExpanded(false);
+            }
+        };
+
+        document.addEventListener("mousedown", handler);
+        return () => document.removeEventListener("mousedown", handler);
+    }, [expanded]);
+
+    useEffect(() => {
+        if (!expanded || !popupRef.current || !wrapperRef.current) return;
+
+        const position = () => {
+            const popup = popupRef.current;
+            if (!popup || !wrapperRef.current) return;
+
+            const replyBar = wrapperRef.current.closest("[class*='repliedMessage']");
+            const replyRect = replyBar?.getBoundingClientRect();
+            const btn = wrapperRef.current.getBoundingClientRect();
+
+            const left = replyRect ? replyRect.left : btn.left - 40;
+            const popupWidth = replyRect ? Math.min(replyRect.width, 500) : 480;
+
+            popup.style.left = `${left}px`;
+            popup.style.width = `${popupWidth}px`;
+
+            const spaceAbove = btn.top - 10;
+            const maxH = Math.min(320, spaceAbove - 10);
+            popup.style.maxHeight = `${Math.max(maxH, 100)}px`;
+            popup.style.bottom = `${window.innerHeight - btn.top + 4}px`;
+            popup.style.top = "auto";
+        };
+
+        requestAnimationFrame(position);
+    }, [expanded]);
+
+    return (
+        <span className="vc-expanded-reply-wrapper" ref={wrapperRef}>
+            <button
+                className="vc-expanded-reply-btn"
+                onClick={e => {
+                    e.stopPropagation();
+                    setExpanded(!expanded);
+                }}
+                aria-label={expanded ? "Collapse reply" : "Expand reply"}
+            >
+                <svg width="12" height="12" viewBox="0 0 24 24" className={expanded ? "vc-expanded-reply-chevron-open" : "vc-expanded-reply-chevron"}>
+                    <path fill="currentColor" d="M7 10l5 5 5-5z" />
+                </svg>
+            </button>
+            {expanded && (
+                <div className="vc-expanded-reply-content" ref={popupRef} onClick={e => e.stopPropagation()}>
+                    <div className="vc-expanded-reply-header">
+                        <img
+                            className="vc-expanded-reply-avatar"
+                            src={`https://cdn.discordapp.com/avatars/${(msg.author as any).id}/${(msg.author as any).avatar}.webp?size=32`}
+                            alt=""
+                        />
+                        <span className="vc-expanded-reply-author">
+                            @{(msg.author as any).username}
+                        </span>
+                        <button
+                            className="vc-expanded-reply-copy"
+                            onClick={() => copyWithToast(msg.content || "")}
+                            aria-label="Copy message"
+                        >
+                            <svg width="14" height="14" viewBox="0 0 24 24">
+                                <path fill="currentColor" d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+                            </svg>
+                        </button>
+                        <button
+                            className="vc-expanded-reply-close"
+                            onClick={() => setExpanded(false)}
+                            aria-label="Close"
+                        >
+                            <svg width="14" height="14" viewBox="0 0 24 24">
+                                <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+                            </svg>
+                        </button>
+                    </div>
+                    <div className="vc-expanded-reply-body">
+                        {msg.content && (
+                            <div className={classes(MarkupClasses.markup, MessageClasses.messageContent, "vc-expanded-reply-text")}>
+                                {Parser.parse(msg.content, false, {
+                                    channelId: baseMessage.channel_id,
+                                    messageId: msg.id,
+                                    allowLinks: true,
+                                    allowHeading: true,
+                                    allowList: true,
+                                    allowEmojiLinks: true,
+                                })}
+                            </div>
+                        )}
+                        {msg.attachments?.map((att: any) => {
+                            if (att.content_type?.startsWith("image/")) {
+                                return (
+                                    <img
+                                        key={att.id}
+                                        src={att.url}
+                                        className="vc-expanded-reply-image"
+                                        alt={att.filename}
+                                        loading="lazy"
+                                        onClick={() => openImageModal({
+                                            url: att.url,
+                                            width: att.width,
+                                            height: att.height,
+                                        })}
+                                    />
+                                );
+                            }
+                            if (att.content_type?.startsWith("video/")) {
+                                return (
+                                    <video
+                                        key={att.id}
+                                        src={att.url}
+                                        className="vc-expanded-reply-video"
+                                        controls
+                                        preload="metadata"
+                                    />
+                                );
+                            }
+                            return null;
+                        })}
+                    </div>
+                </div>
+            )}
+        </span>
+    );
+}
+
+export default definePlugin({
+    name: "ExpandedReply",
+    description: "Adds a button to expand replied message previews to show full content",
+    authors: [{ name: "kira_kohler", id: 839217437383983184n }],
+
+    patches: [
+        {
+            find: "#{intl::REPLY_QUOTE_MESSAGE_NOT_LOADED}",
+            replacement: {
+                match: /\.onClickReply,.+?}\),(?=\i,\i,\i\])/,
+                replace: "$&$self.ExpandedReplyBtn(arguments[0]),"
+            }
+        }
+    ],
+
+    ExpandedReplyBtn: ErrorBoundary.wrap(ExpandedReplyBtn, { noop: true }),
+});

--- a/src/plugins/expandedReply/index.tsx
+++ b/src/plugins/expandedReply/index.tsx
@@ -24,7 +24,7 @@ import { classes } from "@utils/misc";
 import definePlugin from "@utils/types";
 import type { Message } from "@vencord/discord-types";
 import { findCssClassesLazy } from "@webpack";
-import { Parser, useEffect, useRef, useState } from "@webpack/common";
+import { MessageStore, Parser, ReactDOM, useEffect, useRef, useState } from "@webpack/common";
 
 const MarkupClasses = findCssClassesLazy("markup", "codeContainer");
 const MessageClasses = findCssClassesLazy("messageContent", "markupRtl");
@@ -44,55 +44,344 @@ interface ReplyProps {
     baseMessage: Message;
 }
 
+function fmt(s: number) {
+    const m = Math.floor(s / 60);
+    const sec = Math.floor(s % 60);
+    return `${m}:${sec.toString().padStart(2, "0")}`;
+}
+
+function AudioPlayer({ src }: { src: string; }) {
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const [playing, setPlaying] = useState(false);
+    const [current, setCurrent] = useState(0);
+    const [duration, setDuration] = useState(0);
+
+    const toggle = () => {
+        const a = audioRef.current;
+        if (!a) return;
+        if (playing) a.pause(); else a.play();
+    };
+
+    return (
+        <div className="vc-expanded-reply-audio">
+            <audio
+                ref={audioRef}
+                src={src}
+                preload="metadata"
+                onPlay={() => setPlaying(true)}
+                onPause={() => setPlaying(false)}
+                onEnded={() => setPlaying(false)}
+                onTimeUpdate={() => setCurrent(audioRef.current?.currentTime ?? 0)}
+                onLoadedMetadata={() => setDuration(audioRef.current?.duration ?? 0)}
+            />
+            <button className="vc-expanded-reply-audio-play" onClick={toggle} aria-label={playing ? "Pause" : "Play"}>
+                {playing
+                    ? <svg width="14" height="14" viewBox="0 0 24 24"><path fill="currentColor" d="M6 19h4V5H6zm8-14v14h4V5z" /></svg>
+                    : <svg width="14" height="14" viewBox="0 0 24 24"><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
+                }
+            </button>
+            <input
+                className="vc-expanded-reply-audio-bar"
+                type="range"
+                min={0}
+                max={duration || 1}
+                step={0.01}
+                value={current}
+                onChange={e => {
+                    const a = audioRef.current;
+                    if (a) a.currentTime = Number(e.target.value);
+                }}
+            />
+            <span className="vc-expanded-reply-audio-time">
+                {fmt(current)} / {fmt(duration)}
+            </span>
+        </div>
+    );
+}
+
+function VideoControls({ playing, current, duration, volume, muted, onToggle, onToggleMute, onSeek, onVolume, onFullscreen }: {
+    playing: boolean; current: number; duration: number; volume: number; muted: boolean;
+    onToggle(): void; onToggleMute(): void; onSeek(v: number): void; onVolume(v: number): void; onFullscreen(): void;
+}) {
+    return (
+        <div className="vc-expanded-reply-video-controls" onClick={e => e.stopPropagation()}>
+            <button className="vc-expanded-reply-video-btn" onClick={onToggle} aria-label={playing ? "Pause" : "Play"}>
+                {playing
+                    ? <svg width="14" height="14" viewBox="0 0 24 24"><path fill="currentColor" d="M6 19h4V5H6zm8-14v14h4V5z" /></svg>
+                    : <svg width="14" height="14" viewBox="0 0 24 24"><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
+                }
+            </button>
+            <input
+                className="vc-expanded-reply-video-bar"
+                type="range" min={0} max={duration || 1} step={0.01} value={current}
+                style={{ "--pct": `${(current / (duration || 1)) * 100}%` } as React.CSSProperties}
+                onChange={e => onSeek(Number(e.target.value))}
+            />
+            <span className="vc-expanded-reply-video-time">{fmt(current)} / {fmt(duration)}</span>
+            <input
+                className="vc-expanded-reply-video-volume"
+                type="range" min={0} max={1} step={0.01} value={muted ? 0 : volume}
+                onChange={e => onVolume(Number(e.target.value))}
+            />
+            <button className="vc-expanded-reply-video-btn" onClick={onToggleMute} aria-label={muted ? "Unmute" : "Mute"}>
+                {muted || volume === 0
+                    ? <svg width="14" height="14" viewBox="0 0 24 24"><path fill="currentColor" d="M16.5 12A4.5 4.5 0 0 0 14 7.97v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z" /></svg>
+                    : <svg width="14" height="14" viewBox="0 0 24 24"><path fill="currentColor" d="M3 9v6h4l5 5V4L7 9H3zm13.5 3A4.5 4.5 0 0 0 14 7.97v8.05c1.48-.73 2.5-2.25 2.5-4.02z" /></svg>
+                }
+            </button>
+            <button className="vc-expanded-reply-video-btn" onClick={onFullscreen} aria-label="Fullscreen">
+                <svg width="14" height="14" viewBox="0 0 24 24"><path fill="currentColor" d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" /></svg>
+            </button>
+        </div>
+    );
+}
+
+function VideoPlayer({ src }: { src: string; }) {
+    const videoRef = useRef<HTMLVideoElement>(null);
+    const [playing, setPlaying] = useState(false);
+    const [current, setCurrent] = useState(0);
+    const [duration, setDuration] = useState(0);
+    const [volume, setVolume] = useState(1);
+    const [muted, setMuted] = useState(false);
+
+    const toggle = () => { const v = videoRef.current; if (!v) return; if (playing) v.pause(); else v.play(); };
+    const toggleMute = () => { const v = videoRef.current; if (!v) return; v.muted = !muted; setMuted(!muted); };
+    const seek = (val: number) => { const v = videoRef.current; if (v) v.currentTime = val; };
+    const changeVolume = (val: number) => { const v = videoRef.current; if (!v) return; v.volume = val; v.muted = val === 0; };
+
+    const requestFullscreen = () => {
+        const v = videoRef.current;
+        if (!v) return;
+        if (v.requestFullscreen) v.requestFullscreen();
+    };
+
+    return (
+        <div className="vc-expanded-reply-video-wrapper">
+            <video
+                ref={videoRef}
+                src={src}
+                className="vc-expanded-reply-video"
+                preload="metadata"
+                onClick={toggle}
+                onPlay={() => setPlaying(true)}
+                onPause={() => setPlaying(false)}
+                onEnded={() => setPlaying(false)}
+                onTimeUpdate={() => setCurrent(videoRef.current?.currentTime ?? 0)}
+                onLoadedMetadata={() => setDuration(videoRef.current?.duration ?? 0)}
+                onVolumeChange={() => { setVolume(videoRef.current?.volume ?? 1); setMuted(videoRef.current?.muted ?? false); }}
+            />
+            <VideoControls
+                playing={playing} current={current} duration={duration} volume={volume} muted={muted}
+                onToggle={toggle} onToggleMute={toggleMute} onSeek={seek} onVolume={changeVolume}
+                onFullscreen={requestFullscreen}
+            />
+        </div>
+    );
+}
+
+function CopyButton({ fullMsg }: { fullMsg: any; }) {
+    const [showMenu, setShowMenu] = useState(false);
+    const menuRef = useRef<HTMLDivElement>(null);
+
+    const mediaAtts: any[] = (fullMsg.attachments ?? []).filter((a: any) =>
+        a.content_type?.startsWith("image/") || a.content_type?.startsWith("video/") || a.content_type?.startsWith("audio/")
+    );
+    const hasText = !!fullMsg.content;
+    const hasMedia = mediaAtts.length > 0;
+
+    const mediaLabel = (a: any) => a.content_type?.startsWith("image/") ? "Copy image URL"
+        : a.content_type?.startsWith("video/") ? "Copy video URL"
+            : "Copy audio URL";
+
+    useEffect(() => {
+        if (!showMenu) return;
+        const onMouseDown = (e: MouseEvent) => {
+            if (menuRef.current && !menuRef.current.contains(e.target as Node)) setShowMenu(false);
+        };
+        document.addEventListener("mousedown", onMouseDown);
+        return () => document.removeEventListener("mousedown", onMouseDown);
+    }, [showMenu]);
+
+    const copyIcon = (
+        <svg width="14" height="14" viewBox="0 0 24 24">
+            <path fill="currentColor" d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+        </svg>
+    );
+
+    if (!hasText && mediaAtts.length === 1) {
+        return (
+            <button
+                className="vc-expanded-reply-copy"
+                onClick={() => copyWithToast(mediaAtts[0].url)}
+                aria-label="Copy"
+            >
+                {copyIcon}
+            </button>
+        );
+    }
+
+    if (!hasMedia) {
+        return (
+            <button
+                className="vc-expanded-reply-copy"
+                onClick={() => copyWithToast(fullMsg.content || "")}
+                aria-label="Copy"
+            >
+                {copyIcon}
+            </button>
+        );
+    }
+
+    return (
+        <div className="vc-expanded-reply-copy-wrapper" ref={menuRef}>
+            <button
+                className="vc-expanded-reply-copy"
+                onClick={() => setShowMenu(m => !m)}
+                aria-label="Copy"
+            >
+                {copyIcon}
+            </button>
+            {showMenu && (
+                <div className="vc-expanded-reply-copy-menu">
+                    {hasText && <button onClick={() => { copyWithToast(fullMsg.content); setShowMenu(false); }}>Copy text</button>}
+                    {mediaAtts.map((a, i) => (
+                        <button key={i} onClick={() => { copyWithToast(a.url); setShowMenu(false); }}>{mediaLabel(a)}</button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
 function ExpandedReplyBtn({ referencedMessage, baseMessage }: ReplyProps) {
     const [expanded, setExpanded] = useState(false);
     const wrapperRef = useRef<HTMLSpanElement>(null);
     const popupRef = useRef<HTMLDivElement>(null);
+    const [popupStyle, setPopupStyle] = useState<React.CSSProperties>({});
+    const isInFullscreen = useRef(false);
 
-    if (referencedMessage.state !== ReferencedMessageState.LOADED) return null;
-
-    const msg = referencedMessage.message;
-    if (!msg.content && msg.attachments?.length === 0 && msg.embeds?.length === 0) return null;
+    useEffect(() => {
+        const onFsChange = () => { isInFullscreen.current = !!document.fullscreenElement; };
+        document.addEventListener("fullscreenchange", onFsChange);
+        return () => document.removeEventListener("fullscreenchange", onFsChange);
+    }, []);
 
     useEffect(() => {
         if (!expanded) return;
 
-        const handler = (e: MouseEvent) => {
-            if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        const onMouseDown = (e: MouseEvent) => {
+            if (isInFullscreen.current || document.fullscreenElement) return;
+            if (popupRef.current && !popupRef.current.contains(e.target as Node) &&
+                wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
                 setExpanded(false);
             }
         };
 
-        document.addEventListener("mousedown", handler);
-        return () => document.removeEventListener("mousedown", handler);
+        const onScroll = () => { if (!isInFullscreen.current) setExpanded(false); };
+
+        document.addEventListener("mousedown", onMouseDown);
+        document.addEventListener("scroll", onScroll, true);
+        return () => {
+            document.removeEventListener("mousedown", onMouseDown);
+            document.removeEventListener("scroll", onScroll, true);
+        };
     }, [expanded]);
 
     useEffect(() => {
-        if (!expanded || !popupRef.current || !wrapperRef.current) return;
+        if (!expanded || !wrapperRef.current) return;
 
-        const position = () => {
-            const popup = popupRef.current;
-            if (!popup || !wrapperRef.current) return;
+        const compute = () => {
+            if (!wrapperRef.current) return;
 
             const replyBar = wrapperRef.current.closest("[class*='repliedMessage']");
             const replyRect = replyBar?.getBoundingClientRect();
             const btn = wrapperRef.current.getBoundingClientRect();
 
             const left = replyRect ? replyRect.left : btn.left - 40;
-            const popupWidth = replyRect ? Math.min(replyRect.width, 500) : 480;
+            const width = replyRect ? Math.min(replyRect.width, 500) : 480;
+            const bottom = window.innerHeight - btn.top + 4;
+            const maxHeight = btn.top - 8;
 
-            popup.style.left = `${left}px`;
-            popup.style.width = `${popupWidth}px`;
-
-            const spaceAbove = btn.top - 10;
-            const maxH = Math.min(320, spaceAbove - 10);
-            popup.style.maxHeight = `${Math.max(maxH, 100)}px`;
-            popup.style.bottom = `${window.innerHeight - btn.top + 4}px`;
-            popup.style.top = "auto";
+            setPopupStyle({ left, width, bottom, maxHeight });
         };
 
-        requestAnimationFrame(position);
+        requestAnimationFrame(compute);
     }, [expanded]);
+
+    if (referencedMessage.state !== ReferencedMessageState.LOADED) return null;
+
+    const msg = referencedMessage.message;
+    const fullMsg = (MessageStore.getMessage(baseMessage.channel_id, msg.id) as any) ?? msg;
+
+    if (!fullMsg.content && (fullMsg.attachments?.length ?? 0) === 0 && (fullMsg.embeds?.length ?? 0) === 0) return null;
+
+    const author = fullMsg.author as any;
+    const avatarSrc = author?.id && author?.avatar
+        ? `https://cdn.discordapp.com/avatars/${author.id}/${author.avatar}.webp?size=32`
+        : `https://cdn.discordapp.com/embed/avatars/${author?.discriminator ? Number(author.discriminator) % 5 : 0}.png`;
+
+    const popup = expanded && (
+        <div
+            className="vc-expanded-reply-content"
+            ref={popupRef}
+            style={popupStyle}
+            onClick={e => e.stopPropagation()}
+        >
+            <div className="vc-expanded-reply-header">
+                <img className="vc-expanded-reply-avatar" src={avatarSrc} alt="" />
+                <span className="vc-expanded-reply-author">@{author?.username}</span>
+                <CopyButton fullMsg={fullMsg} />
+                <button
+                    className="vc-expanded-reply-close"
+                    onClick={() => setExpanded(false)}
+                    aria-label="Close"
+                >
+                    <svg width="14" height="14" viewBox="0 0 24 24">
+                        <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+                    </svg>
+                </button>
+            </div>
+            <div className="vc-expanded-reply-body">
+                {fullMsg.content && (
+                    <div className={classes(MarkupClasses.markup, MessageClasses.messageContent, "vc-expanded-reply-text")}>
+                        {Parser.parse(fullMsg.content, false, {
+                            channelId: baseMessage.channel_id,
+                            messageId: msg.id,
+                            allowLinks: true,
+                            allowHeading: true,
+                            allowList: true,
+                            allowEmojiLinks: true,
+                        })}
+                    </div>
+                )}
+                {fullMsg.attachments?.map((att: any) => {
+                    if (att.content_type?.startsWith("image/")) {
+                        return (
+                            <img
+                                key={att.id}
+                                src={att.url}
+                                className="vc-expanded-reply-image"
+                                alt={att.filename}
+                                loading="lazy"
+                                onClick={() => openImageModal({
+                                    url: att.url,
+                                    width: att.width,
+                                    height: att.height,
+                                })}
+                            />
+                        );
+                    }
+                    if (att.content_type?.startsWith("video/")) {
+                        return <VideoPlayer key={att.id} src={att.url} />;
+                    }
+                    if (att.content_type?.startsWith("audio/")) {
+                        return <AudioPlayer key={att.id} src={att.url} />;
+                    }
+                    return null;
+                })}
+            </div>
+        </div>
+    );
 
     return (
         <span className="vc-expanded-reply-wrapper" ref={wrapperRef}>
@@ -108,82 +397,7 @@ function ExpandedReplyBtn({ referencedMessage, baseMessage }: ReplyProps) {
                     <path fill="currentColor" d="M7 10l5 5 5-5z" />
                 </svg>
             </button>
-            {expanded && (
-                <div className="vc-expanded-reply-content" ref={popupRef} onClick={e => e.stopPropagation()}>
-                    <div className="vc-expanded-reply-header">
-                        <img
-                            className="vc-expanded-reply-avatar"
-                            src={`https://cdn.discordapp.com/avatars/${(msg.author as any).id}/${(msg.author as any).avatar}.webp?size=32`}
-                            alt=""
-                        />
-                        <span className="vc-expanded-reply-author">
-                            @{(msg.author as any).username}
-                        </span>
-                        <button
-                            className="vc-expanded-reply-copy"
-                            onClick={() => copyWithToast(msg.content || "")}
-                            aria-label="Copy message"
-                        >
-                            <svg width="14" height="14" viewBox="0 0 24 24">
-                                <path fill="currentColor" d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                            </svg>
-                        </button>
-                        <button
-                            className="vc-expanded-reply-close"
-                            onClick={() => setExpanded(false)}
-                            aria-label="Close"
-                        >
-                            <svg width="14" height="14" viewBox="0 0 24 24">
-                                <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-                            </svg>
-                        </button>
-                    </div>
-                    <div className="vc-expanded-reply-body">
-                        {msg.content && (
-                            <div className={classes(MarkupClasses.markup, MessageClasses.messageContent, "vc-expanded-reply-text")}>
-                                {Parser.parse(msg.content, false, {
-                                    channelId: baseMessage.channel_id,
-                                    messageId: msg.id,
-                                    allowLinks: true,
-                                    allowHeading: true,
-                                    allowList: true,
-                                    allowEmojiLinks: true,
-                                })}
-                            </div>
-                        )}
-                        {msg.attachments?.map((att: any) => {
-                            if (att.content_type?.startsWith("image/")) {
-                                return (
-                                    <img
-                                        key={att.id}
-                                        src={att.url}
-                                        className="vc-expanded-reply-image"
-                                        alt={att.filename}
-                                        loading="lazy"
-                                        onClick={() => openImageModal({
-                                            url: att.url,
-                                            width: att.width,
-                                            height: att.height,
-                                        })}
-                                    />
-                                );
-                            }
-                            if (att.content_type?.startsWith("video/")) {
-                                return (
-                                    <video
-                                        key={att.id}
-                                        src={att.url}
-                                        className="vc-expanded-reply-video"
-                                        controls
-                                        preload="metadata"
-                                    />
-                                );
-                            }
-                            return null;
-                        })}
-                    </div>
-                </div>
-            )}
+            {popup && ReactDOM.createPortal(popup, document.body)}
         </span>
     );
 }

--- a/src/plugins/expandedReply/style.css
+++ b/src/plugins/expandedReply/style.css
@@ -38,7 +38,7 @@
 
 .vc-expanded-reply-content {
     position: fixed;
-    z-index: 1001;
+    z-index: 10000;
     width: min(480px, 50vw);
     max-height: 320px;
     display: flex;
@@ -79,6 +79,41 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.vc-expanded-reply-copy-wrapper {
+    position: relative;
+    display: inline-flex;
+}
+
+.vc-expanded-reply-copy-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 10001;
+    background: rgb(17 18 20 / 98%);
+    border: 1px solid rgb(255 255 255 / 10%);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgb(0 0 0 / 50%);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    min-width: 140px;
+}
+
+.vc-expanded-reply-copy-menu button {
+    padding: 8px 12px;
+    background: transparent;
+    border: none;
+    color: #fff;
+    font-size: 0.85rem;
+    text-align: left;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.vc-expanded-reply-copy-menu button:hover {
+    background: rgb(255 255 255 / 6%);
 }
 
 .vc-expanded-reply-copy,
@@ -130,17 +165,160 @@
     margin: 4px 0;
 }
 
-.vc-expanded-reply-image,
-.vc-expanded-reply-video {
+.vc-expanded-reply-audio {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    padding: 6px 10px;
+    background: rgb(255 255 255 / 5%);
+    border-radius: 8px;
+}
+
+.vc-expanded-reply-audio-play {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    border: none;
+    border-radius: 50%;
+    background: var(--brand-500);
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.vc-expanded-reply-audio-play:hover {
+    background: var(--brand-560);
+}
+
+.vc-expanded-reply-audio-bar {
+    flex: 1;
+    height: 4px;
+    appearance: none;
+    background: rgb(255 255 255 / 15%);
+    border-radius: 2px;
+    accent-color: var(--brand-500);
+    cursor: pointer;
+}
+
+.vc-expanded-reply-audio-time {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.vc-expanded-reply-image {
     max-width: 100%;
     max-height: 200px;
     border-radius: 8px;
     margin-top: 8px;
     object-fit: contain;
+    cursor: pointer;
+    display: block;
 }
 
-.vc-expanded-reply-image {
+.vc-expanded-reply-video-wrapper {
+    margin-top: 8px;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #000;
+}
+
+.vc-expanded-reply-video {
+    display: block;
+    max-width: 100%;
+    max-height: 180px;
+    object-fit: contain;
     cursor: pointer;
+    width: 100%;
+}
+
+.vc-expanded-reply-video-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: rgb(0 0 0 / 80%);
+}
+
+.vc-expanded-reply-video-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    border: none;
+    border-radius: 50%;
+    background: rgb(255 255 255 / 10%);
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.15s;
+    padding: 0;
+}
+
+.vc-expanded-reply-video-btn:hover {
+    background: rgb(255 255 255 / 22%);
+}
+
+.vc-expanded-reply-video-bar,
+.vc-expanded-reply-video-volume {
+    appearance: none;
+    height: 4px;
+    border-radius: 2px;
+    background: rgb(255 255 255 / 20%);
+    cursor: pointer;
+    outline: none;
+}
+
+.vc-expanded-reply-video-bar {
+    flex: 1;
+}
+
+.vc-expanded-reply-video-volume {
+    width: 60px;
+    flex-shrink: 0;
+}
+
+.vc-expanded-reply-video-bar::-webkit-slider-thumb,
+.vc-expanded-reply-video-volume::-webkit-slider-thumb {
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #fff;
+    cursor: pointer;
+    box-shadow: 0 0 0 2px rgb(0 0 0 / 40%);
+    transition: transform 0.1s;
+}
+
+.vc-expanded-reply-video-bar::-webkit-slider-thumb:hover,
+.vc-expanded-reply-video-volume::-webkit-slider-thumb:hover {
+    transform: scale(1.2);
+}
+
+.vc-expanded-reply-video-bar::-webkit-slider-runnable-track {
+    background: linear-gradient(to right, var(--brand-500) var(--pct, 0%), rgb(255 255 255 / 20%) var(--pct, 0%));
+    border-radius: 2px;
+    height: 4px;
+}
+
+.vc-expanded-reply-video-volume::-webkit-slider-runnable-track {
+    background: rgb(255 255 255 / 20%);
+    border-radius: 2px;
+    height: 4px;
+}
+
+.vc-expanded-reply-video-time {
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+    color: rgb(255 255 255 / 75%);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 @keyframes vc-expanded-reply-in {

--- a/src/plugins/expandedReply/style.css
+++ b/src/plugins/expandedReply/style.css
@@ -1,0 +1,156 @@
+.vc-expanded-reply-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.vc-expanded-reply-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    margin-left: 4px;
+    border: none;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--interactive-normal);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+    flex-shrink: 0;
+}
+
+.vc-expanded-reply-btn:hover {
+    color: var(--interactive-hover);
+    background: var(--background-modifier-hover);
+}
+
+.vc-expanded-reply-chevron {
+    transition: transform 0.2s ease;
+    transform: rotate(-90deg);
+}
+
+.vc-expanded-reply-chevron-open {
+    transition: transform 0.2s ease;
+    transform: rotate(0deg);
+}
+
+.vc-expanded-reply-content {
+    position: fixed;
+    z-index: 1001;
+    width: min(480px, 50vw);
+    max-height: 320px;
+    display: flex;
+    flex-direction: column;
+    border-radius: 12px;
+    background: rgb(17 18 20 / 92%);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgb(255 255 255 / 8%);
+    box-shadow:
+        0 12px 40px rgb(0 0 0 / 50%),
+        0 0 0 1px rgb(255 255 255 / 4%);
+    color: var(--text-normal);
+    overflow: hidden;
+    animation: vc-expanded-reply-in 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.vc-expanded-reply-header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 10px;
+    flex-shrink: 0;
+    border-bottom: 1px solid rgb(255 255 255 / 6%);
+}
+
+.vc-expanded-reply-avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.vc-expanded-reply-author {
+    flex: 1;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vc-expanded-reply-copy,
+.vc-expanded-reply-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--interactive-normal);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+}
+
+.vc-expanded-reply-copy:hover {
+    color: var(--brand-500);
+    background: rgb(88 101 242 / 10%);
+}
+
+.vc-expanded-reply-close:hover {
+    color: var(--status-danger);
+    background: rgb(240 71 71 / 10%);
+}
+
+.vc-expanded-reply-body {
+    padding: 0 14px 12px;
+    font-size: 0.9rem;
+    line-height: 1.4rem;
+    overflow-wrap: break-word;
+    overflow-y: auto;
+}
+
+.vc-expanded-reply-body::-webkit-scrollbar {
+    width: 4px;
+}
+
+.vc-expanded-reply-body::-webkit-scrollbar-thumb {
+    background: rgb(255 255 255 / 10%);
+    border-radius: 4px;
+}
+
+.vc-expanded-reply-text h1,
+.vc-expanded-reply-text h2,
+.vc-expanded-reply-text h3 {
+    margin: 4px 0;
+}
+
+.vc-expanded-reply-image,
+.vc-expanded-reply-video {
+    max-width: 100%;
+    max-height: 200px;
+    border-radius: 8px;
+    margin-top: 8px;
+    object-fit: contain;
+}
+
+.vc-expanded-reply-image {
+    cursor: pointer;
+}
+
+@keyframes vc-expanded-reply-in {
+    from {
+        opacity: 0;
+        transform: scale(0.96) translateY(-6px);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a chevron button next to reply previews to expand and show the full original message
- Floating popup with proper markdown rendering (headings, bold, italic, lists, etc.), images (clickable to open Discord's image viewer), and playable videos
- Header with author avatar and username, copy and close buttons
- Popup positions above the reply bar and adapts to available space
- Closes when clicking outside