### PR TITLE
feat(plugin): NoSendWarnings

### DIFF
--- a/src/plugins/noSendWarnings/index.ts
+++ b/src/plugins/noSendWarnings/index.ts
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NoSendWarnings",
+    description: "Removes @everyone and token warnings before sending a message.",
+    authors: [Devs.RoScripter999],
+
+    patches: [
+        {
+            find: "@Everyone",
+            replacement: {
+                match: /(let \w+)=\[[\s\S]+?\}\]/,
+                replace: "$1=[]"
+            }
+        }
+    ]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    RoScripter999: {
+        name: "RoScripter999",
+        id: 1352787303168344095n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This plugin simply just removes the hold up warnings before sending a discord token or a @everyone ping.