### PR TITLE
feat: add Discord Tracker Link plugin

### DIFF
--- a/src/plugins/tracersearch/README.md
+++ b/src/plugins/tracersearch/README.md
@@ -1,0 +1,56 @@
+# Discord Tracker Link - Vencord Plugin
+
+Adds a context menu button to quickly open user profiles on Discord Tracker.
+
+## Features
+
+- 🔗 "Open in Discord Tracker" button in context menu
+- 🚀 Quick access to user information
+- 🎯 Works with any Discord user
+- 🌐 Opens profile in a new browser tab
+
+## Installation
+
+### Automatic Installation (Windows)
+1. Run `install.bat`
+2. Restart Discord
+3. Enable the plugin in Vencord settings
+
+### Manual Installation
+1. Copy `index.tsx` file to:
+   ```
+   %appdata%/Vencord/userplugins/DiscordTrackerLink/
+   ```
+2. Restart Discord
+3. Enable plugin: Settings → Vencord → Plugins → DiscordTrackerLink
+
+## Usage
+
+1. Right-click on any user
+2. Select "Open in Discord Tracker" from context menu
+3. A new tab will open with the user's profile on discord-tracker.com
+
+## Where it works
+
+The button appears in the context menu when right-clicking on:
+- User avatar in chat
+- Username in member list
+- User profile
+- User mention in messages
+
+## What Discord Tracker shows
+
+On Discord Tracker website you will see:
+- Full user profile
+- Avatar and banner
+- Account creation date
+- Badges
+- Biography
+- Profile change history
+- Server list (if available)
+
+## Requirements
+
+- Vencord installed and running
+- Discord Desktop Client
+- Internet connection to access discord-tracker.com

--- a/src/plugins/tracersearch/index.tsx
+++ b/src/plugins/tracersearch/index.tsx
@@ -1,0 +1,32 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { Menu } from "@webpack/common";
+
+export default definePlugin({
+    name: "DiscordTrackerLink",
+    description: "Adds a button to open user profiles in Discord Tracker",
+    authors: [Devs.hell1sh],
+
+    contextMenus: {
+        "user-context": (children, { user }) => {
+            if (!user) return;
+
+            children.push(
+                <Menu.MenuItem
+                    id="open-discord-tracker"
+                    label="Open in Discord Tracker"
+                    action={() => {
+                        const url = `https://discord-tracker.com/tracker/user/${user.id}`;
+                        window.open(url, "_blank");
+                    }}
+                />
+            );
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    hell1sh: {
+        name: "hell1sh",
+        id: 738689083190280252n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Adds a context menu option to quickly open Discord user profiles in Discord Tracker.

Features:
- Adds "Open in Discord Tracker" button to user context menus
- Opens profile at https://discord-tracker.com/tracker/user/{userId}
- Works on avatars, usernames, mentions, and profiles
