### PR TITLE
feat(plugin) noNameplates

### DIFF
--- a/src/plugins/noNameplates/index.ts
+++ b/src/plugins/noNameplates/index.ts
@@ -25,6 +25,6 @@ export default definePlugin({
     name: "NoNameplates",
     description: "Hides Discord nameplates in member lists.",
     tags: ["Appearance", "Customisation"],
-    authors: [Devs.KingFish],
+    authors: [Devs.Moli],
     managedStyle,
 });

--- a/src/plugins/noNameplates/index.ts
+++ b/src/plugins/noNameplates/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2026 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+import managedStyle from "./style.css?managed";
+
+export default definePlugin({
+    name: "NoNameplates",
+    description: "Hides Discord nameplates in member lists.",
+    tags: ["Appearance", "Customisation"],
+    authors: [Devs.KingFish],
+    managedStyle,
+});

--- a/src/plugins/noNameplates/style.css
+++ b/src/plugins/noNameplates/style.css
@@ -1,0 +1,10 @@
+[class*="members_"] [class*="nameplated_"] > [class*="container_df39b2"],
+[class*="members_"] [class*="nameplated_"] > [class*="img_df39b2"],
+[class*="members_"] [class*="nameplated_"] > [style*="linear-gradient"],
+[class*="members_"] [class*="nameplated_"] > [style*="mask-image"],
+[class*="membersWrap_"] [class*="nameplated_"] > [class*="container_df39b2"],
+[class*="membersWrap_"] [class*="nameplated_"] > [class*="img_df39b2"],
+[class*="membersWrap_"] [class*="nameplated_"] > [style*="linear-gradient"],
+[class*="membersWrap_"] [class*="nameplated_"] > [style*="mask-image"] {
+    display: none !important;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -196,6 +196,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "King Fish",
         id: 499400512559382538n
     },
+    Moli: {
+        name: "Moli",
+        id: 470904884946796544n
+    },
     Commandtechno: {
         name: "Commandtechno",
         id: 296776625432035328n,


### PR DESCRIPTION
## Summary

Adds NoNameplates, an appearance plugin that hides Discord collectible nameplates in the member list.

## Rationale

Discord nameplates can make the member list visually noisy and harder to scan, especially in large servers where many users have animated or high-contrast nameplates. This plugin provides a simple toggle for users who want a cleaner member list without disabling other profile decorations.

Although this is implemented with CSS, keeping it as a plugin makes it discoverable and easy to enable/disable from Vencord settings without requiring users to maintain custom CSS selectors themselves.

## Implementation

The CSS is scoped to member list nameplate wrappers and only hides the direct visual layers used by Discord nameplates. It does not touch the member row itself, so hover states, avatars, badges, activities, status text, and popouts continue to work.

## Testing

- Enabled the plugin in Discord
- Verified member list nameplate gradients/images are hidden
- Verified hover states and user row content still work
- Ran `pnpm exec eslint src/plugins/noNameplates/index.ts src/utils/constants.ts`
- Ran `pnpm exec stylelint src/plugins/noNameplates/style.css`
- Ran `pnpm exec tsc --noEmit --pretty false`
