### PR TITLE
feat: add autoPublishAnnoucements  plugin 

### DIFF
--- a/src/plugins/autoPublishAnnoucements/index.ts
+++ b/src/plugins/autoPublishAnnoucements/index.ts
@@ -1,0 +1,55 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { findByPropsLazy, findStoreLazy } from "@webpack";
+import { RestAPI, showToast, Toasts } from "@webpack/common";
+
+const NEWS_CHANNEL_TYPE = 5;
+
+const UserStore = findByPropsLazy("getCurrentUser");
+const ChannelStore = findStoreLazy("ChannelStore");
+
+
+export default definePlugin({
+    name: "autoPublishAnnoucements",
+    description: "Allows you to auto publish messages sent on announcements channels",
+    authors: [Devs.WaveDev],
+    flux: {
+        "MESSAGE_CREATE": function (event) {
+            const { message } = event;
+            const currentUser = UserStore.getCurrentUser();
+            const channel = ChannelStore.getChannel(message.channel_id);
+
+            if (!message.author || !currentUser || !channel) return;
+            if (message.author.id !== currentUser.id) return;
+
+            if (channel.type !== NEWS_CHANNEL_TYPE) return;
+
+            // skip as it is not sent yet
+            if (event.optimistic) return;
+
+            setTimeout(async () => {
+                try {
+                    await RestAPI.post({
+                        url: `/channels/${message.channel_id}/messages/${message.id}/crosspost`,
+                    });
+                    showToast("Automatically published message", Toasts.Type.SUCCESS);
+
+                } catch (err) {
+                    console.error(
+                        `autoPublishMessages: Failed to publish message ${message.id}:`,
+                        err,
+                    );
+                    showToast("Failed to automatically publish message, check console for logs.", Toasts.Type.FAILURE);
+
+                }
+            }, 500);
+            return;
+        }
+    }
+});

--- a/src/plugins/copyEmojiMarkdown/index.tsx
+++ b/src/plugins/copyEmojiMarkdown/index.tsx
@@ -51,7 +51,7 @@ const settings = definePluginSettings({
 export default definePlugin({
     name: "CopyEmojiMarkdown",
     description: "Allows you to copy emojis as formatted string (<:blobcatcozy:1026533070955872337>)",
-    authors: [Devs.HappyEnderman, Devs.Vishnya],
+    authors: [Devs.WaveDev, Devs.Vishnya],
     settings,
 
     contextMenus: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -453,9 +453,9 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Elvyra",
         id: 708275751816003615n,
     },
-    HappyEnderman: {
-        name: "Happy enderman",
-        id: 1083437693347827764n
+    WaveDev: {
+        name: "WaveDev",
+        id: 1102694284425187418n
     },
     Vishnya: {
         name: "Vishnya",


### PR DESCRIPTION
This plugin automatically publishes message sent by the current user in any announcement channel after the message is sent. 
<img width="513" height="117" alt="image" src="https://github.com/user-attachments/assets/f6910406-2c4c-4d55-942b-ab71b4268adf" />

I also modified my username from `HappyEnderman` to `WaveDev` and my id to my new account id on devs constant.