### PR TITLE
feat: add DidIGhostThem plugin

### DIFF
--- a/src/plugins/didIGhostThem/index.tsx
+++ b/src/plugins/didIGhostThem/index.tsx
@@ -1,0 +1,147 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import {
+    ChannelStore,
+    FluxDispatcher,
+    MessageStore,
+    ReadStateStore,
+    SnowflakeUtils,
+    UserStore,
+    useStateFromStores } from "@webpack/common";
+
+// only use cached msgs to avoid api abuse
+const cache = new Map<string, { id: string; name: string; content: string; }>();
+
+function stripMarkdown(s: string) {
+    return s
+        .replace(/<a?:(\w+):\d+>/g, ":$1:")
+        .replace(/<@!?\d+>/g, "@user")
+        .replace(/<#\d+>/g, "#channel")
+        .replace(/https?:\/\/\S+/g, "[link]")
+        .replace(/\*{1,2}(.+?)\*{1,2}/g, "$1")
+        .replace(/~~(.+?)~~/g, "$1");
+}
+
+function getInfo(channelId: string) {
+    const msg = MessageStore.getLastMessage(channelId);
+    if (msg?.author) return {
+        id: msg.author.id,
+        name: (msg.author as any).globalName ?? msg.author.username,
+        content: msg.content ?? "",
+        hasAttachment: (msg.attachments?.length ?? 0) > 0
+    };
+    const c = cache.get(channelId);
+    if (c) return { ...c, hasAttachment: false };
+    return null;
+}
+
+function timeAgo(ts: number) {
+    const d = Date.now() - ts;
+    const m = Math.floor(d / 60000);
+    if (m < 1) return "just now";
+    if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
+}
+
+function onMessage({ message, channelId }: any) {
+    if (!message?.author) return;
+    const ch = ChannelStore.getChannel(channelId);
+    if (!ch?.isDM()) return;
+    cache.set(channelId, {
+        id: message.author.id,
+        name: message.author.global_name ?? message.author.username,
+        content: message.content ?? ""
+    });
+}
+
+function onLoad({ channelId }: any) {
+    if (cache.has(channelId)) return;
+    const msg = MessageStore.getLastMessage(channelId);
+    if (msg?.author) cache.set(channelId, {
+        id: msg.author.id,
+        name: (msg.author as any).globalName ?? msg.author.username,
+        content: msg.content ?? ""
+    });
+}
+
+function init() {
+    for (const ch of ChannelStore.getSortedPrivateChannels()) {
+        if (!ch.isDM() || cache.has(ch.id)) continue;
+        const msg = MessageStore.getLastMessage(ch.id);
+        if (msg?.author) cache.set(ch.id, {
+            id: msg.author.id,
+            name: (msg.author as any).globalName ?? msg.author.username,
+            content: msg.content ?? ""
+        });
+    }
+}
+
+function GhostSubtitle({ channel }: { channel: any; }) {
+    useStateFromStores([MessageStore, ReadStateStore], () =>
+        (MessageStore.getLastMessage(channel.id)?.id ?? "") + ReadStateStore.lastMessageId(channel.id)
+    );
+
+    const me = UserStore.getCurrentUser();
+    if (!me) return null;
+
+    const info = getInfo(channel.id);
+    if (!info) {
+        if (!channel.lastMessageId) return null;
+        const ts = SnowflakeUtils.extractTimestamp(channel.lastMessageId);
+        return <div className="vc-ghost-sub vc-ghost-unknown">{timeAgo(ts)}</div>;
+    }
+
+    const isMe = info.id === me.id;
+    const unread = ReadStateStore.hasUnread(channel.id);
+    const who = isMe ? "You" : info.name;
+
+    let preview = stripMarkdown(info.content);
+    preview = preview.length > 20 ? preview.slice(0, 20) + "…" : preview;
+    if (!preview) preview = info.hasAttachment ? "sent a file" : "sent something";
+
+    const cls = isMe ? "vc-ghost-you" : unread ? "vc-ghost-unread" : "vc-ghost-ghosting";
+
+    return (
+        <div className={`vc-ghost-sub ${cls}`}>
+            {!isMe && !unread && "👻 "}{unread && !isMe && "💬 "}{who}: {preview}
+        </div>
+    );
+}
+
+// <wtl2026>
+export default definePlugin({
+    name: "DidIGhostThem",
+    description: "shows who sent the last message in your dms",
+    authors: [Devs.wtl],
+    patches: [{
+        find: "PrivateChannel.renderAvatar",
+        replacement: {
+            match: /subText:(\i\.isSystemDM\(\)\?.+?:null)/,
+            replace: "subText:[$1,$self.GhostSubtitle({channel:arguments[0]?.channel})]"
+        }
+    }],
+
+    GhostSubtitle,
+
+    start() {
+        FluxDispatcher.subscribe("MESSAGE_CREATE", onMessage);
+        FluxDispatcher.subscribe("LOAD_MESSAGES_SUCCESS", onLoad);
+        init();
+        setTimeout(init, 5000);
+    },
+    stop() {
+        FluxDispatcher.unsubscribe("MESSAGE_CREATE", onMessage);
+        FluxDispatcher.unsubscribe("LOAD_MESSAGES_SUCCESS", onLoad);
+        cache.clear();
+    }
+});

--- a/src/plugins/didIGhostThem/style.css
+++ b/src/plugins/didIGhostThem/style.css
@@ -1,0 +1,25 @@
+.vc-ghost-sub {
+    font-size: 12px;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vc-ghost-you {
+    color: var(--status-positive);
+    opacity: 0.7;
+}
+
+.vc-ghost-unread {
+    color: var(--text-normal);
+}
+
+.vc-ghost-ghosting {
+    color: var(--status-danger);
+}
+
+.vc-ghost-unknown {
+    opacity: 0.4;
+    font-style: italic;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    wtl: {
+        name: "watchthelight",
+        id: 697169405422862417n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Summary
Shows who sent the last message in your DMs, so you can tell if you left someone on read.

Patches PrivateChannel subText to show a preview below the username:
👻 red = you ghosted them!
💬 white = you have an unread from them  
green = you sent last

<img width="607" height="453" alt="image" src="https://github.com/user-attachments/assets/1ca0ad54-ce35-41dc-a173-f345a6b92759" />

No API calls, just reads from cached messages and flux events.

Got the idea from https://github.com/Vencord/plugin-requests/issues/852

## Test plan
Enable plugin, open some DMs, go back to list
Check the three states show up correctly
Send/receive a message and make sure it updates