### PR TITLE
PinDMs: Allow directly moving channels from one category to another

### DIFF
--- a/src/plugins/pinDms/components/contextMenu.tsx
+++ b/src/plugins/pinDms/components/contextMenu.tsx
@@ -6,7 +6,7 @@
 
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { PinOrder, settings } from "@plugins/pinDms";
-import { addChannelToCategory, canMoveChannelInDirection, currentUserCategories, isPinned, moveChannel, removeChannelFromCategory } from "@plugins/pinDms/data";
+import { addChannelToCategory, moveChannelToCategory, canMoveChannelInDirection, currentUserCategories, isPinned, moveChannel, removeChannelFromCategory } from "@plugins/pinDms/data";
 import { Menu } from "@webpack/common";
 
 import { openCategoryModal } from "./CreateCategoryModal";
@@ -45,6 +45,34 @@ function createPinMenuItem(channelId: string) {
 
             {pinned && (
                 <>
+                    <Menu.MenuItem
+                        id="move-dm"
+                        label="Move DM"
+                    >
+                        <Menu.MenuItem
+                            id="vc-add-category"
+                            label="Add Category"
+                            color="brand"
+                            action={() => openCategoryModal(null, channelId)}
+                        />
+                        <Menu.MenuSeparator />
+                        {
+
+                            currentUserCategories.filter(c => !c.channels.includes(channelId)).
+                                map(category => (
+                                    <Menu.MenuItem
+                                        key={category.id}
+                                        id={`pin-category-${category.id}`}
+                                        label={category.name}
+                                        action={() => moveChannelToCategory(channelId, category.id)}
+                                    />
+                                ))
+                        }
+
+                    </Menu.MenuItem>
+
+                    <Menu.MenuSeparator />
+
                     <Menu.MenuItem
                         id="unpin-dm"
                         label="Unpin DM"

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -43,6 +43,15 @@ export function getCategoryByIndex(index: number) {
 export function createCategory(category: Category) {
     currentUserCategories.push(category);
 }
+export function moveChannelToCategory(channelId: string, categoryId: string) {
+    const category = currentUserCategories.find(c => c.id === categoryId);
+    if (category == null) return;
+
+    if (category.channels.includes(channelId)) return;
+
+    removeChannelFromCategory(channelId);
+    category.channels.push(channelId);
+}
 
 export function addChannelToCategory(channelId: string, categoryId: string) {
     const category = currentUserCategories.find(c => c.id === categoryId);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+        antokek: {
+        name: "antokek",
+        id: 224864947480297472n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
added the option to move channels from one category to another via DM ContextMenu, without having to waste time unpinning them first. just a small QoL feature