### PR TITLE
feat (plugin): add BlurImages

### DIFF
--- a/src/plugins/blurImages/README.md
+++ b/src/plugins/blurImages/README.md
@@ -1,0 +1,4 @@
+# BlurImages
+
+This plugin blurs all images and GIFs by default, requiring you to hover over
+them to reveal them.

--- a/src/plugins/blurImages/index.tsx
+++ b/src/plugins/blurImages/index.tsx
@@ -1,0 +1,76 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { managedStyleRootNode } from "@api/Styles";
+import { Devs } from "@utils/constants";
+import { createAndAppendStyle } from "@utils/css";
+import definePlugin, { makeRange, OptionType } from "@utils/types";
+
+let style: HTMLStyleElement;
+
+const settings = definePluginSettings({
+    blurAmount: {
+        type: OptionType.SLIDER,
+        description: "Blur amount in pixels",
+        markers: makeRange(0, 100, 5),
+        stickToMarkers: false,
+        default: 50,
+        onChange: setCss
+    },
+    transitionDuration: {
+        type: OptionType.SLIDER,
+        description: "Transition duration in seconds",
+        markers: makeRange(0, 2, 0.1),
+        stickToMarkers: false,
+        default: 0.2,
+        onChange: setCss
+    }
+});
+
+function setCss() {
+    if (!style) return;
+
+    style.textContent = `
+    .vc-blur-all-images [class*=imageContainer],
+    .vc-blur-all-images [class*=wrapperPaused] {
+        filter: blur(${settings.store.blurAmount}px);
+        transition: filter ${settings.store.transitionDuration}s;
+    }
+
+    .vc-blur-all-images [class*=imageContainer]:hover,
+    .vc-blur-all-images [class*=wrapperPaused]:hover {
+        filter: blur(0);
+    }
+`;
+}
+
+export default definePlugin({
+    name: "BlurImages",
+    description: "Blurs all images and GIFs in chat by default",
+    tags: ["Privacy", "Appearance"],
+    authors: [Devs.nikokomninos],
+    settings,
+
+    patches: [
+        {
+            find: "}renderStickersAccessories(",
+            replacement: {
+                match: /(\.renderReactions\(\i\).+?className:)/,
+                replace: '$&"vc-blur-all-images "+'
+            }
+        }
+    ],
+
+    start() {
+        style = createAndAppendStyle("VcBlurAllImages", managedStyleRootNode);
+        setCss();
+    },
+
+    stop() {
+        style?.remove();
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    nikokomninos: {
+        name: "nikokomninos",
+        id: 193909794258550786n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This PR adds a simple plugin that blurs all images and GIFs by default. I made it for public privacy purposes since I couldn't find it in another plugin.

Customizable options:

- Blur amount (px)
- Transition duration (s)

<img width="281" height="241" alt="CleanShot 2026-05-03 at 21 21 44" src="https://github.com/user-attachments/assets/c794955d-befd-4ff0-b816-d0cd79a37a15" />

<img width="314" height="266" alt="CleanShot 2026-05-03 at 21 22 49@2x" src="https://github.com/user-attachments/assets/0d8ee0e0-26f6-497a-8819-7f9015516f91" />

