### PR TITLE
fix(plugins): narrow MessageStore webpack patch find strings

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -350,7 +350,8 @@ export default definePlugin({
 
     patches: [
         {
-            find: '"MessageStore"',
+            // Narrow match: plain "MessageStore" hits many webpack chunks and breaks unrelated modules on new Discord builds.
+            find: "static displayName=\"MessageStore\"",
             replacement: [
                 {
                     // Add deleted=true to all target messages in the MESSAGE_DELETE event
@@ -492,7 +493,7 @@ export default definePlugin({
 
         {
             // ReferencedMessageStore
-            find: '"ReferencedMessageStore"',
+            find: "static displayName=\"ReferencedMessageStore\"",
             replacement: [
                 {
                     match: /(?<=MESSAGE_DELETE:function\(\i\)\{)/,

--- a/src/plugins/noBlockedMessages/index.ts
+++ b/src/plugins/noBlockedMessages/index.ts
@@ -64,7 +64,7 @@ export default definePlugin({
             ]
         },
         {
-            find: '"MessageStore"',
+            find: "static displayName=\"MessageStore\"",
             predicate: () => settings.store.ignoreMessages,
             replacement: [
                 {


### PR DESCRIPTION
Plain '"MessageStore"' appears in many webpack chunks, so MessageLogger and NoBlockedMessages patches could run on the wrong module factory. That produced invalid JS after substitution and eval() threw SyntaxError (e.g. Discord stable 1.0.136), often showing a blank client.

Scope patches to the flux store implementation via static displayName="MessageStore" / "ReferencedMessageStore", which is unique in the main web bundle.