### PR TITLE
feat:(plugin) Add 7TVEmotes plugin

### DIFF
--- a/src/plugins/sevenTVEmotes/README.md
+++ b/src/plugins/sevenTVEmotes/README.md
@@ -1,0 +1,68 @@
+# 7TV Emotes
+
+Adds a dedicated 7TV tab to Discord's expression picker, allowing you to browse and use 7TV emotes directly from the emote picker alongside GIFs and stickers.
+
+## Features
+
+- **7TV Tab Integration**: New tab in the expression picker with a dedicated 7TV interface
+- **Favorites System**: Mark your frequently used emotes as favorites for quick access
+- **Channel Management**: Add 7TV channels to browse their emote collections
+- **Global Search**: Search across all 7TV emotes globally
+- **Priority Search**: Smart search that prioritizes favorites → configured channels → global emotes
+- **Auto-Expansion**: Use `:+emotename:` syntax to automatically expand to a 7TV emote URL in messages
+- **Responsive UI**: Clean sidebar with channel navigation and search filtering
+
+## Preview
+
+The plugin integrates seamlessly into Discord's expression picker with a dedicated 7TV tab:
+
+- **Left Sidebar**: Channel navigation with avatars (favorites tab + your configured channels)
+- **Main Area**: 64px emote grid with search and filtering
+- **Star Indicator**: Gold star (★) marks your favorite emotes for quick identification
+
+## Usage
+
+### Adding 7TV Channels
+
+1. Open Discord settings
+2. Navigate to **Plugins** → **7TVEmotes**
+3. In the **Channels Manager** section, enter a 7TV username or channel ID
+4. The channel's avatar will load automatically
+5. Click the ➕ button to add the channel
+
+### Using Emotes
+
+**Via Expression Picker:**
+
+1. Open the expression picker (usually next to emoji/GIF buttons)
+2. Click the **7TV** tab
+3. Browse channels from the left sidebar or search for emotes
+4. Click an emote to insert it into your message
+5. Right-click or Ctrl/Cmd-click any emote to add/remove it from favorites
+
+**Via Quick Expansion:**
+Type `:+emotename:` in a message to automatically expand it to a 7TV emote URL. The plugin searches in this order:
+
+1. Your favorite emotes (highest priority)
+2. Channels you've configured
+3. Global 7TV emotes
+
+**Favorites Tab:**
+
+- Click the ⭐ button in the sidebar to view all your favorited emotes
+- Easily insert frequently used emotes without searching
+
+### First-Time Setup
+
+On first use, you may see a CSP permission request. Discord will ask for permission to access 7TV APIs:
+
+- **API Access**: `https://7tv.io` (for emote data and user lookups)
+- **CDN Access**: `https://cdn.7tv.app` (for emote images)
+
+Accept the permissions and restart Discord for the plugin to work fully.
+
+## Configuration
+
+**Channels**: Comma-separated list of 7TV usernames or channel IDs to include in your browser
+
+Example: `username1, userid123, another_user`

--- a/src/plugins/sevenTVEmotes/api/api.ts
+++ b/src/plugins/sevenTVEmotes/api/api.ts
@@ -1,0 +1,329 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import * as DataStore from "@api/DataStore";
+import type {
+    Emote,
+    SevenTVChannel,
+    SevenTVEmote,
+    SevenTVGraphQLSearchResponse,
+    SevenTVUserResponse,
+} from "@plugins/sevenTVEmotes/utils/types";
+
+export const SEVEN_TV_API_ORIGIN = "https://7tv.io";
+export const SEVEN_TV_CDN_ORIGIN = "https://cdn.7tv.app";
+const FAVORITES_KEY = "sevenTVEmotes.favorites";
+
+interface SevenTVSearchEmoteItem {
+    id: string;
+    defaultName?: string;
+}
+
+interface SevenTVSearchResponse {
+    data?: {
+        search?: {
+            all?: {
+                emotes?: {
+                    items?: SevenTVSearchEmoteItem[];
+                };
+            };
+        };
+    };
+}
+
+export async function getFavoriteEmotes(): Promise<Emote[]> {
+    return (await DataStore.get<Emote[]>(FAVORITES_KEY)) ?? [];
+}
+
+export async function setFavoriteEmotes(emotes: Emote[]) {
+    await DataStore.set(FAVORITES_KEY, emotes);
+}
+
+export async function toggleFavoriteEmote(emote: Emote) {
+    const favorites = await getFavoriteEmotes();
+    const existingIndex = favorites.findIndex(favorite => favorite.id === emote.id);
+
+    if (existingIndex === -1) {
+        favorites.unshift(emote);
+    } else {
+        favorites.splice(existingIndex, 1);
+    }
+
+    await setFavoriteEmotes(favorites);
+    return favorites;
+}
+
+export async function isFavoriteEmote(emoteId: string) {
+    return (await getFavoriteEmotes()).some(favorite => favorite.id === emoteId);
+}
+
+interface CachedChannel {
+    id: string;
+    name: string;
+    avatarUrl?: string;
+    emotes: Emote[];
+}
+
+const channelCache = new Map<string, CachedChannel | null>();
+const inflightChannelLoads = new Map<string, Promise<CachedChannel | null>>();
+const globalSearchCache = new Map<string, Emote[]>();
+
+export function clear7TVCache() {
+    channelCache.clear();
+    inflightChannelLoads.clear();
+}
+
+export function emoteUrl(id: string, animated: boolean, size: "1x" | "2x" | "4x" = "2x") {
+    return `${SEVEN_TV_CDN_ORIGIN}/emote/${id}/${size}.${animated ? "avif" : "webp"}`;
+}
+
+export const formatEmote = (emoteId: string) => emoteUrl(emoteId, false, "2x");
+
+async function searchEmotes(query: string, perPage = 5): Promise<SevenTVSearchEmoteItem[] | null> {
+    try {
+        const response = await fetch(`${SEVEN_TV_API_ORIGIN}/v4/gql`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                operationName: "SearchEmote",
+                query: `
+                    query SearchEmote($query: String!, $perPage: Int!) {
+                        search {
+                            all(query: $query, page: 1, perPage: $perPage) {
+                                emotes {
+                                    items {
+                                        id
+                                        defaultName
+                                    }
+                                }
+                            }
+                        }
+                    }
+                `,
+                variables: { query, perPage },
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const data = await response.json() as SevenTVSearchResponse;
+        return data.data?.search?.all?.emotes?.items ?? null;
+    } catch (error) {
+        console.error("Error searching for emotes:", error);
+        return null;
+    }
+}
+
+function getMatchScore(emoteName: string, query: string): number {
+    const name = emoteName.toLowerCase();
+    const q = query.toLowerCase();
+
+    if (name === q) return 1000;
+
+    if (name.startsWith(q)) return 500;
+
+    if (name.includes(q)) return 300;
+
+    let queryIdx = 0;
+    for (let i = 0; i < name.length && queryIdx < q.length; i++) {
+        if (name[i] === q[queryIdx]) queryIdx++;
+    }
+    if (queryIdx === q.length) return 200;
+
+    return 0;
+}
+
+function findBestEmote(emotes: Emote[], query: string): Emote | null {
+    if (!emotes.length) return null;
+
+    let best = emotes[0];
+    let bestScore = getMatchScore(best.name, query);
+
+    for (const emote of emotes) {
+        const score = getMatchScore(emote.name, query);
+        if (score > bestScore) {
+            best = emote;
+            bestScore = score;
+        }
+    }
+
+    return bestScore > 0 ? best : null;
+}
+
+export async function emoteSearchReplacer(message: string): Promise<string> {
+    try {
+        const query = message.trim();
+        if (!query) return "";
+
+        const favorites = await getFavoriteEmotes();
+        const favoriteMatch = findBestEmote(favorites, query);
+        if (favoriteMatch && getMatchScore(favoriteMatch.name, query) >= 200) {
+            return formatEmote(favoriteMatch.id);
+        }
+
+        const { settings } = await import("@plugins/sevenTVEmotes/utils/settings");
+        const channelsConfig = (settings.store.channels as string).split(",").map(c => c.trim()).filter(Boolean);
+        if (channelsConfig.length > 0) {
+            const channels = await load7TVChannels(channelsConfig);
+            for (const channel of channels) {
+                const channelMatch = findBestEmote(channel.emotes, query);
+                if (channelMatch && getMatchScore(channelMatch.name, query) >= 200) {
+                    return formatEmote(channelMatch.id);
+                }
+            }
+        }
+
+        const globalResults = await searchGlobalEmotes(query, 5);
+        const globalMatch = findBestEmote(globalResults, query);
+        if (globalMatch) {
+            return formatEmote(globalMatch.id);
+        }
+
+        return "";
+    } catch (error) {
+        console.error("Error replacing emote:", error);
+        return "";
+    }
+}
+
+export async function searchGlobalEmotes(query: string, perPage = 100): Promise<Emote[]> {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return [];
+
+    const cached = globalSearchCache.get(normalized);
+    if (cached) return cached;
+
+    const results = await searchEmotes(query, perPage);
+    const mapped = results?.map(item => ({
+        id: item.id,
+        name: item.defaultName ?? query,
+        animated: false,
+    })) ?? [];
+
+    globalSearchCache.set(normalized, mapped);
+    return mapped;
+}
+
+async function resolveUserId(input: string): Promise<string> {
+    const normalized = input.trim();
+    if (!normalized) return input;
+
+    try {
+        const res = await fetch(`${SEVEN_TV_API_ORIGIN}/v3/users/${encodeURIComponent(normalized)}`);
+        if (res.ok) {
+            const data = await res.json();
+            return data?.id ?? normalized;
+        }
+    } catch { }
+
+    try {
+        const res = await fetch(`${SEVEN_TV_API_ORIGIN}/v3/gql`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                operationName: "SearchUsers",
+                query: "query SearchUsers($query:String!){users(query:$query){id username display_name}}",
+                variables: { query: normalized },
+            }),
+        });
+        if (res.ok) {
+            const data: SevenTVGraphQLSearchResponse = await res.json();
+            const lower = normalized.toLowerCase();
+            const user = data.data?.users?.find(u =>
+                u.username?.toLowerCase() === lower || u.display_name?.toLowerCase() === lower
+            );
+            if (user?.id) return user.id;
+        }
+    } catch { }
+
+    return normalized;
+}
+
+function addEmotes(source: SevenTVEmote[] | undefined, seen: Set<string>, all: Emote[]) {
+    source?.forEach(e => {
+        if (seen.has(e.id)) return;
+        seen.add(e.id);
+        all.push({ id: e.id, name: e.name, animated: e.data?.animated ?? false });
+    });
+}
+
+function getChannelEmotes(data: SevenTVUserResponse) {
+    const all: Emote[] = [];
+    const seen = new Set<string>();
+
+    if (data.emote_set?.emotes?.length) {
+        addEmotes(data.emote_set.emotes, seen, all);
+        return all;
+    }
+
+    const connection = data.connections?.find(c => c.emote_set?.emotes?.length);
+    addEmotes(connection?.emote_set?.emotes, seen, all);
+    return all;
+}
+
+function getCacheKey(raw: string) {
+    return raw.trim().toLowerCase();
+}
+
+async function loadSingleChannel(raw: string): Promise<CachedChannel | null> {
+    try {
+        const id = await resolveUserId(raw.trim());
+        const res = await fetch(`${SEVEN_TV_API_ORIGIN}/v3/users/${id}`);
+        if (!res.ok) return null;
+
+        const data: SevenTVUserResponse = await res.json();
+        return {
+            id: data.id ?? id,
+            name: data.display_name ?? data.username ?? raw,
+            avatarUrl: data.avatar_url,
+            emotes: getChannelEmotes(data),
+        };
+    } catch {
+        return null;
+    }
+}
+
+async function loadSingleChannelCached(raw: string): Promise<CachedChannel | null> {
+    const cacheKey = getCacheKey(raw);
+    if (!cacheKey) return null;
+
+    if (channelCache.has(cacheKey)) {
+        return channelCache.get(cacheKey) ?? null;
+    }
+
+    const inflight = inflightChannelLoads.get(cacheKey);
+    if (inflight) return inflight;
+
+    const request = loadSingleChannel(raw).then(channel => {
+        channelCache.set(cacheKey, channel);
+        inflightChannelLoads.delete(cacheKey);
+        return channel;
+    });
+
+    inflightChannelLoads.set(cacheKey, request);
+    return request;
+}
+
+export async function load7TVChannels(userIds: string[]): Promise<SevenTVChannel[]> {
+    const results: Array<SevenTVChannel | null> = await Promise.all(userIds.map(async (raw, index) => {
+        const channel = await loadSingleChannelCached(raw);
+        if (!channel) return null;
+
+        return {
+            key: `${channel.id}:${index}`,
+            id: channel.id,
+            name: channel.name,
+            avatarUrl: channel.avatarUrl,
+            emotes: channel.emotes,
+        };
+    }));
+
+    return results.filter((channel): channel is SevenTVChannel => channel !== null);
+}

--- a/src/plugins/sevenTVEmotes/components/channelsManager.tsx
+++ b/src/plugins/sevenTVEmotes/components/channelsManager.tsx
@@ -1,0 +1,132 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Button } from "@components/Button";
+import { DeleteIcon } from "@components/Icons";
+import { load7TVChannels } from "@plugins/sevenTVEmotes/api/api";
+import { settings } from "@plugins/sevenTVEmotes/utils/settings";
+import { React, TextInput, useEffect, useMemo, useState } from "@webpack/common";
+
+function parseChannels(raw: string) {
+    return raw
+        .split(",")
+        .map(s => s.trim())
+        .filter(Boolean);
+}
+
+function serializeChannels(channels: string[]) {
+    return channels.join(", ");
+}
+
+function buildAvatarByIndex(channels: Awaited<ReturnType<typeof load7TVChannels>>) {
+    const byIndex = new Map<number, string>();
+
+    for (const channel of channels) {
+        const index = Number(channel.key.split(":").at(-1));
+        if (Number.isNaN(index) || !channel.avatarUrl) continue;
+        byIndex.set(index, channel.avatarUrl);
+    }
+
+    return byIndex;
+}
+
+export function SettingsChannelsManager() {
+    const { channels } = settings.use(["channels"]);
+    const configuredChannels = useMemo(() => parseChannels(channels), [channels]);
+
+    const [input, setInput] = useState("");
+    const [avatarByIndex, setAvatarByIndex] = useState<Map<number, string>>(new Map());
+
+    useEffect(() => {
+        let alive = true;
+
+        if (configuredChannels.length === 0) {
+            setAvatarByIndex(new Map());
+            return;
+        }
+
+        load7TVChannels(configuredChannels).then(list => {
+            if (!alive) return;
+            setAvatarByIndex(buildAvatarByIndex(list));
+        });
+
+        return () => { alive = false; };
+    }, [channels]);
+
+    const addChannel = () => {
+        const value = input.trim();
+        if (!value) return;
+
+        const lower = value.toLowerCase();
+        if (configuredChannels.some(ch => ch.toLowerCase() === lower)) {
+            setInput("");
+            return;
+        }
+
+        settings.store.channels = serializeChannels([...configuredChannels, value]);
+        setInput("");
+    };
+
+    const removeChannel = (index: number) => {
+        settings.store.channels = serializeChannels(configuredChannels.filter((_, i) => i !== index));
+    };
+
+    return (
+        <div className="vc-7tv-settings-root">
+            <div className="vc-7tv-settings-row">
+                <TextInput
+                    placeholder="7TV username or user ID"
+                    value={input}
+                    onChange={setInput}
+                    onKeyDown={event => {
+                        if (event.key === "Enter") {
+                            event.preventDefault();
+                            addChannel();
+                        }
+                    }}
+                />
+                <Button onClick={addChannel} disabled={!input.trim()}>
+                    Add
+                </Button>
+            </div>
+
+            <div className="vc-7tv-settings-list">
+                {configuredChannels.length === 0 && (
+                    <div className="vc-7tv-settings-empty">No channels added yet.</div>
+                )}
+
+                {configuredChannels.map((channel, index) => (
+                    <div key={`${channel}:${index}`} className="vc-7tv-settings-item">
+                        {avatarByIndex.get(index)
+                            ? (
+                                <img
+                                    src={avatarByIndex.get(index)}
+                                    alt={channel}
+                                    className="vc-7tv-settings-avatar"
+                                    loading="lazy"
+                                />
+                            )
+                            : (
+                                <div className="vc-7tv-settings-avatar vc-7tv-settings-avatar-fallback">
+                                    {channel.slice(0, 2).toUpperCase()}
+                                </div>
+                            )}
+
+                        <span className="vc-7tv-settings-channel-name">{channel}</span>
+
+                        <Button
+                            variant="dangerSecondary"
+                            size="iconOnly"
+                            onClick={() => removeChannel(index)}
+                        >
+                            <DeleteIcon aria-label="Remove channel" width={16} height={16} />
+                        </Button>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/plugins/sevenTVEmotes/components/sevenTVPicker.tsx
+++ b/src/plugins/sevenTVEmotes/components/sevenTVPicker.tsx
@@ -1,0 +1,465 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { clear7TVCache, emoteUrl, getFavoriteEmotes, load7TVChannels, searchGlobalEmotes, toggleFavoriteEmote } from "@plugins/sevenTVEmotes/api/api";
+import { ensureSevenTvCsp } from "@plugins/sevenTVEmotes/utils/csp";
+import { settings } from "@plugins/sevenTVEmotes/utils/settings";
+import type { Emote, SevenTVChannel } from "@plugins/sevenTVEmotes/utils/types";
+import { classNameFactory } from "@utils/css";
+import { insertTextIntoChatInputBox } from "@utils/discord";
+import { React, useCallback, useEffect, useState } from "@webpack/common";
+
+const cl = classNameFactory("vc-7tv-");
+
+interface ChannelButtonProps {
+    title: string;
+    isActive: boolean;
+    onClick: () => void;
+    children: React.ReactNode;
+    className?: string;
+}
+
+interface SevenTVPickerProps {
+    closePopout: () => void;
+    onOpenSettings: () => void;
+}
+
+function ChannelButton({ title, isActive, onClick, children, className }: ChannelButtonProps) {
+    return (
+        <div className={cl("pill-wrapper", { "pill-active": isActive })}>
+            <div className={cl("pill")} />
+            <button
+                type="button"
+                title={title}
+                aria-label={title}
+                onClick={onClick}
+                className={[
+                    cl("channel-button"),
+                    isActive ? cl("channel-button-active") : "",
+                    className ?? "",
+                ].filter(Boolean).join(" ")}
+            >
+                {children}
+            </button>
+        </div>
+    );
+}
+
+export function SevenTVPicker({ closePopout, onOpenSettings }: SevenTVPickerProps) {
+    const [channels, setChannels] = useState<SevenTVChannel[]>([]);
+    const [selectedChannelKey, setSelectedChannelKey] = useState<string>("all");
+    const [search, setSearch] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [favorites, setFavorites] = useState<Emote[]>([]);
+    const [globalSearchResults, setGlobalSearchResults] = useState<Emote[]>([]);
+    const [searchLoading, setSearchLoading] = useState(false);
+    const [cspReady, setCspReady] = useState(IS_WEB);
+    const [reloadNonce, setReloadNonce] = useState(0);
+
+    const userIds = settings.store.channels
+        .split(",").map((s: string) => s.trim()).filter(Boolean);
+
+    useEffect(() => {
+        let alive = true;
+
+        if (IS_WEB) {
+            setCspReady(true);
+            return;
+        }
+
+        ensureSevenTvCsp().then(ready => {
+            if (!alive) return;
+            setCspReady(ready);
+            if (!ready) setLoading(false);
+        });
+
+        return () => { alive = false; };
+    }, []);
+
+    useEffect(() => {
+        let alive = true;
+        getFavoriteEmotes().then(list => {
+            if (!alive) return;
+            setFavorites(list);
+        });
+        return () => { alive = false; };
+    }, []);
+
+    useEffect(() => {
+        if (!cspReady) return;
+
+        let alive = true;
+        setLoading(true);
+
+        load7TVChannels(userIds).then(list => {
+            if (!alive) return;
+
+            setChannels(list);
+            setSelectedChannelKey(cur =>
+                cur === "all" || list.some(ch => ch.key === cur) ? cur : "all"
+            );
+            setLoading(false);
+        });
+
+        return () => { alive = false; };
+    }, [cspReady, settings.store.channels, reloadNonce]);
+
+    useEffect(() => {
+        if (selectedChannelKey !== "all") {
+            setGlobalSearchResults([]);
+            setSearchLoading(false);
+            return;
+        }
+
+        const query = search.trim();
+        if (!query) {
+            setGlobalSearchResults([]);
+            setSearchLoading(false);
+            return;
+        }
+
+        let alive = true;
+        setSearchLoading(true);
+        const timeout = setTimeout(() => {
+            searchGlobalEmotes(query).then(list => {
+                if (!alive) return;
+                setGlobalSearchResults(list);
+                setSearchLoading(false);
+            });
+        }, 250);
+
+        return () => {
+            alive = false;
+            clearTimeout(timeout);
+        };
+    }, [search, selectedChannelKey]);
+
+    const allEmotes = channels
+        .flatMap(ch => ch.emotes)
+        .filter((e, i, arr) => arr.findIndex(o => o.id === e.id) === i);
+
+    const favoriteIds = new Set(favorites.map(favorite => favorite.id));
+
+    const activeEmotes = selectedChannelKey === "all"
+        ? (search.trim() ? globalSearchResults : allEmotes)
+        : selectedChannelKey === "favorites"
+            ? favorites
+            : channels.find(ch => ch.key === selectedChannelKey)?.emotes ?? [];
+
+    const filtered = search
+        ? selectedChannelKey === "all"
+            ? activeEmotes
+            : activeEmotes.filter(e => e.name.toLowerCase().includes(search.toLowerCase()))
+        : activeEmotes;
+
+    const sendEmote = useCallback((emote: Emote) => {
+        insertTextIntoChatInputBox(`${emoteUrl(emote.id, emote.animated, "4x")} `);
+        closePopout();
+    }, [closePopout]);
+
+    const handleEmoteClick = useCallback(async (emote: Emote, event: React.MouseEvent) => {
+        if (event.ctrlKey || event.metaKey) {
+            const updated = await toggleFavoriteEmote(emote);
+            setFavorites(updated);
+            if (selectedChannelKey === "favorites") {
+                setGlobalSearchResults([]);
+            }
+            return;
+        }
+
+        sendEmote(emote);
+    }, [selectedChannelKey, sendEmote]);
+
+    const handleEmoteContextMenu = useCallback(async (emote: Emote, event: React.MouseEvent) => {
+        event.preventDefault();
+        const updated = await toggleFavoriteEmote(emote);
+        setFavorites(updated);
+    }, []);
+
+    const refreshChannels = useCallback(() => {
+        clear7TVCache();
+        setReloadNonce(n => n + 1);
+    }, []);
+
+    return (
+        <div className={cl("root")} style={{
+            display: "flex",
+            height: "100%",
+            width: "100%",
+            boxSizing: "border-box",
+            overflow: "hidden",
+        }}>
+            <div style={{
+                width: "60px",
+                minWidth: "60px",
+                flexShrink: 0,
+                position: "relative",
+                background: "var(--background-secondary)",
+                borderRight: "1px solid var(--background-modifier-accent)",
+                display: "flex",
+                flexDirection: "column",
+            }}>
+                <div
+                    className={cl("sidebar", "scrollbar")}
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        gap: "6px",
+                        overflowY: "auto",
+                        overflowX: "hidden",
+                        flex: 1,
+                        paddingTop: "8px",
+                        paddingBottom: "8px",
+                    }}
+                >
+                    <ChannelButton
+                        title="All channels"
+                        isActive={selectedChannelKey === "all"}
+                        onClick={() => setSelectedChannelKey("all")}
+                    >
+                        <svg
+                            width="20"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="M5 13.5H3.5V20.5H10.5V13.5H9M13.5 5V3.5H20.5V10.5H13.5V9M3.5 3.5H10.5V10.5H3.5V3.5ZM13.5 13.5H20.5V20.5H13.5V13.5Z"
+                                stroke="#23a55a"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                        </svg>
+                    </ChannelButton>
+                    <ChannelButton
+                        title="Favorites"
+                        isActive={selectedChannelKey === "favorites"}
+                        onClick={() => setSelectedChannelKey("favorites")}
+                    >
+                        <svg width="22" height="22" viewBox="0 0 24 24" fill="#FFD700" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                            <path d="M12 2l2.9 5.88L21.4 9l-4.7 4.58L17.8 21 12 17.97 6.2 21l1.1-7.42L2.6 9l6.5-1.12L12 2z" />
+                        </svg>
+                    </ChannelButton>
+                    <div style={{
+                        width: "32px",
+                        height: "2px",
+                        borderRadius: "1px",
+                        background: "var(--background-modifier-accent)",
+                        flexShrink: 0,
+                        margin: "2px 0",
+                    }} />
+
+                    {channels.map(ch => (
+                        <ChannelButton
+                            key={ch.key}
+                            title={ch.name}
+                            isActive={selectedChannelKey === ch.key}
+                            onClick={() => setSelectedChannelKey(ch.key)}
+                        >
+                            {ch.avatarUrl ? (
+                                <img
+                                    src={ch.avatarUrl}
+                                    alt={ch.name}
+                                    style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                                    loading="lazy"
+                                />
+                            ) : (
+                                <span style={{ fontSize: "11px" }}>
+                                    {ch.name.slice(0, 2).toUpperCase()}
+                                </span>
+                            )}
+                        </ChannelButton>
+                    ))}
+
+                    <div style={{ flex: 1, minHeight: "8px" }} />
+
+                    <ChannelButton
+                        title="7TV settings"
+                        isActive={false}
+                        onClick={onOpenSettings}
+                        className={cl("settings-button")}
+                    >
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
+                        </svg>
+                    </ChannelButton>
+                </div>
+            </div>
+
+            <div style={{
+                display: "flex",
+                flexDirection: "column",
+                minWidth: 0,
+                minHeight: 0,
+                flex: 1,
+                gap: "8px",
+                padding: "8px",
+                background: "var(--background-primary)",
+            }}>
+                <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+                    <input
+                        type="text"
+                        placeholder="Search 7TV emotes..."
+                        value={search}
+                        onChange={ev => setSearch(ev.target.value)}
+                        onClick={ev => ev.stopPropagation()}
+                        onKeyDown={ev => { ev.stopPropagation(); ev.nativeEvent.stopImmediatePropagation(); }}
+                        onKeyUp={ev => { ev.stopPropagation(); ev.nativeEvent.stopImmediatePropagation(); }}
+                        onKeyPress={ev => { ev.stopPropagation(); ev.nativeEvent.stopImmediatePropagation(); }}
+                        autoFocus
+                        className={cl("search-input")}
+                        style={{
+                            borderRadius: "4px",
+                            padding: "6px 10px",
+                            width: "100%",
+                            minWidth: 0,
+                            boxSizing: "border-box",
+                            outline: "none",
+                            fontSize: "14px",
+                            border: "1px solid var(--input-border, var(--background-tertiary))",
+                            background: "var(--input-background)",
+                            color: "inherit",
+                            WebkitTextFillColor: "inherit",
+                            caretColor: "inherit"
+                        }}
+                    />
+                    <button
+                        type="button"
+                        title="Refresh emotes"
+                        aria-label="Refresh emotes"
+                        className="vc-7tv-refresh-button"
+                        onClick={ev => {
+                            ev.stopPropagation();
+                            refreshChannels();
+                        }}
+                        style={{
+                            borderRadius: "4px",
+                            border: "1px solid var(--background-modifier-accent)",
+                            background: "var(--background-secondary)",
+                            height: "32px",
+                            padding: "0 10px",
+                            fontSize: "12px",
+                            fontWeight: 600,
+                            cursor: "pointer",
+                            flexShrink: 0,
+                        }}
+                    >
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
+                        >
+                            <path
+                                d="M20 4V9H15"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <path
+                                d="M4 20V15H9"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <path
+                                d="M5.5 9C6.45 6.67 8.95 5 11.83 5C14.27 5 16.43 6.18 17.79 8"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                            />
+                            <path
+                                d="M18.5 15C17.55 17.33 15.05 19 12.17 19C9.73 19 7.57 17.82 6.21 16"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                            />
+                        </svg>
+                    </button>
+                </div>
+
+                {loading ? (
+                    <p style={{ color: "var(--text-muted)", textAlign: "center", marginTop: "20px" }}>
+                        Loading emotes...
+                    </p>
+                ) : (
+                    <div className={cl("emote-grid", "scrollbar")} style={{
+                        display: "grid",
+                        gridTemplateColumns: "repeat(auto-fill, 64px)",
+                        gap: "4px",
+                        overflowY: "auto",
+                        overflowX: "hidden",
+                        flexGrow: 1,
+                        alignContent: "start",
+                        paddingBottom: "8px",
+                    }}>
+                        {filtered.map(emote => (
+                            <button
+                                key={emote.id}
+                                title={emote.name}
+                                onClick={event => void handleEmoteClick(emote, event)}
+                                onContextMenu={event => void handleEmoteContextMenu(emote, event)}
+                                style={{
+                                    position: "relative",
+                                    background: "none",
+                                    border: "none",
+                                    borderRadius: "4px",
+                                    cursor: "pointer",
+                                    padding: "4px",
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    alignItems: "center",
+                                    width: "64px",
+                                    height: "72px",
+                                }}
+                                onMouseEnter={e => (e.currentTarget.style.background = "var(--background-modifier-hover)")}
+                                onMouseLeave={e => (e.currentTarget.style.background = "none")}
+                            >
+                                {favoriteIds.has(emote.id) && (
+                                    <span className="vc-7tv-favorite-star" aria-hidden="true">★</span>
+                                )}
+                                <img
+                                    src={emoteUrl(emote.id, emote.animated, "2x")}
+                                    alt={emote.name}
+                                    style={{ width: "48px", height: "48px", objectFit: "contain" }}
+                                    loading="lazy"
+                                />
+                                <span style={{
+                                    fontSize: "9px",
+                                    color: "var(--text-muted)",
+                                    width: "100%",
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    whiteSpace: "nowrap",
+                                    textAlign: "center",
+                                }}>
+                                    {emote.name}
+                                </span>
+                            </button>
+                        ))}
+                        {filtered.length === 0 && (
+                            <p style={{ color: "var(--text-muted)", gridColumn: "1/-1", textAlign: "center" }}>
+                                No emotes found
+                            </p>
+                        )}
+                    </div>
+                )}
+                {selectedChannelKey === "all" && searchLoading && (
+                    <p style={{ color: "var(--text-muted)", textAlign: "center" }}>
+                        Searching 7TV...
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/plugins/sevenTVEmotes/index.tsx
+++ b/src/plugins/sevenTVEmotes/index.tsx
@@ -1,0 +1,101 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles/style.css";
+
+import { openPluginModal } from "@components/settings";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import type { Channel as DiscordChannel } from "@vencord/discord-types";
+import type { ComponentType } from "react";
+
+import { emoteSearchReplacer } from "./api/api";
+import { SevenTVPicker } from "./components/sevenTVPicker";
+import { settings } from "./utils/settings";
+import { type ExpressionPickerTabProps, ExpressionPickerView } from "./utils/types";
+
+const sevenTVPlugin = definePlugin({
+    name: "7TVEmotes",
+    description: "Adds a 7TV tab to the Discord expression picker",
+    tags: ["Chat", "Emotes"],
+    authors: [Devs.yuki6942],
+    settings,
+
+    patches: [
+        {
+            find: "#{intl::EXPRESSION_PICKER_CATEGORIES_A11Y_LABEL}",
+            replacement: [
+                {
+                    match: /\(0,\i\.jsx\)\((\i),[^}]{20,40}?"aria-selected":(\i)[^}]{50,100}?#{intl::EXPRESSION_PICKER_GIF}\)\}\)/,
+                    replace: "$self.renderTabs($1,$2)"
+                },
+                {
+                    match: /\{onSelectGIF:(\i),[^}]{20,40}\}\):null,(?=(\i)===)/,
+                    replace: "$&$self.renderSevenTVPicker($2),"
+                }
+            ]
+        },
+    ],
+
+    renderTabs(Tab: ComponentType<ExpressionPickerTabProps>, activeView: ExpressionPickerView) {
+        return (
+            <>
+                <Tab
+                    id="gif-picker-tab"
+                    key="gif-picker-tab"
+                    aria-controls="gif-picker-tab-panel"
+                    aria-selected={activeView === ExpressionPickerView.GIF}
+                    isActive={activeView === ExpressionPickerView.GIF}
+                    viewType={ExpressionPickerView.GIF}
+                >
+                    GIFs
+                </Tab>
+                <Tab
+                    id="7tv-picker-tab"
+                    key="7tv-picker-tab"
+                    aria-controls="7tv-picker-tab-panel"
+                    aria-selected={activeView === ExpressionPickerView.SEVEN_TV}
+                    isActive={activeView === ExpressionPickerView.SEVEN_TV}
+                    viewType={ExpressionPickerView.SEVEN_TV}
+                >
+                    7TV
+                </Tab>
+            </>
+        );
+    },
+
+    async onBeforeMessageSend(_, msg) {
+        if (!msg.content) return;
+
+        const matched = msg.content.match(/^:\+(.+):$/);
+        if (!matched) return;
+
+        const emote = await emoteSearchReplacer(matched[1]);
+        if (emote) msg.content = emote;
+    },
+
+    renderSevenTVPicker(activeView: ExpressionPickerView) {
+        return activeView === ExpressionPickerView.SEVEN_TV
+            ? (
+                <SevenTVPicker
+                    closePopout={() => { }}
+                    onOpenSettings={() => openPluginModal(sevenTVPlugin)}
+                />
+            )
+            : null;
+    },
+
+    sevenTVComponent({ closePopout }: { channel: DiscordChannel; closePopout: () => void; }) {
+        return (
+            <SevenTVPicker
+                closePopout={closePopout}
+                onOpenSettings={() => openPluginModal(sevenTVPlugin)}
+            />
+        );
+    },
+});
+
+export default sevenTVPlugin;

--- a/src/plugins/sevenTVEmotes/styles/style.css
+++ b/src/plugins/sevenTVEmotes/styles/style.css
@@ -1,0 +1,250 @@
+.vc-7tv-pill-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+}
+
+.vc-7tv-pill {
+    position: absolute;
+    left: -2px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 4px;
+    border-radius: 0 4px 4px 0;
+    pointer-events: none;
+    height: 0;
+    opacity: 0;
+    transition:
+        height 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+        opacity 0.15s ease;
+    background: #fff;
+}
+
+.theme-dark .vc-7tv-pill {
+    background: #fff !important;
+}
+
+.theme-light .vc-7tv-pill {
+    background: #060607 !important;
+}
+
+.vc-7tv-pill-wrapper:hover .vc-7tv-pill,
+.vc-7tv-pill-wrapper:focus-within .vc-7tv-pill {
+    height: 20px;
+    opacity: 1;
+}
+
+.vc-7tv-pill-wrapper.vc-7tv-pill-active .vc-7tv-pill {
+    height: 40px;
+    opacity: 1;
+}
+
+.vc-7tv-channel-button {
+    width: 44px;
+    height: 44px;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: var(--background-secondary);
+    color: var(--interactive-normal);
+    transition:
+        border-radius 0.15s ease,
+        background 0.15s ease,
+        color 0.15s ease;
+}
+
+.vc-7tv-channel-button:hover {
+    border-radius: 30%;
+    background: var(--brand-experiment);
+    color: #fff;
+}
+
+.vc-7tv-channel-button-active {
+    border-radius: 30% !important;
+    background: var(--brand-experiment) !important;
+    color: #fff !important;
+}
+
+.vc-7tv-settings-button {
+    color: var(--status-positive) !important;
+    background: var(--background-secondary);
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.vc-7tv-settings-button:hover {
+    color: #fff !important;
+    background: var(--status-positive) !important;
+}
+
+.vc-7tv-search-input {
+    background: var(--input-background) !important;
+    border: 1px solid var(--input-border, var(--background-tertiary)) !important;
+    caret-color: #fff !important;
+}
+
+.theme-dark .vc-7tv-search-input,
+.theme-dark .vc-7tv-search-input input {
+    color: #fff !important;
+    -webkit-text-fill-color: #fff !important;
+    caret-color: #fff !important;
+}
+
+.theme-light .vc-7tv-search-input,
+.theme-light .vc-7tv-search-input input {
+    color: #060607 !important;
+    -webkit-text-fill-color: #060607 !important;
+    caret-color: #060607 !important;
+}
+
+.vc-7tv-search-input:focus {
+    border-color: var(--brand-experiment);
+    box-shadow: 0 0 0 1px var(--brand-experiment);
+}
+
+.theme-dark .vc-7tv-search-input::placeholder {
+    color: #b5bac1 !important;
+    -webkit-text-fill-color: #b5bac1 !important;
+}
+
+.theme-light .vc-7tv-search-input::placeholder {
+    color: #747f8d !important;
+    -webkit-text-fill-color: #747f8d !important;
+}
+
+.vc-7tv-search-input::selection {
+    background: var(--brand-experiment);
+    color: #fff;
+}
+
+.vc-7tv-scrollbar {
+    scrollbar-color: var(--scrollbar-thin-thumb) var(--scrollbar-thin-track);
+}
+
+.vc-7tv-scrollbar::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+.vc-7tv-scrollbar::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thin-thumb);
+    border-radius: 999px;
+    border: 2px solid var(--scrollbar-thin-track);
+}
+
+.vc-7tv-scrollbar::-webkit-scrollbar-track {
+    background: var(--scrollbar-thin-track);
+}
+
+.vc-7tv-settings-root {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 6px;
+}
+
+.vc-7tv-settings-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.vc-7tv-settings-row > div:first-child {
+    flex: 1;
+}
+
+.vc-7tv-settings-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.vc-7tv-settings-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--background-modifier-accent);
+    background: var(--background-secondary);
+    border-radius: 8px;
+    padding: 6px 8px;
+}
+
+.vc-7tv-settings-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
+.vc-7tv-settings-avatar-fallback {
+    display: grid;
+    place-items: center;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--interactive-active);
+    background: var(--background-primary);
+}
+
+.vc-7tv-settings-channel-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+    color: inherit;
+}
+
+.vc-7tv-refresh-button {
+    color: inherit;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.vc-7tv-refresh-button:hover {
+    background: var(--background-modifier-hover) !important;
+    color: inherit !important;
+}
+
+.theme-dark .vc-7tv-settings-channel-name,
+.theme-dark .vc-7tv-refresh-button,
+.theme-dark .vc-7tv-refresh-button svg {
+    color: #fff !important;
+    -webkit-text-fill-color: #fff !important;
+}
+
+.theme-light .vc-7tv-settings-channel-name,
+.theme-light .vc-7tv-refresh-button,
+.theme-light .vc-7tv-refresh-button svg {
+    color: #060607 !important;
+    -webkit-text-fill-color: #060607 !important;
+}
+
+.vc-7tv-settings-item button {
+    margin-left: auto;
+}
+
+.vc-7tv-settings-empty {
+    color: var(--text-muted);
+    font-size: 13px;
+    padding: 6px 2px;
+}
+
+.vc-7tv-favorite-star {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
+    font-size: 16px;
+    line-height: 1;
+    color: #FFD700 !important;
+    text-shadow: 0 1px 2px rgb(0 0 0 / 60%) !important;
+    pointer-events: none;
+    filter: drop-shadow(0 0 1px #FFD700) !important;
+    -webkit-text-fill-color: #FFD700 !important;
+}

--- a/src/plugins/sevenTVEmotes/utils/csp.ts
+++ b/src/plugins/sevenTVEmotes/utils/csp.ts
@@ -1,0 +1,49 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { SEVEN_TV_API_ORIGIN, SEVEN_TV_CDN_ORIGIN } from "@plugins/sevenTVEmotes/api/api";
+import { relaunch } from "@utils/native";
+import { Alerts } from "@webpack/common";
+
+export async function ensureSevenTvCsp() {
+    if (IS_WEB) return true;
+
+    const hasApiConnect = await VencordNative.csp.isDomainAllowed(SEVEN_TV_API_ORIGIN, ["connect-src"]);
+    const hasCdnImg = await VencordNative.csp.isDomainAllowed(SEVEN_TV_CDN_ORIGIN, ["img-src"]);
+
+    let addedOverride = false;
+
+    if (!hasApiConnect) {
+        const result = await VencordNative.csp.requestAddOverride(SEVEN_TV_API_ORIGIN, ["connect-src"], "7TV Emotes");
+        if (result === "ok") {
+            addedOverride = true;
+        } else {
+            return false;
+        }
+    }
+
+    if (!hasCdnImg) {
+        const result = await VencordNative.csp.requestAddOverride(SEVEN_TV_CDN_ORIGIN, ["img-src"], "7TV Emotes");
+        if (result === "ok") {
+            addedOverride = true;
+        } else {
+            return false;
+        }
+    }
+
+    if (addedOverride) {
+        Alerts.show({
+            title: "Restart Required",
+            body: "7TV domains were allowed. Please fully restart Discord/Vesktop to apply CSP changes.",
+            confirmText: "Restart now",
+            cancelText: "Later",
+            onConfirm: relaunch
+        });
+        return false;
+    }
+
+    return true;
+}

--- a/src/plugins/sevenTVEmotes/utils/settings.ts
+++ b/src/plugins/sevenTVEmotes/utils/settings.ts
@@ -1,0 +1,20 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { SettingsChannelsManager } from "@plugins/sevenTVEmotes/components/channelsManager";
+import { OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    channels: {
+        type: OptionType.CUSTOM,
+        default: "",
+    },
+    channelsManager: {
+        type: OptionType.COMPONENT,
+        component: SettingsChannelsManager,
+    },
+});

--- a/src/plugins/sevenTVEmotes/utils/types.ts
+++ b/src/plugins/sevenTVEmotes/utils/types.ts
@@ -1,0 +1,72 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import type { PropsWithChildren } from "react";
+
+export interface Emote {
+    id: string;
+    name: string;
+    animated: boolean;
+}
+
+export enum ExpressionPickerView {
+    GIF = "gif",
+    SEVEN_TV = "7tv",
+}
+
+export interface ExpressionPickerTabProps extends PropsWithChildren {
+    id?: string;
+    "aria-controls"?: string;
+    "aria-selected"?: boolean;
+    isActive?: boolean;
+    viewType: ExpressionPickerView;
+}
+
+export interface SevenTVChannel {
+    key: string;
+    id: string;
+    name: string;
+    avatarUrl?: string;
+    emotes: Emote[];
+}
+
+export interface SevenTVEmote {
+    id: string;
+    name: string;
+    data?: {
+        animated?: boolean;
+    };
+}
+
+export interface SevenTVConnection {
+    platform?: string;
+    emote_set?: {
+        emotes?: SevenTVEmote[];
+    };
+}
+
+export interface SevenTVUserResponse {
+    id?: string;
+    username?: string;
+    display_name?: string;
+    avatar_url?: string;
+    connections?: SevenTVConnection[];
+    emote_set?: {
+        emotes?: SevenTVEmote[];
+    };
+}
+
+export interface SevenTVGraphQLUser {
+    id: string;
+    username?: string;
+    display_name?: string;
+}
+
+export interface SevenTVGraphQLSearchResponse {
+    data?: {
+        users?: SevenTVGraphQLUser[];
+    };
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -629,6 +629,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    yuki6942: {
+        name: "yuki6942",
+        id: 594627968668794896n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Adds a new 7TV tab to Discord's expression picker so you can browse and use 7TV emotes directly alongside GIFs and stickers.

**Features:**
- Dedicated 7TV tab in the expression picker
- Favorites system for quick access to frequently used emotes
- Add 7TV channels to browse their collections
- Global search with smart priority (favorites -> channels -> global)
- `:+emotename:` syntax to auto-expand to 7TV emote URLs
