### PR TITLE
feat: add betterTiktokEmbeds plugins

### DIFF
--- a/src/plugins/betterTiktokEmbeds/README.md
+++ b/src/plugins/betterTiktokEmbeds/README.md
@@ -1,0 +1,3 @@
+# BetterTiktokEmbeds
+
+Uses tnktok.com (https://github.com/okdargy/fxtiktok) to give better tiktok embeds in chat.

--- a/src/plugins/betterTiktokEmbeds/index.ts
+++ b/src/plugins/betterTiktokEmbeds/index.ts
@@ -1,0 +1,54 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { MessageObject } from "@api/MessageEvents";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "BetterTikTokEmbeds",
+    description: "Automatically changes all tiktok.com links to tnktok.com for much better video embeds",
+    authors: [{ name: "Olykir", id: 621154191192096778n }],
+
+    onBeforeMessageSend(_channelId: string, message: MessageObject) {
+        if (!message.content) return;
+
+        message.content = message.content
+            .replace(/https?:\/\/(?:www\.)?tiktok\.com/gi, "https://tnktok.com")
+            .replace(/https?:\/\/vm\.tiktok\.com/gi, "https://tnktok.com");
+    },
+
+    onBeforeMessageEdit(_channelId: string, _messageId: string, message: MessageObject) {
+        if (!message.content) return;
+
+        message.content = message.content
+            .replace(/https?:\/\/(?:www\.)?tiktok\.com/gi, "https://tnktok.com")
+            .replace(/https?:\/\/vm\.tiktok\.com/gi, "https://tnktok.com");
+    },
+
+    start() {
+        const rewriteVisibleLinks = () => {
+            document.querySelectorAll<HTMLAnchorElement>('a[href*="tiktok.com"]').forEach(link => {
+                let href = link.getAttribute("href") || "";
+
+                href = href
+                    .replace(/https?:\/\/(?:www\.)?tiktok\.com/gi, "https://tnktok.com")
+                    .replace(/https?:\/\/vm\.tiktok\.com/gi, "https://tnktok.com");
+
+                link.setAttribute("href", href);
+
+                if (link.textContent) {
+                    link.textContent = link.textContent.replace(/tiktok\.com/gi, "tnktok.com");
+                }
+            });
+        };
+
+        const observer = new MutationObserver(rewriteVisibleLinks);
+        observer.observe(document.body, { childList: true, subtree: true });
+        rewriteVisibleLinks();
+
+        return () => observer.disconnect();
+    }
+});


### PR DESCRIPTION
Closes #1072 on plugin requests repository.

Uses [tnktok.com](tnktok.com) to provide better embeds for Tiktok, could be done with TextReplace but this is more simple for users to find/turn on. 

<img width="626" height="514" alt="Discord_8DttNrmm6I" src="https://github.com/user-attachments/assets/5ad30f28-22e6-4fe6-ac2d-852693e13fa7" />
<img width="738" height="462" alt="Discord_FMThGYBj2Y" src="https://github.com/user-attachments/assets/a2573f71-0535-4a9a-857b-1a0e732d9aa0" />
