### PR TITLE
feat: add MentionHighlighter plugin

### DIFF
--- a/src/plugins/mentionHighlighter/README.md
+++ b/src/plugins/mentionHighlighter/README.md
@@ -1,0 +1,7 @@
+# MentionHighlighter
+
+Customizes the appearance of messages where you are mentioned.
+
+You can set a custom highlight color, enable a glow effect, and toggle the default Discord mention background in the plugin settings. 
+
+![]()

--- a/src/plugins/mentionHighlighter/index.ts
+++ b/src/plugins/mentionHighlighter/index.ts
@@ -1,0 +1,94 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import "./style.css";
+
+import { definePluginSettings } from "@api/Settings";
+import { Logger } from "@utils/Logger";
+import definePlugin, { OptionType } from "@utils/types";
+import { ColorPicker, React } from "@webpack/common";
+
+const logger = new Logger("MentionHighlighter");
+
+const settings = definePluginSettings({
+    highlightColor: {
+        type: OptionType.COMPONENT,
+        default: "#ff6100",
+        name: "Highlight Color",
+        description: "The color to highlight your own mentions with",
+        component: ({ setValue }) => React.createElement(ColorPicker, {
+            color: parseInt(settings.store.highlightColor.replace("#", ""), 16),
+            onChange: (v: number) => {
+                const hex = `#${v.toString(16).padStart(6, "0")}`;
+                setValue(hex);
+                document.body.style.setProperty("--mention-highlighter-color", hex);
+            }
+        })
+    },
+    removeBackground: {
+        type: OptionType.BOOLEAN,
+        default: false,
+        description: "Remove standard yellow background for mentioned messages",
+        onChange: v => {
+            if (v) document.body.classList.add("vc-mention-highlighter-remove-background");
+            else document.body.classList.remove("vc-mention-highlighter-remove-background");
+        }
+    },
+    glowEnabled: {
+        type: OptionType.BOOLEAN,
+        default: false,
+        description: "Add a glow effect to mentioned messages",
+        onChange: v => {
+            if (v) document.body.classList.add("vc-mention-highlighter-glow");
+            else document.body.classList.remove("vc-mention-highlighter-glow");
+        }
+    }
+});
+
+export default definePlugin({
+    name: "MentionHighlighter",
+    description: "Highlights mentions of yourself more prominently within messages",
+    authors: [Devs.reese],
+    settings,
+
+    start() {
+        document.body.style.setProperty("--mention-highlighter-color", settings.store.highlightColor);
+        if (settings.store.removeBackground) {
+            document.body.classList.add("vc-mention-highlighter-remove-background");
+        }
+        if (settings.store.glowEnabled) {
+            document.body.classList.add("vc-mention-highlighter-glow");
+        }
+    },
+
+    stop() {
+        document.body.style.removeProperty("--mention-highlighter-color");
+        document.body.classList.remove("vc-mention-highlighter-remove-background");
+        document.body.classList.remove("vc-mention-highlighter-glow");
+    },
+
+    patches: [
+        {
+            find: "isCurrentUser",
+            replacement: {
+                match: /className:([\w$]+)\.mention/,
+                replace: "className:$self.processMentionProps($1, $1.mention)"
+            }
+        }
+    ],
+
+    processMentionProps(props: any, originalClass: string) {
+        try {
+            if (props.isCurrentUser) {
+                return `${originalClass} vc-mention-highlighter`;
+            }
+        } catch (e) {
+            logger.error("Error processing mention props", e);
+        }
+        return originalClass;
+    }
+});

--- a/src/plugins/mentionHighlighter/style.css
+++ b/src/plugins/mentionHighlighter/style.css
@@ -1,0 +1,22 @@
+.vc-mention-highlighter {
+    display: inline-flex !important;
+    color: var(--mention-highlighter-color, #ff6100) !important;
+    background: transparent !important;
+    padding: 0 !important;
+    font-weight: bold;
+}
+
+.vc-mention-highlighter-remove-background [class*="mentioned_"]::before {
+    display: none !important;
+}
+
+.vc-mention-highlighter-remove-background [class*="mentioned_"] {
+    background-color: transparent !important;
+}
+
+.vc-mention-highlighter-glow [class*="mentioned_"] {
+    box-shadow: 0 0 10px var(--mention-highlighter-color, #ff6100);
+    border-radius: 8px;
+    margin-left: 8px;
+    margin-right: 8px;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    reese: {
+        name: "reese",
+        id: 1083437693347827764n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
# MentionHighlighter

Customizes the appearance of messages where you are mentioned.

You can set a custom highlight color, enable a glow effect, and toggle the default Discord mention background in the plugin settings. 

![](https://github.com/user-attachments/assets/1c4557c6-56e3-4081-83bc-9c8a59e4bcd0)