### PR TITLE
feat(plugin): DisableOverlaySoundboard

### DIFF
--- a/src/plugins/disableOverlaySoundboard/index.ts
+++ b/src/plugins/disableOverlaySoundboard/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "DisableOverlaySoundboard",
+    description: "Prevents Discord's in-game overlay soundboard from opening.",
+    authors: [Devs.AndrewDLO],
+    patches: [
+        {
+            find: 'type:"SOUNDBOARD_SET_OVERLAY_ENABLED",pid:t,enabled:!0,keepOpen:e',
+            replacement: [
+                {
+                    match: /\{type:"SOUNDBOARD_SET_OVERLAY_ENABLED",pid:t,enabled:!0,keepOpen:e\}/,
+                    replace: '{type:"SOUNDBOARD_SET_OVERLAY_ENABLED",pid:t,enabled:!1,keepOpen:e}'
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
Simply disables the entire soundboard while using the in-game overlay, usually accessed by ``Ctrl + ` `` or `Ctrl + /`. For some reason the soundboard in the in-game overlay can not be disabled and the default keybind can not be disabled in the default Discord client.🙃

I made this plugin because I use ``Ctrl + ` `` as my toggle mute keybind and was tired of Discord playing super loud sounds every time I try to mute while in a game. After searching online I saw tens of Reddit posts and people in the Vencord discord complaining about the same thing.
<img width="925" height="723" alt="soundboard6" src="https://github.com/user-attachments/assets/e22c4eb1-ed83-42dc-b8fc-98111220e0be" />
