### PR TITLE
New Plugin: ReformatTimestamps

### DIFF
--- a/src/plugins/reformatTimestamps/index.tsx
+++ b/src/plugins/reformatTimestamps/index.tsx
@@ -1,0 +1,101 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import { useForceUpdater } from "@utils/react";
+import definePlugin from "@utils/types";
+import { findByCodeLazy, findLazy } from "@webpack";
+import { Menu, moment, Popout, useEffect, useRef, useState } from "@webpack/common";
+
+const TimeFormats = findLazy(m => m?.D && m?.F && m?.d && m?.t);
+const getParsedTimestamp = findByCodeLazy("{timestamp:", ",format:");
+
+export const TimestampPopout = ({ node, TimestampComponent, channelOptions }) => {
+    const [currentNode, setNode] = useState(node);
+    const formats = Object.keys(TimeFormats);
+    const update = useForceUpdater();
+    const targetRef = useRef<HTMLSpanElement>(null);
+
+    const setTimestampFormat = format => {
+        if (!currentNode) return;
+        setNode(getParsedTimestamp(currentNode.timestamp, format));
+    };
+
+    useEffect(() => {
+        if (!currentNode) return;
+        const interval = setInterval(() => {
+            moment.relativeTimeThreshold("ss", -1);
+            update();
+        }, 1000);
+
+        return () => clearInterval(interval);
+    }, [currentNode]);
+
+    return (
+        <Popout
+            targetElementRef={targetRef}
+            position="top"
+            align="center"
+            renderPopout={({ closePopout }) => {
+                return (
+                    <Menu.Menu
+                        navId="timestamp-format"
+                        onClose={closePopout}
+                    >
+                        <Menu.MenuGroup
+                            label="Timestamp format"
+                        >
+                            {formats.map((format, i) => format === currentNode.format ? null : (
+                                <Menu.MenuItem
+                                    id={format}
+                                    label={TimeFormats[format](currentNode.parsed)}
+                                    key={i}
+                                    action={() => {
+                                        setTimestampFormat(format);
+                                        closePopout();
+                                    }}
+                                />
+                            ))}
+                        </Menu.MenuGroup>
+                    </Menu.Menu>
+                );
+            }}
+        >
+            {popoutProps =>
+                <span {...popoutProps} style={{ cursor: "pointer" }} ref={targetRef}>
+                    <TimestampComponent node={currentNode} key={channelOptions.key}/>
+                </span>
+            }
+        </Popout>
+    );
+};
+
+export default definePlugin({
+    name: "ReformatTimestamps",
+    description: "Click on a timestamp to change its format locally",
+    authors: [Devs.Suffocate],
+
+    patches: [
+        {
+            find: "style:{\"--totalCharacters\":",
+            replacement: [
+                {
+                    match: /timestamp:\{react:.*?(\i\.\i),\{node.*?\.key\)},/,
+                    replace: "timestamp:$self.renderTimestampPopout($1),"
+                }
+            ]
+        },
+    ],
+
+    renderTimestampPopout: timestampComponent => {
+        return {
+            react: (node, t, channelOptions) => {
+                return <TimestampPopout node={node} TimestampComponent={timestampComponent}
+                                        channelOptions={channelOptions}/>;
+            }
+        };
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    Suffocate: {
+        name: "Suffocate",
+        id: 772601756776923187n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Small plugin to let you click on timestamps and switch to one of the other formats. Could probably go in Tweaks if that ever becomes a thing.

<img width="176" height="196" alt="image" src="https://github.com/user-attachments/assets/eebc9834-73ff-4724-80b9-b13ae708b645" />

<img width="203" height="200" alt="image" src="https://github.com/user-attachments/assets/9e9f7e88-f656-4c36-ae3b-1402c337d105" />
