### PR TITLE
Create plugin "microslop"

### DIFF
--- a/src/plugins/microslop/index.ts
+++ b/src/plugins/microslop/index.ts
@@ -1,0 +1,61 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Revilo0509
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "microslop",
+    description: "Replaces any and all occurrences of \"microsoft\" to \"microslop\" (case-insensitive)",
+    authors: [Devs.revilo0509],
+
+    start() {
+        this.scan();
+
+        const observer = new MutationObserver(() => {
+            this.scan();
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+
+        this.observer = observer;
+    },
+
+    stop() {
+        this.observer?.disconnect();
+    },
+
+    scan() {
+        const walker = document.createTreeWalker(
+            document.body,
+            NodeFilter.SHOW_TEXT,
+            null
+        );
+
+        let node: Node | null;
+        while ((node = walker.nextNode())) {
+            const original = node.nodeValue;
+            if (!original) continue;
+
+            const replaced = original.replace(/microsoft/gi, (match: string) => {
+                const replacement = "microslop";
+                return match.split("").map((char: string, i: string | number) => {
+                    const repChar = replacement[i] ?? "";
+                    return char === char.toUpperCase()
+                        ? repChar.toUpperCase()
+                        : repChar.toLowerCase();
+                }).join("");
+            });
+
+            if (original !== replaced) {
+                node.nodeValue = replaced;
+            }
+        }
+    }
+});

--- a/src/plugins/microslop/index.ts
+++ b/src/plugins/microslop/index.ts
@@ -9,7 +9,7 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "microslop",
-    description: "Replaces any and all occurrences of \"microsoft\" to \"microslop\" (case-insensitive)",
+    description: "WARNING: Uses direct DOM manipulation. May cause other stuff to break. Replaces any and all occurrences of \"microsoft\" to \"microslop\" (case-insensitive)",
     authors: [Devs.revilo0509],
 
     start() {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    revilo0509: {
+        name: "Revilo0509",
+        id: 565162541748322334n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
**TL:DR This plugin NEEDS direct DOM manipulation for its primary function.** In the case that this is **COMPLETELY** unacceptable *just close this PR* without a second thought.

I'm aware of the rule "No raw DOM manipulation. Use proper patches and React". But the primary function of this plugin is to replace *ALL* occurrences of "microsoft" to "microslop". This means the plugin has to be able to walk the DOM tree and replace the occurrences.

I originally got the idea from this [chome web extension](https://chromewebstore.google.com/detail/microsoft-to-microslop/hlkljlkdinjnbfmclionhbefbnefcgll) and wanted a discord/vencord equivalent.

I've tried this as thoroughly as I could. It works on server names, usernames, nicknames and messages. But doesn't break links and is only visual.

I'm mainly making this PR so everybody has the chance to experience the beauty of seeing *microslop* instead of the horrifying "microsoft" (Eww) 