### PR TITLE
feat(NoBlockedMessages): Remove replies to blocked messages

### DIFF
--- a/src/plugins/noBlockedMessages/index.ts
+++ b/src/plugins/noBlockedMessages/index.ts
@@ -21,12 +21,44 @@ import { Devs } from "@utils/constants";
 import { runtimeHashMessageKey } from "@utils/intlHash";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
-import { Message } from "@vencord/discord-types";
-import { i18n, RelationshipStore } from "@webpack/common";
+import { Message, MessageJSON } from "@vencord/discord-types";
+import { MessageType } from "@vencord/discord-types/enums";
+import { FluxDispatcher, i18n, MessageStore, RelationshipStore, SelectedChannelStore } from "@webpack/common";
 
 interface MessageDeleteProps {
     // Internal intl message for BLOCKED_MESSAGE_COUNT
     collapsedReason: () => any;
+}
+
+let ReplyStore: any;
+
+// Some referenced messages aren't in the MessageStore so this falls back to the ReplyStore cache
+function getReferencedMessage(channelId: string, messageId: string) {
+    const fromMessageStore = MessageStore.getMessage(channelId, messageId);
+    if (fromMessageStore) return fromMessageStore;
+
+    const fromReplyStore = ReplyStore?._channelCaches?.get(channelId)?._cachedMessages?.get(messageId)?.message;
+    if (fromReplyStore) return fromReplyStore;
+}
+
+function rerenderChannelMessages() {
+    if (!settings.store.hideRepliesToBlockedUsers) return;
+
+    try {
+        const channelId = SelectedChannelStore.getChannelId();
+        if (!channelId) return;
+
+        const messages = MessageStore.getMessages(channelId)?._array ?? [];
+        for (const message of messages) {
+            if (message.type !== MessageType.REPLY) continue;
+            FluxDispatcher.dispatch({
+                type: "MESSAGE_UPDATE",
+                message
+            });
+        }
+    } catch (e) {
+        new Logger("NoBlockedMessages").error("Failed to refresh visible messages:", e);
+    }
 }
 
 // Remove this migration once enough time has passed
@@ -42,6 +74,12 @@ const settings = definePluginSettings({
         description: "Additionally apply to 'ignored' users",
         type: OptionType.BOOLEAN,
         default: true,
+        restartNeeded: false
+    },
+    hideRepliesToBlockedUsers: {
+        description: "Hide replies to blocked users",
+        type: OptionType.BOOLEAN,
+        default: false,
         restartNeeded: false
     }
 });
@@ -82,10 +120,44 @@ export default definePlugin({
                     replace: (_, props) => `if($self.shouldIgnoreMessage(${props}.message))return;`
                 }
             ]
+        },
+        {
+            find: "Message must not be a thread starter message",
+            predicate: () => settings.store.hideRepliesToBlockedUsers,
+            replacement: {
+                match: /return (null!=\i\?\(0,\i\.jsx\)\(\i,\{flashKey:\i,[\s\S]*?`bg-flash-\$\{\i\}`\):\i)/,
+                replace: "return $self.shouldHideReply(arguments[0])?null:$1",
+            }
+        },
+        {
+            find: "ReferencedMessageStore",
+            predicate: () => settings.store.hideRepliesToBlockedUsers,
+            replacement: [
+                {
+                    match: /_channelCaches=new Map;/,
+                    replace: "$&_=$self.setReplyStore(this);"
+                }
+            ]
         }
     ],
 
-    shouldIgnoreMessage(message: Message) {
+    flux: {
+        RELATIONSHIP_ADD() {
+            rerenderChannelMessages();
+        },
+        RELATIONSHIP_UPDATE() {
+            rerenderChannelMessages();
+        },
+        RELATIONSHIP_REMOVE() {
+            rerenderChannelMessages();
+        }
+    },
+
+    setReplyStore(store: any) {
+        ReplyStore = store;
+    },
+
+    shouldIgnoreMessage(message: MessageJSON) {
         try {
             if (RelationshipStore.isBlocked(message.author.id)) {
                 return true;
@@ -107,5 +179,19 @@ export default definePlugin({
             new Logger("NoBlockedMessages").error("Failed to check if message should be hidden:", e);
             return false;
         }
-    }
+    },
+
+    shouldHideReply({ message }: { message?: Message; }) {
+        if (!settings.store.hideRepliesToBlockedUsers) return false;
+        if (!message || message?.type !== MessageType.REPLY) return false;
+
+        const ref = message.messageReference;
+        if (!ref?.channel_id || !ref.message_id) return false;
+
+        const referencedMessage = getReferencedMessage(ref.channel_id, ref.message_id);
+        if (!referencedMessage) return false;
+
+        if (RelationshipStore.isBlocked(referencedMessage.author.id)) return true;
+        return settings.store.applyToIgnoredUsers && RelationshipStore.isIgnored(referencedMessage.author.id);
+    },
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    nickoates: {
+        name: "nickoates",
+        id: 302915598038335490n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Closes #4182 

This is my first time writing patch regexes for Vencord, so hopefully I'm doing this right. Apologies if not.

I initially thought this would be a pretty simple task but it required a lot more code than I had anticipated.
* Patches the Message component to check if its a reply to a blocked user and return `null` if so.
* That check uses `ReplyStore` to lookup message references, because messages being replied to often weren't in `MessageStore` in my testing, especially when they were old. So there's additional patches to get access to `ReplyStore`.
* Added flux handlers for relationship updates that just sends stub message updates for the current channel. Otherwise, when you blocked someone messages wouldn't re-render until you navigated away from the channel and back. If that's an ok tradeoff though, I'm happy to remove the flux handlers to make the code simpler.