### PR TITLE
ReviewDB: fix emoji picker close behavior

### DIFF
--- a/src/plugins/reviewDB/components/ReviewsView.tsx
+++ b/src/plugins/reviewDB/components/ReviewsView.tsx
@@ -156,6 +156,7 @@ export function ReviewsInputComponent(
                     disableThemedBackground={true}
                     setEditorRef={ref => editorRef.current = ref}
                     parentModalKey={modalKey}
+                    emojiPickerCloseOnModalOuterClick={true}
                     textValue=""
                     onSubmit={
                         async res => {

--- a/src/plugins/reviewDB/utils.tsx
+++ b/src/plugins/reviewDB/utils.tsx
@@ -17,7 +17,7 @@
 */
 
 import { classNameFactory } from "@utils/css";
-import { Toasts, UserStore } from "@webpack/common";
+import { showToast as showToastCommon, Toasts, UserStore } from "@webpack/common";
 
 import { Auth } from "./auth";
 import { Review, UserType } from "./entities";
@@ -43,12 +43,7 @@ export function canReportReview(review: Review) {
 }
 
 export function showToast(message: string, type = Toasts.Type.MESSAGE) {
-    Toasts.show({
-        id: Toasts.genId(),
-        message,
-        type,
-        options: {
-            position: Toasts.Position.BOTTOM, // NOBODY LIKES TOASTS AT THE TOP
-        },
+    showToastCommon(message, type, {
+        position: Toasts.Position.BOTTOM, // NOBODY LIKES TOASTS AT THE TOP
     });
 }


### PR DESCRIPTION
Hii

I noticed that I couldn't exit the emoji picker in the ReviewDB modal by clicking outside of the frame

ReviewDB uses Discord's user profile reply text area inside a modal. Discord's native user profile reply input passes `emojiPickerCloseOnModalOuterClick`, so this PR mirrors that behavior for ReviewDB's review input.

Repro:
1. Open a user's ReviewDB reviews modal.
2. Click the emoji button in the review text box.
3. Click outside the emoji picker.

Before this change, the picker stayed open until pressing esc or selecting an emoji
