### PR TITLE
fix(notification): add max-width to prevent alert overflow on ultrawide screens

### DIFF
--- a/src/api/Notifications/styles.css
+++ b/src/api/Notifications/styles.css
@@ -16,6 +16,7 @@
     z-index: 2147483647;
     right: 1rem;
     width: 25vw;
+    max-width: 500px;
     min-height: 10vh;
 }
 


### PR DESCRIPTION
# Summary
This PR fixes #4116 by adding a max-width of `500px` to the `.vc-notification-root` element.

## What was the issue ?
On ultrawide screens, the notification alert (e.g., "Click here to restart") was displayed at `25vw` width (25% of viewport width), which resulted in an excessively wide alert that looked out of proportion compared to other UI elements.

## Fix
Added `max-width: 500px` to cap the notification width regardless of screen size, while still maintaining the responsive `25vw` width on smaller displays.

## Testing
- Verified the fix on ultrawide displays where the notification no longer exceeds 500px width
- Normal displays are unaffected since `25vw` is already below 500px