### PR TITLE
chore: add TypeScript output folder and Vesktop files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ src/userplugins
 
 ExtensionCache/
 /settings
+who-fucking-cares-dude/

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,9 @@ src/userplugins
 
 ExtensionCache/
 /settings
+
+# TypeScript output
 who-fucking-cares-dude/
+
+# Vesktop files
+vencordDesktop*


### PR DESCRIPTION
Adds the `who-fucking-cares-dude` folder (which is the defined output folder in `tsconfig.json`) and files starting with `vencordDesktop` (created by Vesktop if you point it at the source tree) to `.gitignore`.