### PR TITLE
QuickCSS: drop inherited app menu so close shortcuts only close the e…

### DIFF
--- a/src/main/ipcMain.ts
+++ b/src/main/ipcMain.ts
@@ -163,6 +163,8 @@ ipcMain.handle(IpcEvents.OPEN_MONACO_EDITOR, async () => {
         }
     });
 
+    win.removeMenu();
+
     makeLinksOpenExternally(win);
 
     await win.loadURL(`data:text/html;base64,${monacoHtml}`);


### PR DESCRIPTION
## What this fixes

Pressing `Alt+F4` on the Vencord QuickCSS Editor window quits the entire
Discord client instead of only the editor, closes #2548.

## Root cause

The QuickCSS `BrowserWindow` is created without a per-window menu, so
on Windows and Linux it inherits Discord's application menu. The
inherited menu's accelerators (Quit) keep firing from this window even
though `autoHideMenuBar: true` is set, that option only hides the bar,
it doesn't disable accelerators.

## Fix

Call `win.removeMenu()` immediately after creating the BrowserWindow.

- **Windows/Linux**: per-window menu is removed, so inherited
  accelerators no longer fire from the QuickCSS window. `Alt+F4` falls
  back to the OS-level "close focused window" behavior, and any other
  inherited menu accelerator on Linux (e.g. `Ctrl+Q`) becomes inert
  here.
- **macOS**: `removeMenu` is a no-op (the menu is global). `Cmd+Q`
  quitting the focused app is the OS convention there and is left
  untouched, matching the position taken in the issue thread by
  @Tiagoquix.

This addresses the platform-coverage concern raised on #2493
("the shortcut is different on linux & mac") without trying to
intercept individual key combinations.

## Validation

End-to-end on Discord Canary (Windows 11):

- Built the dev bundle from the parent commit (without this change),
  injected, opened QuickCSS, pressed `Alt+F4` → entire Discord client
  closed (bug reproduced).
- Built with this change applied, re-injected, repeated the steps →
  only the QuickCSS window closed; Discord remained open.