### PR TITLE
fix(PauseInvitesForever): add missing null check in disableInvites

### DIFF
--- a/src/plugins/pauseInvitesForever/index.tsx
+++ b/src/plugins/pauseInvitesForever/index.tsx
@@ -34,6 +34,8 @@ function showDisableInvites(guildId: string) {
 
 function disableInvites(guildId: string) {
     const guild = GuildStore.getGuild(guildId);
+    if (!guild) return;
+
     const features = [...guild.features, "INVITES_DISABLED"];
     RestAPI.patch({
         url: Constants.Endpoints.GUILD(guildId),


### PR DESCRIPTION
\`showDisableInvites\` already guards against a null guild from \`GuildStore.getGuild\`, but \`disableInvites\` does not, which can crash when spreading \`guild.features\`.

Added the same \`if (!guild) return;\` guard that the sibling function already uses.