### PR TITLE
MessagePopover: use proper React components for hook support

### DIFF
--- a/src/api/MessagePopover.tsx
+++ b/src/api/MessagePopover.tsx
@@ -64,6 +64,17 @@ export function removeMessagePopoverButton(identifier: string) {
     MessagePopoverButtonMap.delete(identifier);
 }
 
+function PluginPopoverButton({ render, message, Component }: {
+    render: MessagePopoverButtonFactory;
+    message: Message;
+    Component: React.ComponentType<MessagePopoverButtonItem>;
+}) {
+    const item = render(message);
+    if (!item) return null;
+
+    return <Component {...item} />;
+}
+
 function VencordPopoverButtons(props: { Component: React.ComponentType<MessagePopoverButtonItem>, message: Message; }) {
     const { Component, message } = props;
 
@@ -71,22 +82,11 @@ function VencordPopoverButtons(props: { Component: React.ComponentType<MessagePo
 
     const elements = Array.from(MessagePopoverButtonMap.entries())
         .filter(([key]) => messagePopoverButtons[key]?.enabled !== false)
-        .map(([key, { render }]) => {
-            try {
-                // FIXME: this should use proper React to ensure hooks work
-                const item = render(message);
-                if (!item) return null;
-
-                return (
-                    <ErrorBoundary noop>
-                        <Component key={key} {...item} />
-                    </ErrorBoundary>
-                );
-            } catch (err) {
-                logger.error(`[${key}]`, err);
-                return null;
-            }
-        });
+        .map(([key, { render }]) => (
+            <ErrorBoundary noop key={key} onError={e => logger.error(`[${key}]`, e.error)}>
+                <PluginPopoverButton render={render} message={message} Component={Component} />
+            </ErrorBoundary>
+        ));
 
     return <>{elements}</>;
 }


### PR DESCRIPTION
## Summary
- Render functions in `VencordPopoverButtons` were called as plain
  functions inside `.map()`, which violates React's Rules of Hooks
- Extracted a `PluginPopoverButton` wrapper component so the render
  call happens inside a proper React component body
- Follows the same pattern already used by `ChatButtons.tsx`
- Error handling moved from try/catch to ErrorBoundary (consistent
  with every other similar API)

All 4 existing consumers (viewRaw, translate, quickMention,
hideAttachments) work without changes.

## Tests run
- [x] viewRaw renders and responds to left/right click
- [x] Translate renders and opens modal
- [x] QuickMention renders and works
- [x] No console errors