### PR TITLE
feat: add FixLinkEmbeds plugin

### DIFF
--- a/src/plugins/fixLinkEmbeds/README.md
+++ b/src/plugins/fixLinkEmbeds/README.md
@@ -1,0 +1,31 @@
+# FixLinkEmbeds
+
+A Vencord plugin that automatically fixes embeds from links by replacing them with Cloudflare worker alternatives. Messages are modified before sending to ensure links display proper embeds in Discord.
+
+## Supported Platforms
+
+The plugin automatically converts links from these platforms:
+
+- **X/Twitter**: `x.com` → `fixupx.com`, `twitter.com` → `fxtwitter.com` ([FxEmbed](https://github.com/FxEmbed/FxEmbed))
+- **Bluesky**: `bsky.app` → `fxbsky.app` ([FxEmbed](https://github.com/FxEmbed/FxEmbed))
+- **TikTok**: `tiktok.com` → `tnktok.com` ([fxTikTok](https://github.com/okdargy/fxTikTok))
+- **Instagram**: `instagram.com` → `kkinstagram.com` ([KKinstagram](https://github.com/kkscript/kk))
+- **Reddit**: `reddit.com` → `rxddit.com` ([FixReddit](https://github.com/MinnDevelopment/fxreddit))
+- **Pixiv**: `pixiv.net` → `phixiv.net` ([Phixiv](https://github.com/HazelTheWitch/phixiv))
+- **Fur Affinity**: `furaffinity.net` → `fxfuraffinity.net` ([fxraffinity](https://fxraffinity.net/))
+- **Twitch**: `twitch.tv`, `twitch.com` → `fxtwitch.seria.moe` ([fxtwitch](https://github.com/seriaati/fxtwitch))
+- **Tumblr**: `tumblr.com` → `tpmblr.com` ([fxtumblr](https://tpmblr.com/))
+- **DeviantArt**: `deviantart.com` → `fixdeviantart.com` ([fixDeviantArt](https://github.com/Tschrock/fixdeviantart))
+- **Threads**: `threads.net`, `threads.com` → `vxthreads.net` ([vxThreads](https://github.com/everettsouthwick/vxthreads))
+- **Spotify**: `spotify.com` → `fxspotify.com` ([fxspotify](https://github.com/lumyar/fxspotify))
+- **Facebook**: `facebook.com` → `facebed.com` ([facebed](https://github.com/facebed/facebed))
+
+## How It Works
+
+When you send a message containing a link to one of the supported platforms, the plugin automatically replaces the domain with its embed-fixing alternative before the message is sent to Discord. This works for both new messages and message edits.
+
+The plugin also handles:
+- URLs with `www.` prefix
+- Preservation of URL paths and query parameters
+- Safe error handling for malformed URLs
+

--- a/src/plugins/fixLinkEmbeds/index.ts
+++ b/src/plugins/fixLinkEmbeds/index.ts
@@ -1,0 +1,78 @@
+/*
+* Vencord, a Discord client mod
+* Copyright (c) 2025 Vendicated and contributors*
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+import { MessageObject } from "@api/MessageEvents";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+const DOMAIN_REPLACEMENTS: Record<string, string> = {
+    "x.com": "fixupx.com",
+    "twitter.com": "fxtwitter.com",
+    "bsky.app": "fxbsky.app",
+    "tiktok.com": "tnktok.com",
+    "instagram.com": "kkinstagram.com",
+    "reddit.com": "rxddit.com",
+    "pixiv.net": "phixiv.net",
+    "furaffinity.net": "fxfuraffinity.net",
+    "twitch.tv": "fxtwitch.seria.moe",
+    "twitch.com": "fxtwitch.seria.moe",
+    "tumblr.com": "tpmblr.com",
+    "deviantart.com": "fixdeviantart.com",
+    "threads.net": "vxthreads.net",
+    "threads.com": "vxthreads.net",
+    "spotify.com": "fxspotify.com",
+    "facebook.com": "facebed.com"
+};
+
+
+
+function matchDomain(host: string): string | null {
+    return Object.keys(DOMAIN_REPLACEMENTS)
+        .find(d => host === d || host.endsWith("." + d)) ?? null;
+}
+
+
+export default definePlugin({
+    name: "FixLinkEmbeds",
+    description: "Automatically fixes embeds from links by modifying URLs before sending.",
+    authors: [
+        Devs.kikkudayo
+    ],
+
+    fixUrl(urlString: string): string {
+        try {
+            const url = new URL(urlString);
+            const domain = matchDomain(url.hostname);
+            if (!domain) return urlString;
+
+            url.hostname = DOMAIN_REPLACEMENTS[domain];
+            return url.toString();
+
+        } catch {
+            return urlString;
+        }
+    },
+
+    cleanMessage(msg: MessageObject) {
+        if (!msg?.content) return;
+
+        msg.content = msg.content.replace(
+            /https?:\/\/[^\s<>()]+/g,
+            (match) => this.fixUrl(match)
+        );
+    },
+
+    onBeforeMessageSend(_, msg) {
+        this.cleanMessage(msg);
+    },
+
+    onBeforeMessageEdit(_cid, _mid, msg) {
+        this.cleanMessage(msg);
+    },
+
+    start() { },
+    stop() { },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    kikkudayo: {
+        name: "kikkudayo",
+        id: 743729410124808284n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Added a plugin that rewrites supported social media URLs to embed-fixing alternative domains before sending messages to improve Discord embed previews.