### PR TITLE
VoiceMessages: add Alt+V to record and Alt+B to send

### DIFF
--- a/src/plugins/voiceMessages/DesktopRecorder.tsx
+++ b/src/plugins/voiceMessages/DesktopRecorder.tsx
@@ -17,20 +17,33 @@
 */
 
 import { PluginNative } from "@utils/types";
-import { Button, MediaEngineStore, showToast, Toasts, useState } from "@webpack/common";
+import { Button, MediaEngineStore, showToast, Toasts, useEffect, useRef, useState } from "@webpack/common";
 
 import type { VoiceRecorder } from ".";
 import { settings } from "./settings";
 
 const Native = VencordNative.pluginHelpers.VoiceMessages as PluginNative<typeof import("./native")>;
 
-export const VoiceRecorderDesktop: VoiceRecorder = ({ setAudioBlob, onRecordingChange }) => {
+export const VoiceRecorderDesktop: VoiceRecorder = ({ setAudioBlob, onRecordingChange, autoStart, stopSignal }) => {
     const [recording, setRecording] = useState(false);
+    const autoStartedRef = useRef(false);
 
     const changeRecording = (recording: boolean) => {
         setRecording(recording);
         onRecordingChange?.(recording);
     };
+
+    useEffect(() => {
+        if (autoStart && !autoStartedRef.current) {
+            autoStartedRef.current = true;
+            toggleRecording();
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!stopSignal) return;
+        if (recording) toggleRecording();
+    }, [stopSignal]);
 
     function toggleRecording() {
         const discordVoice = DiscordNative.nativeModules.requireModule("discord_voice");

--- a/src/plugins/voiceMessages/WebRecorder.tsx
+++ b/src/plugins/voiceMessages/WebRecorder.tsx
@@ -16,21 +16,34 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Button, MediaEngineStore, useState } from "@webpack/common";
+import { Button, MediaEngineStore, useEffect, useRef, useState } from "@webpack/common";
 
 import type { VoiceRecorder } from ".";
 import { settings } from "./settings";
 
-export const VoiceRecorderWeb: VoiceRecorder = ({ setAudioBlob, onRecordingChange }) => {
+export const VoiceRecorderWeb: VoiceRecorder = ({ setAudioBlob, onRecordingChange, autoStart, stopSignal }) => {
     const [recording, setRecording] = useState(false);
     const [paused, setPaused] = useState(false);
     const [recorder, setRecorder] = useState<MediaRecorder>();
     const [chunks, setChunks] = useState<Blob[]>([]);
+    const autoStartedRef = useRef(false);
 
     const changeRecording = (recording: boolean) => {
         setRecording(recording);
         onRecordingChange?.(recording);
     };
+
+    useEffect(() => {
+        if (autoStart && !autoStartedRef.current) {
+            autoStartedRef.current = true;
+            toggleRecording();
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!stopSignal) return;
+        if (recording) toggleRecording();
+    }, [stopSignal]);
 
     function toggleRecording() {
         const nowRecording = !recording;

--- a/src/plugins/voiceMessages/index.tsx
+++ b/src/plugins/voiceMessages/index.tsx
@@ -33,7 +33,7 @@ import { chooseFile } from "@utils/web";
 import { CloudUpload as TCloudUpload } from "@vencord/discord-types";
 import { CloudUploadPlatform } from "@vencord/discord-types/enums";
 import { findLazy } from "@webpack";
-import { Button, Constants, FluxDispatcher, Forms, lodash, Menu, MessageActions, PendingReplyStore, PermissionsBits, PermissionStore, RestAPI, SelectedChannelStore, showToast, SnowflakeUtils, Toasts, useEffect, useState } from "@webpack/common";
+import { Button, ChannelStore, Constants, FluxDispatcher, Forms, lodash, Menu, MessageActions, PendingReplyStore, PermissionsBits, PermissionStore, RestAPI, SelectedChannelStore, showToast, SnowflakeUtils, Toasts, useEffect, useRef, useState } from "@webpack/common";
 import { ComponentType } from "react";
 
 import { VoiceRecorderDesktop } from "./DesktopRecorder";
@@ -47,6 +47,8 @@ export const cl = classNameFactory("vc-vmsg-");
 export type VoiceRecorder = ComponentType<{
     setAudioBlob(blob: Blob): void;
     onRecordingChange?(recording: boolean): void;
+    autoStart?: boolean;
+    stopSignal?: number;
 }>;
 
 export interface VoiceMessageProps {
@@ -74,10 +76,25 @@ const ctxMenuPatch: NavContextMenuPatchCallback = (children, props) => {
     );
 };
 
+function onKeydown(e: KeyboardEvent) {
+    if (!settings.store.keybind) return;
+    if (e.key !== "v" && e.key !== "V") return;
+    if (!e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) return;
+
+    const channelId = SelectedChannelStore.getChannelId();
+    if (!channelId) return;
+    const channel = ChannelStore.getChannel(channelId);
+    if (!channel) return;
+    if (channel.guild_id && !(PermissionStore.can(PermissionsBits.SEND_VOICE_MESSAGES, channel) && PermissionStore.can(PermissionsBits.SEND_MESSAGES, channel))) return;
+
+    e.preventDefault();
+    openModal(modalProps => <Modal modalProps={modalProps} autoStart />);
+}
+
 export default definePlugin({
     name: "VoiceMessages",
-    description: "Allows you to send voice messages like on mobile. To do so, right click the upload button and click Send Voice Message",
-    tags: ["Voice"],
+    description: "Allows you to send voice messages like on mobile. Right click the upload button or press Alt+V to record, then Alt+B to send.",
+    tags: ["Voice", "Shortcuts"],
     authors: [Devs.Ven, Devs.Vap, Devs.Nickyux],
     settings,
 
@@ -97,6 +114,14 @@ export default definePlugin({
 
     contextMenus: {
         "channel-attach": ctxMenuPatch
+    },
+
+    start() {
+        document.addEventListener("keydown", onKeydown);
+    },
+
+    stop() {
+        document.removeEventListener("keydown", onKeydown);
     }
 });
 
@@ -157,10 +182,12 @@ function useObjectUrl() {
     return [url, setWithFree] as const;
 }
 
-function Modal({ modalProps }: { modalProps: ModalProps; }) {
+function Modal({ modalProps, autoStart }: { modalProps: ModalProps; autoStart?: boolean; }) {
     const [isRecording, setRecording] = useState(false);
     const [blob, setBlob] = useState<Blob>();
     const [blobUrl, setBlobUrl] = useObjectUrl();
+    const [stopSignal, setStopSignal] = useState(0);
+    const pendingSendRef = useRef(false);
 
     useEffect(() => () => {
         if (blobUrl)
@@ -207,6 +234,38 @@ function Modal({ modalProps }: { modalProps: ModalProps; }) {
         || blob.type.includes("codecs") && !blob.type.includes("opus")
     );
 
+    const doSend = () => {
+        if (!blob) return;
+        sendAudio(blob, meta ?? EMPTY_META);
+        modalProps.onClose();
+        showToast("Now sending voice message... Please be patient", Toasts.Type.MESSAGE);
+    };
+
+    useEffect(() => {
+        if (!pendingSendRef.current) return;
+        if (!blob || meta === EMPTY_META) return;
+        pendingSendRef.current = false;
+        doSend();
+    }, [blob, meta]);
+
+    useEffect(() => {
+        function onKey(e: KeyboardEvent) {
+            if (!settings.store.keybind) return;
+            if (e.key !== "b" && e.key !== "B") return;
+            if (!e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) return;
+            e.preventDefault();
+
+            if (isRecording) {
+                pendingSendRef.current = true;
+                setStopSignal(s => s + 1);
+            } else if (blob) {
+                doSend();
+            }
+        }
+        document.addEventListener("keydown", onKey);
+        return () => document.removeEventListener("keydown", onKey);
+    }, [isRecording, blob, meta]);
+
     return (
         <ModalRoot {...modalProps}>
             <ModalHeader>
@@ -221,6 +280,8 @@ function Modal({ modalProps }: { modalProps: ModalProps; }) {
                             setBlobUrl(blob);
                         }}
                         onRecordingChange={setRecording}
+                        autoStart={autoStart}
+                        stopSignal={stopSignal}
                     />
 
                     <Button

--- a/src/plugins/voiceMessages/settings.ts
+++ b/src/plugins/voiceMessages/settings.ts
@@ -30,4 +30,9 @@ export const settings = definePluginSettings({
         description: "Echo Cancellation",
         default: true,
     },
+    keybind: {
+        type: OptionType.BOOLEAN,
+        description: "Use keybinds (Alt+V to open and record, Alt+B to send)",
+        default: true,
+    },
 });


### PR DESCRIPTION
## Summary
Adds keybinds to the VoiceMessages plugin: Alt+V to open the recorder and start recording, Alt+B to stop and send.

Motivation: the existing flow requires right-click → context menu → Start → speak → Stop → Send (4 clicks plus mouse navigation). Often voice-message senders just want to fire and forget.

## Behavior
- **Alt+V** (global): opens the modal with `autoStart`. Permission-checked the same way as the right-click context menu.
- **Alt+B** (modal-scoped): if recording, stops; once the blob and waveform are ready, sends and closes. If a blob is already ready (e.g. uploaded file), sends immediately.
- A single new boolean setting **Use keybinds** (default on) controls both shortcuts.
- The right-click "Send Voice Message" entry still opens the modal without auto-starting, so existing UX is preserved.

## Implementation notes
- Pattern follows `quickReply` (global keydown listener registered in `start()`, removed in `stop()`).
- Keybinds reject when any other modifier is held alongside Alt.
- The recorder receives a `stopSignal` counter prop; a watching effect in the modal observes blob+meta and calls `sendAudio` once both are ready and a send is pending.