### PR TITLE
feat(plugin): CustomSounds

### DIFF
--- a/src/plugins/customSounds/README.md
+++ b/src/plugins/customSounds/README.md
@@ -1,0 +1,9 @@
+# Custom Sounds
+Change any native Discord sound.
+
+Features:
+- Custom audio uploads;
+- built-in Discord presets;
+- volume control;
+- sound preview;
+- configuration import/export.

--- a/src/plugins/customSounds/SoundOverrideComponent.tsx
+++ b/src/plugins/customSounds/SoundOverrideComponent.tsx
@@ -1,0 +1,228 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Button } from "@components/Button";
+import { Card } from "@components/Card";
+import { FormSwitch } from "@components/FormSwitch";
+import { Heading } from "@components/Heading";
+import { classNameFactory } from "@utils/css";
+import { useForceUpdater } from "@utils/react";
+import { makeRange } from "@utils/types";
+import { findByCodeLazy } from "@webpack";
+import { React, Select, showToast, Slider } from "@webpack/common";
+
+import * as AudioStore from "./audioStore";
+import { SoundOverride, SoundPlayer, SoundType } from "./types";
+
+const cl = classNameFactory("vc-custom-sounds-");
+const playSound: (id: string) => SoundPlayer = findByCodeLazy(".playWithListener().then");
+
+const capitalizeWords = (str: string) =>
+    str.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+export function SoundOverrideComponent({ type, override, onChange, files, onFilesChange }: {
+    type: SoundType;
+    override: SoundOverride;
+    onChange: () => Promise<void>;
+    files: Record<string, AudioStore.AudioFileMetadata>;
+    onFilesChange: () => void;
+}) {
+    const update = useForceUpdater();
+    const sound = React.useRef<SoundPlayer | null>(null);
+
+    // Cleanup audio on unmount to prevent memory leaks
+    React.useEffect(() => {
+        return () => {
+            sound.current?.stop();
+            sound.current = null;
+        };
+    }, []);
+
+    const saveAndNotify = async () => {
+        await onChange();
+        update();
+    };
+
+    const previewSound = async () => {
+        sound.current?.stop();
+
+        if (!override.enabled) {
+            sound.current = playSound(type.derived ?? type.id);
+            return;
+        }
+
+        const { selectedSound, selectedFileId } = override;
+
+        if (selectedSound === "default") {
+            sound.current = playSound(type.derived ?? type.id);
+            return;
+        }
+        if (selectedSound !== "custom") { // seasonal
+            sound.current = playSound(selectedSound);
+            return;
+        }
+        if (!selectedFileId) {
+            sound.current = playSound(type.derived ?? type.id);
+            return;
+        }
+
+        try {
+            const dataUri = await AudioStore.getAudioDataURI(selectedFileId);
+
+            if (!dataUri || !dataUri.startsWith("data:audio/")) {
+                showToast("No custom sound file available for preview");
+                return;
+            }
+
+            // Check if browser supports this format (e.g. WMA is not supported in Chrome/Firefox)
+            const mimeMatch = dataUri.match(/^data:(audio\/[^;,]+)/i);
+            const mimeType = mimeMatch ? mimeMatch[1] : "audio/mpeg";
+            const testEl = document.createElement("audio");
+            if (testEl.canPlayType(mimeType) === "") {
+                showToast("Your browser doesn't support this format. Try re-uploading as MP3 or WAV.");
+                return;
+            }
+
+            const audio = new Audio(dataUri);
+            audio.volume = override.volume / 100;
+
+            audio.onerror = () => {
+                const msg = audio.error?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+                    ? "Format not supported by browser. Try MP3 or WAV."
+                    : "Could not play file. It may be corrupted or in an unsupported format.";
+                showToast(msg);
+            };
+
+            await audio.play();
+            sound.current = {
+                play: () => audio.play(),
+                pause: () => audio.pause(),
+                stop: () => {
+                    audio.pause();
+                    audio.currentTime = 0;
+                },
+                loop: () => { audio.loop = true; }
+            };
+        } catch (error: unknown) {
+            const err = error as Error & { name?: string; };
+            console.error("[CustomSounds] Error in previewSound:", error);
+            if (err?.name === "NotSupportedError" || err?.message?.includes("supported source")) {
+                showToast("Format not supported by your browser. Try re-uploading as MP3 or WAV.");
+            } else {
+                showToast("Could not play sound. File may be corrupted or in an unsupported format.");
+            }
+        }
+    };
+
+    const deleteFile = async (id: string) => {
+        try {
+            await AudioStore.deleteAudio(id);
+
+            if (override.selectedFileId === id) {
+                override.selectedFileId = undefined;
+                await saveAndNotify();
+            }
+            onFilesChange();
+            showToast("File deleted successfully");
+        } catch (error) {
+            console.error("[CustomSounds] Error deleting file:", error);
+            showToast("Error deleting file. Check console for details.");
+        }
+    };
+
+    const customFileOptions = Object.entries(files)
+        .filter(([id, file]) => !!id && !!file?.name)
+        .map(([id, file]) => ({
+            value: id,
+            label: file.name
+        }));
+
+    return (
+        <Card className={cl("card")}>
+            <FormSwitch
+                title={type.name}
+                value={override.enabled || false}
+                onChange={async val => {
+                    override.enabled = val;
+                    saveAndNotify();
+                }}
+                hideBorder
+            />
+
+            {override.enabled && (
+                <div className={cl("card-content")}>
+                    <div className={cl("buttons")}>
+                        <Button
+                            variant="positive"
+                            onClick={previewSound}
+                        >
+                            Preview
+                        </Button>
+                        <Button
+                            variant="dangerPrimary"
+                            onClick={() => sound.current?.stop()}
+                        >
+                            Stop
+                        </Button>
+                    </div>
+                    <div className={cl("card-option")}>
+                        <Heading>Volume</Heading>
+                        <Slider
+                            markers={makeRange(0, 100, 10)}
+                            initialValue={override.volume}
+                            onValueChange={val => {
+                                override.volume = val;
+                                saveAndNotify();
+                            }}
+                            disabled={!override.enabled}
+                        />
+                    </div>
+                    <div className={cl("card-option")}>
+                        <Heading>Sound Source</Heading>
+                        <Select
+                            options={[
+                                { value: "default", label: "Default" },
+                                ...(type.seasonal?.map(id => ({ value: id, label: capitalizeWords(id) })) ?? []),
+                                { value: "custom", label: "Custom" }
+                            ]}
+                            isSelected={v => v === override.selectedSound}
+                            select={async v => {
+                                override.selectedSound = v;
+                                saveAndNotify();
+                            }}
+                            serialize={opt => opt.value}
+                        />
+                    </div>
+
+                    {override.selectedSound === "custom" && (
+                        <div className={cl("card-option")}>
+                            <Heading>Custom File</Heading>
+                            <Select
+                                options={[
+                                    { value: "", label: "Select a file..." },
+                                    ...customFileOptions
+                                ]}
+                                isSelected={v => v === (override.selectedFileId || "")}
+                                select={async id => {
+                                    override.selectedFileId = id || undefined;
+                                    saveAndNotify();
+                                }}
+                                serialize={opt => opt.value}
+                            />
+                            <Button
+                                variant="dangerPrimary"
+                                onClick={() => deleteFile(override.selectedFileId!)}
+                                disabled={!override.selectedFileId || !files[override.selectedFileId]}
+                            >
+                                Remove Selected Sound
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            )}
+        </Card>
+    );
+}

--- a/src/plugins/customSounds/audioStore.ts
+++ b/src/plugins/customSounds/audioStore.ts
@@ -1,0 +1,278 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { get, set } from "@api/DataStore";
+import { Logger } from "@utils/Logger";
+
+const STORAGE_KEY = "CustomSounds";
+const METADATA_KEY = "CustomSounds_Metadata";
+
+// Default maximum file size: 15MB per file
+const DEFAULT_MAX_FILE_SIZE_MB = 15;
+
+// Configurable max file size (set by plugin settings)
+let maxFileSizeMB = DEFAULT_MAX_FILE_SIZE_MB;
+
+const logger = new Logger("CustomSounds");
+
+export function setMaxFileSizeMB(sizeMB: number): void {
+    maxFileSizeMB = sizeMB;
+}
+
+export function getMaxFileSizeMB(): number {
+    return maxFileSizeMB;
+}
+
+export interface StoredAudioFile {
+    id: string;
+    name: string;
+    type: string;
+    dataUri: string;
+}
+
+export interface AudioFileMetadata {
+    id: string;
+    name: string;
+    type: string;
+    size: number; // Size of dataUri in bytes
+}
+
+// Lightweight metadata stored separately for fast access
+type MetadataStore = Record<string, AudioFileMetadata>;
+
+// Full audio data (only dataUri, no redundant buffer)
+type AudioStore = Record<string, StoredAudioFile>;
+
+/**
+ * Returns audio files metadata.
+ */
+export async function getAllAudioMetadata(): Promise<MetadataStore> {
+    return (await get(METADATA_KEY)) as MetadataStore ?? {};
+}
+
+async function setMetadataStore(new_: MetadataStore): Promise<void> {
+    await set(METADATA_KEY, new_);
+}
+
+/**
+ * Returns a single audio file's data URI.
+ */
+export async function getAudioDataURI(id: string): Promise<string | undefined> {
+    const all: AudioStore = await getAllAudio();
+    return all?.[id]?.dataUri;
+}
+
+/**
+ * Returns all audio files (use sparingly as it loads all the data)
+ */
+export async function getAllAudio(): Promise<AudioStore> {
+    return (await get(STORAGE_KEY)) as AudioStore ?? {};
+}
+
+async function setAudioStore(new_: AudioStore): Promise<void> {
+    await set(STORAGE_KEY, new_);
+}
+
+export async function saveAudioData(audioData: [StoredAudioFile, AudioFileMetadata][]): Promise<void> {
+    const audioStore: AudioStore = await getAllAudio();
+    const metadataStore: MetadataStore = await getAllAudioMetadata();
+
+    for (const [data, metadata] of audioData) { // processing files asyncronounsly makes no real difference
+        audioStore[metadata.id] = data;
+        metadataStore[metadata.id] = metadata;
+    }
+
+    await setAudioStore(audioStore);
+    await setMetadataStore(metadataStore);
+}
+
+export async function processAudioFile(file: File): Promise<[StoredAudioFile, AudioFileMetadata]> {
+    const maxBytes = maxFileSizeMB * 1024 * 1024;
+    if (file.size > maxBytes) {
+        const fileMB = (file.size / (1024 * 1024)).toFixed(1);
+        throw new Error(`File "${file.name}" is too large (${fileMB}MB). Maximum size is ${maxFileSizeMB}MB.`);
+    }
+
+    const buffer = await file.arrayBuffer();
+    const id = file.name;
+    const dataUri = await generateDataURI(buffer, file.type, file.name);
+
+    return [
+        {
+            id,
+            name: file.name,
+            type: file.type,
+            dataUri
+        },
+        {
+            id,
+            name: file.name,
+            type: file.type,
+            size: dataUri.length
+        }
+    ];
+}
+
+/**
+ * Deletes an audio file.
+ */
+export async function deleteAudio(id: string): Promise<void> {
+    // Delete from audio store
+    const audioStore: AudioStore = await getAllAudio();
+    if (audioStore[id]) {
+        delete audioStore[id];
+        await setAudioStore(audioStore);
+    }
+
+    // Delete from metadata store
+    const metadataStore: MetadataStore = await getAllAudioMetadata();
+    if (metadataStore[id]) {
+        delete metadataStore[id];
+        await setMetadataStore(metadataStore);
+    }
+}
+
+/**
+ * Deletes all audio files.
+ */
+export async function clearStore(): Promise<void> {
+    await setAudioStore({});
+    await setMetadataStore({});
+}
+
+/**
+ * Migrates old storage format to new format (run once on startup).
+ */
+export async function migrateStorage(): Promise<{ [oldId: string]: string; } | null> {
+    const audioStore = (await get(STORAGE_KEY)) as Record<string, any> | undefined;
+    if (!audioStore) return null;
+
+    let needsMigration = false;
+    let needsMetadataRebuild = false;
+
+    for (const file of Object.values(audioStore)) {
+        if (!file) continue;
+        if (typeof file !== "object") continue;
+
+        if ("buffer" in file ||
+            ("id" in file && file.id !== file.name)) {
+            needsMigration = true;
+            break;
+        }
+    }
+
+    const metadataStore = await get(METADATA_KEY);
+    if (!metadataStore && Object.keys(audioStore).length > 0) {
+        needsMetadataRebuild = true;
+    }
+
+    const migratedFiles: { [oldId: string]: string; } = {};
+    if (needsMigration) {
+        logger.info("Migrating storage to remove redundant buffers and fix IDs...");
+        const newAudioStore: AudioStore = {};
+
+        for (const file of Object.values(audioStore)) {
+            if (!file || typeof file !== "object") continue;
+
+            // If it has dataUri, keep it; if only buffer, generate dataUri
+            let { dataUri } = file;
+            if (!dataUri && file.buffer) {
+                dataUri = await generateDataURI(file.buffer, file.type, file.name);
+            }
+
+            if (!dataUri) continue;
+
+            logger.debug("Migrating a file: ", file);
+
+            // might want to reuse processAudioFile for this (and the migration check above)
+            // so it's not pain in the ass to change it (if ever needed at all)
+            const oldId = file.id;
+            const newId = file.name;
+
+            newAudioStore[newId] = {
+                id: newId,
+                name: file.name || "Unknown",
+                type: file.type || "audio/mpeg",
+                dataUri
+            };
+
+            migratedFiles[oldId] = newId;
+        }
+
+        await setAudioStore(newAudioStore);
+        needsMetadataRebuild = true;
+        logger.info("Storage migration complete.");
+    }
+
+    if (needsMetadataRebuild) {
+        logger.info("Rebuilding metadata index...");
+        const currentAudioStore = await getAllAudio();
+        const newMetadataStore: MetadataStore = {};
+
+        for (const [id, file] of Object.entries(currentAudioStore)) {
+            newMetadataStore[id] = {
+                id: file.id,
+                name: file.name,
+                type: file.type,
+                size: file.dataUri?.length || 0
+            };
+        }
+
+        await setMetadataStore(newMetadataStore);
+        logger.info("Metadata rebuild complete");
+    }
+
+    return migratedFiles;
+}
+
+async function generateDataURI(buffer: ArrayBuffer, type: string, name: string): Promise<string> {
+    let mimeType = type || "audio/mpeg";
+
+    if (!mimeType || mimeType === "application/octet-stream") {
+        if (name) {
+            const extension = name.split(".").pop()?.toLowerCase();
+            switch (extension) {
+                case "ogg": mimeType = "audio/ogg"; break;
+                case "mp3": mimeType = "audio/mpeg"; break;
+                case "wav": mimeType = "audio/wav"; break;
+                case "m4a":
+                case "mp4": mimeType = "audio/mp4"; break;
+                case "flac": mimeType = "audio/flac"; break;
+                case "aac": mimeType = "audio/aac"; break;
+                case "webm": mimeType = "audio/webm"; break;
+                case "wma": mimeType = "audio/x-ms-wma"; break;
+                default: mimeType = "audio/mpeg";
+            }
+        }
+    }
+
+    const uint8Array = new Uint8Array(buffer);
+    const blob = new Blob([uint8Array], { type: mimeType });
+
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+}
+
+/**
+ * Returns total storage usage info in an object.
+ */
+export async function getStorageInfo(): Promise<{ fileCount: number; totalSizeKB: number; }> {
+    const metadata = await getAllAudioMetadata();
+    let totalSize = 0;
+
+    for (const file of Object.values(metadata)) {
+        totalSize += file.size || 0;
+    }
+
+    return {
+        fileCount: Object.keys(metadata).length,
+        totalSizeKB: Math.round(totalSize / 1024)
+    };
+}

--- a/src/plugins/customSounds/cache.ts
+++ b/src/plugins/customSounds/cache.ts
@@ -1,0 +1,78 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+const MAX_FILES_CACHED_AT_MAX_SIZE = 5;
+const BASE64_OVERHEAD = 1.37;
+const CACHE_SIZE_MULTIPLIER = BASE64_OVERHEAD * MAX_FILES_CACHED_AT_MAX_SIZE;
+
+const MIN_CACHE_SIZE_MB_CAP = 5;
+const MAX_CACHE_SIZE_MB_CAP = 500;
+
+/*
+ * LRU-style cache with dynamic size limit based on max file size setting
+ */
+export class LRU {
+    cache: Map<string, string>; // might make this generic but ehh
+    private _size: number = 0;
+    private _maxSize: number = 0;
+
+    constructor() {
+        this.cache = new Map();
+        this.setSizeLimit(100);
+    }
+
+    setSizeLimit(maxFileSizeMB: number): void {
+        const calculatedSize = Math.round(maxFileSizeMB * CACHE_SIZE_MULTIPLIER);
+        this._maxSize = Math.min(Math.max(calculatedSize, MIN_CACHE_SIZE_MB_CAP), MAX_CACHE_SIZE_MB_CAP) * 1024 * 1024;
+    }
+
+    set(fileId: string, dataUri: string): void {
+        const uriSize = dataUri.length;
+
+        if (uriSize > this._maxSize) {
+            throw new Error(`File too large to cache (${Math.round(uriSize / (1024 * 1024))}MB > ${Math.round(this.maxSize() / (1024 * 1024))}MB limit)`);
+        }
+
+        while (this._size + uriSize > this._maxSize && this.cache.size > 0) {
+            const oldestKey = this.first();
+
+            if (oldestKey) {
+                const oldestSize = this.cache.get(oldestKey)?.length || 0;
+                this.cache.delete(oldestKey);
+                this._size -= oldestSize;
+            }
+        }
+
+        this.cache.set(fileId, dataUri);
+        this._size += uriSize;
+    }
+
+    get(fileId: string): string | undefined {
+        const dataUri = this.cache.get(fileId);
+        if (dataUri !== undefined) {
+            this.cache.delete(fileId);
+            this.cache.set(fileId, dataUri);
+        }
+        return dataUri;
+    }
+
+    clear(): void {
+        this.cache.clear();
+        this._size = 0;
+    }
+
+    first(): string | undefined {
+        return this.cache.keys().next().value;
+    }
+
+    size(): number {
+        return this._size;
+    }
+
+    maxSize(): number {
+        return this._maxSize;
+    }
+}

--- a/src/plugins/customSounds/index.tsx
+++ b/src/plugins/customSounds/index.tsx
@@ -1,0 +1,624 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles.css";
+
+import { definePluginSettings } from "@api/Settings";
+import { Button } from "@components/Button";
+import { Heading } from "@components/Heading";
+import { Paragraph } from "@components/Paragraph";
+import { Devs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
+import { Logger } from "@utils/Logger";
+import { useForceUpdater } from "@utils/react";
+import definePlugin, { OptionType, StartAt } from "@utils/types";
+import { saveFile } from "@utils/web";
+import { MessageJSON } from "@vencord/discord-types";
+import { Alerts, React, showToast, TextInput, UserStore } from "@webpack/common";
+
+import * as AudioStore from "./audioStore";
+import { LRU } from "./cache";
+import { SoundOverrideComponent } from "./SoundOverrideComponent";
+import { makeEmptyOverride, SEASONAL_SOUNDS, SettingsExport, SOUND_TYPES, SoundOverride } from "./types";
+
+const AUDIO_EXTENSIONS = ["mp3", "wav", "ogg", "m4a", "aac", "flac", "webm", "wma", "mp4"];
+const audioExtensionsString = AUDIO_EXTENSIONS.map(v => `.${v}`).join(",");
+const audioExtensionsFormattedString = AUDIO_EXTENSIONS.map(v => `.${v}`).join(", ");
+
+const cl = classNameFactory("vc-custom-sounds-");
+
+const allSoundTypes = SOUND_TYPES || [];
+
+const dataUriCache = new LRU();
+const logger = new Logger("CustomSounds");
+
+function getOverride(id: string): SoundOverride {
+    const stored = settings.store[id];
+    if (!stored) return makeEmptyOverride();
+
+    if (typeof stored === "object") return stored;
+
+    try {
+        return JSON.parse(stored);
+    } catch {
+        return makeEmptyOverride();
+    }
+}
+
+function setOverride(id: string, override: SoundOverride): void {
+    settings.store[id] = JSON.stringify(override);
+}
+
+export function getCustomSoundURL(id: string): string | null {
+    const override = getOverride(id);
+
+    if (!override?.enabled) return null;
+
+    if (override.selectedSound === "custom" && override.selectedFileId) {
+        // null => cache miss - shouldn't happen if preloading worked, but don't block
+        return dataUriCache.get(override.selectedFileId) ?? null;
+    }
+
+    if (override.selectedSound !== "default" && override.selectedSound !== "custom") {
+        if (override.selectedSound in SEASONAL_SOUNDS) return SEASONAL_SOUNDS[override.selectedSound];
+
+        const soundType = allSoundTypes.find(t => t.id === id);
+        if (!soundType?.seasonal) return null;
+
+        // is it even possible for `override.selectedSound` to be "halloween" or "winter"?
+        logger.debug(`${id} reached the seasonal check? soundType: ${soundType}`);
+        const seasonalId = soundType.seasonal.find(id => id.startsWith(`${override.selectedSound}_`));
+        if (seasonalId && seasonalId in SEASONAL_SOUNDS) {
+            logger.debug(`${id} passed the seasonal check?? soundType: ${soundType}, seasonalId: ${seasonalId}`);
+            return SEASONAL_SOUNDS[seasonalId];
+        }
+    }
+
+    return null;
+}
+
+export async function ensureDataURICached(fileId: string): Promise<string | null> {
+    const cached = dataUriCache.get(fileId);
+    if (cached) return cached;
+
+    try {
+        const dataUri = await AudioStore.getAudioDataURI(fileId);
+        if (dataUri) {
+            dataUriCache.set(fileId, dataUri);
+            return dataUri;
+        }
+    } catch (error) {
+        logger.error(`Error loading audio for ${fileId}:`, error);
+    }
+
+    return null;
+}
+
+export async function refreshDataURI(id: string): Promise<void> {
+    const override = getOverride(id);
+    if (!override?.selectedFileId) return;
+
+    await ensureDataURICached(override.selectedFileId);
+}
+
+function resetSeasonalOverridesToDefault(): void {
+    let count = 0;
+    for (const soundType of allSoundTypes) {
+        const override = getOverride(soundType.id);
+        if (override.enabled && override.selectedSound in SEASONAL_SOUNDS) {
+            override.selectedSound = "default";
+            setOverride(soundType.id, override);
+            count++;
+        }
+    }
+    if (count > 0) logger.info(`Reset ${count} seasonal sound(s) to default`);
+}
+
+async function preloadDataURIs(): Promise<void> {
+    const fileIdsToPreload = new Set<string>();
+
+    for (const soundType of allSoundTypes) {
+        const override = getOverride(soundType.id);
+        if (override?.enabled && override.selectedSound === "custom" && override.selectedFileId) {
+            fileIdsToPreload.add(override.selectedFileId);
+        }
+    }
+
+    if (fileIdsToPreload.size === 0) return;
+
+    let loaded = 0;
+    for (const fileId of fileIdsToPreload) {
+        try {
+            await ensureDataURICached(fileId);
+            loaded++;
+        } catch (error) {
+            logger.error(`Failed to preload file ${fileId}:`, error);
+        }
+    }
+
+    logger.info(`Preloaded ${loaded}/${fileIdsToPreload.size} custom sounds`);
+}
+
+export async function debugCustomSounds(): Promise<void> {
+    logger.info("=== DEBUG INFO ===");
+    logger.info(`Max file size: ${AudioStore.getMaxFileSizeMB()}MB`);
+    logger.info(`Max cache size: ${Math.round(dataUriCache.maxSize() / (1024 * 1024))}MB`);
+
+    const storageInfo = await AudioStore.getStorageInfo();
+    logger.info(`Stored files: ${storageInfo.fileCount}, Total size: ${storageInfo.totalSizeKB}KB`);
+    logger.info(`Memory cache: ${dataUriCache.size()} items, ${Math.round(dataUriCache.size() / 1024)}KB`);
+
+    let enabledCount = 0;
+    let customSoundCount = 0;
+    for (const soundType of allSoundTypes) {
+        const override = getOverride(soundType.id);
+        if (override.enabled) {
+            enabledCount++;
+            if (override.selectedSound === "custom") {
+                customSoundCount++;
+            }
+        }
+    }
+
+    logger.info(`Enabled overrides: ${enabledCount} (${customSoundCount} custom)`);
+
+    const metadata = await AudioStore.getAllAudioMetadata();
+    const filesData: string = Object.entries(metadata)
+        .map(([id, file]) => `  - ${file.name} (${Math.round(file.size / 1024)}KB) [${id}]`)
+        .join("\n");
+
+    logger.info("Audio files:\n" + filesData);
+    logger.info("=== END DEBUG ===");
+}
+
+const soundSettings = Object.fromEntries(
+    allSoundTypes.map(type => [
+        type.id,
+        {
+            type: OptionType.STRING,
+            description: `Override for ${type.name}`,
+            default: JSON.stringify(makeEmptyOverride()),
+            hidden: true
+        }
+    ])
+);
+
+const fileSizeOptions = [
+    { value: 5, label: "5 MB (Conservative)" },
+    { value: 15, label: "15 MB (Default)" },
+    { value: 30, label: "30 MB (Large)" },
+    { value: 50, label: "50 MB (Very Large)" },
+    { value: 100, label: "100 MB (Extreme - Use with caution!)" },
+];
+
+const settings = definePluginSettings({
+    ...soundSettings,
+    skipForAll: {
+        type: OptionType.BOOLEAN,
+        description: "Used for the existing file upload alert",
+        default: false,
+        hidden: true
+    },
+    maxFileSize: {
+        type: OptionType.SELECT,
+        description: "Larger uploads use more memory, take more time to process and may cause performance issues or crashes on lower-end devices. Increase at your own risk!",
+        options: fileSizeOptions,
+        default: 15,
+        onChange: (value: number) => {
+            AudioStore.setMaxFileSizeMB(value);
+            dataUriCache.setSizeLimit(value);
+        }
+    },
+    resetSeasonalSoundsOnStartup: {
+        type: OptionType.BOOLEAN,
+        description: "Any sound set to a Halloween/Winter variant will be changed back to Default when the plugin loads.",
+        default: true
+    },
+    overrides: {
+        type: OptionType.COMPONENT,
+        description: "",
+        component: () => {
+            const [searchQuery, setSearchQuery] = React.useState("");
+            const [files, setFiles] = React.useState<Record<string, AudioStore.AudioFileMetadata>>({});
+            const [filesLoaded, setFilesLoaded] = React.useState(false);
+            const update = useForceUpdater();
+            const audioFilesInputRef = React.useRef<HTMLInputElement>(null);
+            const settingsFileInputRef = React.useRef<HTMLInputElement>(null);
+
+            const loadFiles = React.useCallback(async () => {
+                try {
+                    const metadata = await AudioStore.getAllAudioMetadata();
+                    setFiles(metadata);
+                    setFilesLoaded(true);
+                } catch (error) {
+                    logger.error("Error loading audio metadata:", error);
+                    setFilesLoaded(true);
+                }
+            }, []);
+
+            React.useEffect(() => {
+                allSoundTypes.forEach(type => {
+                    if (!settings.store[type.id]) {
+                        setOverride(type.id, makeEmptyOverride());
+                    }
+                });
+                loadFiles();
+            }, []);
+
+            const resetOverrides = () => {
+                allSoundTypes.forEach(type => setOverride(type.id, makeEmptyOverride()));
+            };
+
+            const uploadFiles = async (event: React.ChangeEvent<HTMLInputElement>) => {
+                const selectedFiles = event.target.files;
+                if (!selectedFiles) return;
+
+                showToast(selectedFiles.length > 1 ? `Uploading ${selectedFiles.length} files...` : "Uploading file...");
+
+                const filteredFiles: File[] = [];
+                for (const file of selectedFiles) {
+                    if (!file) continue;
+
+                    const fileExtension = file.name.split(".").pop()?.toLowerCase();
+                    if (!fileExtension || !AUDIO_EXTENSIONS.includes(fileExtension)) {
+                        showToast(`Invalid file type of "${file.name}". Please upload only audio files (${audioExtensionsFormattedString}).`);
+                        continue;
+                    }
+                    filteredFiles.push(file);
+                }
+
+                const audioDataToSave: [AudioStore.StoredAudioFile, AudioStore.AudioFileMetadata][] = [];
+                for (const file of filteredFiles) {
+                    try {
+                        const [data, metadata] = await AudioStore.processAudioFile(file);
+
+                        if (files[metadata.id]) {
+                            if (settings.store.skipForAll) continue;
+
+                            const doSkip = await Alerts.confirm({
+                                title: "The file already exists",
+                                body: `You already have a file named "${metadata.name}" uploaded.`,
+                                confirmText: "Skip",
+                                secondaryConfirmText: "Skip for all",
+                                cancelText: "Replace",
+                                onConfirmSecondary() {
+                                    settings.store.skipForAll = true;
+                                },
+                            });
+
+                            if (doSkip) continue;
+                        }
+
+                        audioDataToSave.push([data, metadata]);
+                    } catch (error: any) {
+                        logger.error("Upload error:", error);
+                        const message = error.message ?? "Unknown error";
+                        showToast(message.includes("too large") ? message : `Upload of "${error.name}" failed: ${message}`);
+                        continue;
+                    }
+                }
+                settings.store.skipForAll = false;
+
+                await AudioStore.saveAudioData(audioDataToSave);
+
+                for (const [_, metadata] of audioDataToSave) await ensureDataURICached(metadata.id);
+
+                update();
+                await loadFiles();
+                showToast(`Added ${audioDataToSave.length} file${audioDataToSave.length !== 1 ? "s" : ""}.`);
+                event.target.value = "";
+            };
+
+            const handleSettingsUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+                const file = event.target.files?.[0];
+
+                if (!file) return;
+
+                const reader = new FileReader();
+                reader.onload = async (e: ProgressEvent<FileReader>) => {
+                    try {
+                        resetOverrides();
+                        const imported: SettingsExport = JSON.parse(e.target?.result as string);
+
+                        const empty = makeEmptyOverride();
+                        const filesMissing: ({ id: string; } & SoundOverride)[] = [];
+                        if (imported.overrides && Array.isArray(imported.overrides)) {
+                            for (const setting of imported.overrides) {
+                                if (!setting.id) continue;
+
+                                const override: SoundOverride = {
+                                    enabled: setting.enabled ?? empty.enabled,
+                                    selectedSound: setting.selectedSound ?? empty.selectedSound,
+                                    selectedFileId: setting.selectedFileId ?? empty.selectedFileId,
+                                    volume: setting.volume ?? empty.volume,
+                                };
+                                setOverride(setting.id, override);
+
+                                if (!setting.selectedFileId) continue;
+                                if (!files[setting.selectedFileId]) filesMissing.push(setting);
+
+                                await ensureDataURICached(setting.selectedFileId);
+                            }
+                        }
+
+                        if (filesMissing.length !== 0) {
+                            Alerts.show({
+                                title: "Audio files not found",
+                                body: `Seems like some custom audio files are missing: ${filesMissing.map(setting => setting.selectedFileId).join(", ")}. Do you want to add missing files?`,
+                                async onConfirm() {
+                                    audioFilesInputRef.current?.click();
+                                },
+                                async onCancel() {
+                                    filesMissing.forEach(setting => {
+                                        const override: SoundOverride = {
+                                            enabled: setting.enabled,
+                                            selectedSound: setting.selectedSound,
+                                            selectedFileId: empty.selectedFileId,
+                                            volume: setting.volume,
+                                        };
+                                        setOverride(setting.id, override);
+                                    });
+                                },
+                                confirmText: "Yes",
+                                cancelText: "No"
+                            });
+                        }
+
+                        showToast("Settings imported successfully!");
+                    } catch (error) {
+                        logger.error("Error importing settings:", error);
+                        showToast("Error importing settings. Check console for details.");
+                    }
+                };
+
+                reader.readAsText(file);
+                event.target.value = "";
+            };
+
+            const downloadSettings = async () => {
+                const overrides = allSoundTypes.map(type => {
+                    const override = getOverride(type.id);
+                    return {
+                        id: type.id,
+                        enabled: override.enabled,
+                        selectedSound: override.selectedSound,
+                        selectedFileId: override.selectedFileId ?? undefined,
+                        volume: override.volume
+                    };
+                }).filter(o => o.enabled || o.selectedSound !== "default");
+
+                const exportPayload: SettingsExport = {
+                    __note: "Audio files are not included in exports and will need to be re-added before import",
+                    overrides
+                };
+
+                showToast(`Exporting ${overrides.length} settings... (Audio files are not included!)`);
+
+                const file = new File(
+                    [JSON.stringify(exportPayload, null, 2)],
+                    "customSounds-settings.json",
+                    { type: "application/json" }
+                );
+                saveFile(file);
+            };
+
+            const filteredSoundTypes = allSoundTypes.filter(type =>
+                type.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                type.id.toLowerCase().includes(searchQuery.toLowerCase())
+            );
+
+            return (
+                <div className={cl("main")}>
+                    <div className={cl("section")}>
+                        <Heading>Custom Audio Files</Heading>
+                        <div className={cl("buttons")}>
+                            <Button variant="positive" onClick={() => audioFilesInputRef.current?.click()}>Add</Button>
+                            <Button
+                                disabled={Object.keys(files).length === 0}
+                                variant="dangerPrimary"
+                                onClick={() => {
+                                    Alerts.show({
+                                        title: "Are you sure?",
+                                        body: `This will remove ${Object.keys(files).length} file${Object.keys(files).length !== 1 ? "s" : ""} imported into the plugin.`,
+                                        async onConfirm() {
+                                            await AudioStore.clearStore();
+                                            dataUriCache.clear();
+                                            update();
+                                            await loadFiles();
+                                            allSoundTypes.forEach(type => {
+                                                const override = getOverride(type.id);
+                                                override.selectedFileId = undefined;
+                                                setOverride(type.id, override);
+                                            });
+                                            showToast("Files removed successfully.");
+                                        },
+                                        confirmText: "Do it!",
+                                        confirmColor: "vc-notification-log-danger-btn",
+                                        cancelText: "Nevermind"
+                                    });
+                                }}
+                            >
+                                Remove All</Button>
+                            <Button variant="overlayPrimary" onClick={() => {
+                                debugCustomSounds();
+                                showToast("Debug info printed in the console.");
+                            }}
+                            >
+                                Debug</Button>
+                            <input
+                                ref={audioFilesInputRef}
+                                type="file"
+                                accept={audioExtensionsString}
+                                multiple
+                                style={{ display: "none" }}
+                                onChange={uploadFiles}
+                            />
+                        </div>
+                    </div>
+                    <div className={cl("section")}>
+                        <Heading>Overrides</Heading>
+                        <div className={cl("buttons")}>
+                            <Button variant="primary" onClick={() => settingsFileInputRef.current?.click()}>Import</Button>
+                            <Button variant="secondary" onClick={downloadSettings}>Export</Button>
+                            <Button variant="dangerPrimary" onClick={() => { resetOverrides(); showToast("All overrides reset successfully!"); }}>Reset All</Button>
+                            <input
+                                ref={settingsFileInputRef}
+                                type="file"
+                                accept=".json"
+                                style={{ display: "none" }}
+                                onChange={handleSettingsUpload}
+                            />
+                        </div>
+                        <Paragraph>NOTE: before importing settings, make sure to add required audio files by clicking "Add" button.</Paragraph>
+                    </div>
+                    <div className={cl("search")}>
+                        <Heading>Search Sounds</Heading>
+                        <TextInput
+                            value={searchQuery}
+                            onChange={(e: string) => setSearchQuery(e)}
+                            placeholder="Search by name or ID"
+                        />
+                    </div>
+
+                    {!filesLoaded ? (
+                        <Paragraph>Loading audio files...</Paragraph>
+                    ) : (
+                        <div className={cl("sounds-list")}>
+                            {filteredSoundTypes.map(type => {
+                                const currentOverride = getOverride(type.id);
+
+                                if (currentOverride.selectedFileId &&
+                                    !files[currentOverride.selectedFileId]) {
+                                    currentOverride.selectedFileId = undefined;
+                                    // setOverride(type.id, currentOverride);  // breaks "file missing" prompt
+                                }
+
+                                if (type.id === "disconnect") logger.debug("rerendering overrides list");
+
+                                return (
+                                    <SoundOverrideComponent
+                                        key={type.id}
+                                        type={type}
+                                        override={currentOverride}
+                                        files={files}
+                                        onFilesChange={loadFiles}
+                                        onChange={async () => {
+                                            setOverride(type.id, currentOverride);
+
+                                            if (currentOverride.enabled && currentOverride.selectedSound === "custom" && currentOverride.selectedFileId) {
+                                                try {
+                                                    await ensureDataURICached(currentOverride.selectedFileId);
+                                                } catch (error) {
+                                                    logger.error("Failed to load custom sound:", error);
+                                                    showToast("Error loading custom sound file. Check console for details.");
+                                                }
+                                            }
+                                        }}
+                                    />
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            );
+        }
+    }
+});
+
+export function isOverriden(id: string): boolean {
+    return !!getOverride(id)?.enabled;
+}
+
+export function findOverride(id: string): SoundOverride | null {
+    const override = getOverride(id);
+    return override?.enabled ? override : null;
+}
+
+export default definePlugin({
+    name: "CustomSounds",
+    description: "Customize Discord's sounds.",
+    authors: [Devs.SyberiaK, Devs.ScattrdBlade, Devs.TheKodeToad],
+    settings,
+    patches: [
+        {
+            find: 'Error("could not play audio")',
+            replacement: [
+                {
+                    match: /(?<=new Audio;\i\.src=)\i\([0-9]+\)\(`\.\/\$\{this\.name\}\.mp3`\)/,
+                    replace: "(() => { const customUrl = $self.getCustomSoundURL(this.name); return customUrl || $& })()"
+                },
+                {
+                    match: /Math.min\(\i\.\i\.getOutputVolume\(\)\/100\*this\._volume/,
+                    replace: "$& * ($self.findOverride(this.name)?.volume ?? 100) / 100"
+                }
+            ]
+        },
+        {
+            find: ".playWithListener().then",
+            replacement: {
+                match: /\i\.\i\.getSoundpack\(\)/,
+                replace: '$self.isOverriden(arguments[0]) ? "classic" : $&'
+            }
+        },
+        {
+            find: ".connectHasStarted",
+            replacement: {
+                match: /return;return"user_join"/,
+                replace: 'return;return $self.isOverriden("connect") ? "connect" : "user_join"'
+            }
+        },
+        {
+            find: ".getDesktopType()===",
+            replacement: [
+                {
+                    match: /sound:(\i\?\i:void 0,volume:\i,onClick)/,
+                    replace: 'sound: $self.mentionsEveryone(arguments[0]?.message) && $self.isOverriden("mention2") ? "mention2" : $self.mentionsMe(arguments[0]?.message) && $self.isOverriden("user_mentioned") ? "user_mentioned" : $1'
+                }
+            ]
+        }
+    ],
+    findOverride,
+    isOverriden,
+    getCustomSoundURL,
+    refreshDataURI,
+    ensureDataURICached,
+    debugCustomSounds,
+    mentionsEveryone(message: MessageJSON) {
+        return message.mention_everyone;
+    },
+    mentionsMe(message: MessageJSON) {
+        return message.mentions.some(m => m.id === UserStore.getCurrentUser().id);
+    },
+    startAt: StartAt.Init,
+
+    async start() {
+        try {
+            const maxSize = settings.store.maxFileSize ?? 15;
+            AudioStore.setMaxFileSizeMB(maxSize);
+            dataUriCache.setSizeLimit(maxSize);
+
+            if (settings.store.resetSeasonalSoundsOnStartup) {
+                resetSeasonalOverridesToDefault();
+            }
+
+            const migratedFiles = await AudioStore.migrateStorage();
+            if (migratedFiles) {
+                allSoundTypes.forEach(type => {
+                    const override = getOverride(type.id);
+                    if (override.selectedFileId) {
+                        const newId = migratedFiles[override.selectedFileId];
+                        override.selectedFileId = newId ?? override.selectedFileId;
+                        setOverride(type.id, override);
+                    }
+                });
+            }
+
+            await preloadDataURIs();
+        } catch (error) {
+            logger.error("Startup error:", error);
+        }
+    }
+});

--- a/src/plugins/customSounds/styles.css
+++ b/src/plugins/customSounds/styles.css
@@ -1,0 +1,66 @@
+.vc-custom-sounds-main {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25em;
+}
+
+.vc-custom-sounds-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+}
+
+.vc-custom-sounds-section * {
+    margin-bottom: 0;
+}
+
+.vc-custom-sounds-card {
+    padding: 1em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+}
+
+.vc-custom-sounds-card > * {
+    margin-bottom: 0;
+}
+
+.vc-custom-sounds-card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+}
+
+.vc-custom-sounds-card-option {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+}
+
+.vc-custom-sounds-card-option * {
+    margin-bottom: 0;
+}
+
+.vc-custom-sounds-buttons {
+    display: flex;
+    gap: 8px;
+}
+
+.vc-custom-sounds-search {
+    margin-bottom: 0;
+}
+
+.vc-custom-sounds-search input {
+    width: 100%;
+    padding: 8px;
+    background: var(--input-background);
+    border: none;
+    border-radius: 3px;
+    color: var(--text-normal);
+}
+
+.vc-custom-sounds-sounds-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}

--- a/src/plugins/customSounds/types.ts
+++ b/src/plugins/customSounds/types.ts
@@ -1,0 +1,143 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface SoundType {
+    name: string;
+    id: string;
+    seasonal?: string[];
+    derived?: string; // any sound with this is implemented by the plugin
+}
+
+export interface SoundOverride {
+    enabled: boolean;
+    selectedSound: "default" | "custom" | (string & {}); // `keyof typeof SEASONAL_SOUNDS`?
+    volume: number;
+    selectedFileId?: string;
+}
+
+export interface SoundPlayer {
+    loop(): void;
+    play(): void;
+    pause(): void;
+    stop(): void;
+}
+
+export const SEASONAL_SOUNDS = {
+    "halloween_call_calling": "https://canary.discord.com/assets/0950a7ea4f1dd037870b.mp3",
+    "winter_call_calling": "https://canary.discord.com/assets/7b945e7be3f86c5b7c82.mp3",
+    "halloween_call_ringing": "https://canary.discord.com/assets/1b883b366ae11a303b82.mp3",
+    "winter_call_ringing": "https://canary.discord.com/assets/e087eb83aaa4c43a44bc.mp3",
+    "call_ringing_beat": "https://canary.discord.com/assets/3b3a2f5f29b9cb656efb.mp3",
+    "call_ringing_snow_halation": "https://canary.discord.com/assets/99b1d8a6fe0b95e99827.mp3",
+    "call_ringing_snowsgiving": "https://canary.discord.com/assets/54527e70cf0ddaeff76f.mp3",
+    "halloween_deafen": "https://canary.discord.com/assets/c4aedda3b528df50221c.mp3",
+    "winter_deafen": "https://canary.discord.com/assets/9bb77985afdb60704817.mp3",
+    "halloween_disconnect": "https://canary.discord.com/assets/ca7d2e46cb5a16819aff.mp3",
+    "winter_disconnect": "https://canary.discord.com/assets/ec5d85405877c27caeda.mp3",
+    "halloween_message1": "https://canary.discord.com/assets/e386c839fb98675c6a79.mp3",
+    "halloween_mute": "https://canary.discord.com/assets/ee7fdadf4c714eed6254.mp3",
+    "winter_mute": "https://canary.discord.com/assets/6d7616e08466ab9f1c6d.mp3",
+    "halloween_undeafen": "https://canary.discord.com/assets/045e5b9608df1607e0cf.mp3",
+    "winter_undeafen": "https://canary.discord.com/assets/fa8da1499894ecac36c7.mp3",
+    "halloween_unmute": "https://canary.discord.com/assets/260c581568eacca03f7e.mp3",
+    "winter_unmute": "https://canary.discord.com/assets/9dbfb1c211e3815cd7b1.mp3",
+    "halloween_user_join": "https://canary.discord.com/assets/80cf806f45467a5898cd.mp3",
+    "winter_user_join": "https://canary.discord.com/assets/badc42c2a9063b4a962c.mp3",
+    "halloween_user_leave": "https://canary.discord.com/assets/f407ad88a1dc40541769.mp3",
+    "winter_user_leave": "https://canary.discord.com/assets/ec3d9eaea30b33e16da6.mp3"
+} as const; // for some reason discord also bundles "halloween_defean" and "halloween_undefean" which are exactly same as the sane named ones
+
+export const SOUND_TYPES: readonly SoundType[] = [
+    { name: "Activity End", id: "activity_end" },
+    { name: "Activity Launch", id: "activity_launch" },
+    { name: "Activity User Join", id: "activity_user_join" },
+    { name: "Activity User Left", id: "activity_user_left" },
+    { name: "Call Calling (outcoming)", id: "call_calling", seasonal: ["halloween_call_calling", "winter_call_calling"] },
+    {
+        name: "Call Ringing (incoming)",
+        id: "call_ringing",
+        seasonal: [
+            "halloween_call_ringing",
+            "winter_call_ringing",
+            "call_ringing_beat",
+            "call_ringing_snow_halation",
+            "call_ringing_snowsgiving"
+        ]
+    },
+    { name: "Camera Off", id: "camera_off" },
+    { name: "Camera On", id: "camera_on" },
+    { name: "Clip Error", id: "clip_error" },
+    { name: "Clip Save", id: "clip_save" },
+    { name: "Connect (derived from User Join)", id: "connect", derived: "user_join" },
+    { name: "DDR Down", id: "ddr-down" },
+    { name: "DDR Left", id: "ddr-left" },
+    { name: "DDR Right", id: "ddr-right" },
+    { name: "DDR Up", id: "ddr-up" },
+    { name: "Deafen", id: "deafen", seasonal: ["halloween_deafen", "winter_deafen"] },
+    { name: "Discodo", id: "discodo" },
+    { name: "Disconnect", id: "disconnect", seasonal: ["halloween_disconnect", "winter_disconnect"] },
+    { name: "Hang Status Select", id: "hang_status_select" },
+    // { name: "Human Man (unused)", id: "human_man" },
+    { name: "Invited to Speak", id: "reconnect" },
+    // { name: "Mention 1 (unused)", id: "mention1" },
+    { name: "Mention 2 (@everyone)", id: "mention2" },
+    { name: "Mention 3 (used in switching audio devices)", id: "mention3" },
+    {
+        name: "Message 1",
+        id: "message1",
+        seasonal: [
+            "halloween_message1",
+            "asmr_message1",
+            "bit_message1",
+            "bop_message1",
+            "ducky_message1",
+            "lofi_message1",
+        ]
+    },
+    { name: "Message 2 (unused?)", id: "message2" },
+    { name: "Message 3 (unused?)", id: "message3" },
+    { name: "Mute", id: "mute", seasonal: ["halloween_mute", "winter_mute"] },
+    { name: "Overlay Unlock", id: "overlayunlock" },
+    { name: "Poggermode Achievement", id: "poggermode_achievement_unlock" },
+    { name: "Poggermode Applause", id: "poggermode_applause" },
+    { name: "Poggermode Enabled", id: "poggermode_enabled" },
+    { name: "Poggermode Message", id: "poggermode_message_send" },
+    { name: "PTT Start", id: "ptt_start" },
+    { name: "PTT Stop", id: "ptt_stop" },
+    { name: "Robot Man", id: "robot_man" },
+    { name: "Stage Waiting", id: "stage_waiting" },
+    { name: "Stream Ended", id: "stream_ended" },
+    { name: "Stream Started", id: "stream_started" },
+    { name: "Stream User Joined", id: "stream_user_joined" },
+    { name: "Stream User Left", id: "stream_user_left" },
+    { name: "Success", id: "success" },
+    { name: "Undeafen", id: "undeafen", seasonal: ["halloween_undeafen", "winter_undeafen"] },
+    { name: "Unmute", id: "unmute", seasonal: ["halloween_unmute", "winter_unmute"] },
+    { name: "User Join", id: "user_join", seasonal: ["halloween_user_join", "winter_user_join"] },
+    { name: "User Leave", id: "user_leave", seasonal: ["halloween_user_leave", "winter_user_leave"] },
+    { name: "User Mentioned (derived from Message 1)", id: "user_mentioned", derived: "message1" },
+    { name: "User Moved", id: "user_moved" },
+    { name: "Vibing Wumpus", id: "vibing_wumpus" },
+    { name: "Voice Filter off (unused?)", id: "voice_filter_off" },
+    { name: "Voice Filter on (unused?)", id: "voice_filter_on" },
+    { name: "Voice Filter swap (unused?)", id: "voice_filter_swap" },
+    { name: "Voice Filter loopback off (unused?)", id: "voice_filter_loopback_off" },
+    { name: "Voice Filter loopback on (unused?)", id: "voice_filter_loopback_on" },
+] as const;
+
+export function makeEmptyOverride(): SoundOverride {
+    return {
+        enabled: false,
+        selectedSound: "default",
+        volume: 100,
+        selectedFileId: undefined
+    };
+}
+
+export interface SettingsExport {
+    __note: "Audio files are not included in exports and will need to be re-added before import";
+    overrides: ({ id: string; } & SoundOverride)[];
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    SyberiaK: {
+        name: "SyberiaK",
+        id: 355270337702920192n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
A plugin that allows to change Discord sounds, replacing them with the seasonal ones or your own sounds that you can upload.

Basically a duplicate of #1765 with some QoL changes:

- Allowed uploading multiple files within the same popup;
- Uploading existing files invokes a prompt to skip or replace files;
- Missing files at configuration import invokes a prompt to upload those files;
- Derived sounds: you can set different sounds to events that either reuse the same sound (connecting to a VC vs someone else connecting to your VC) or where the separation makes sense (mentioning you vs everyone/here vs role);
  - There are currently two derived sounds implemented: `connect` (derived from `user_join`) and `user_mentioned` (derived from `message1`)
- Various fixes and changes that improved on UX or made the plugin's behavior more predictable.

## Some context

For one of my projects I was looking for a Discord plugin that allows to replace sounds with the custom ones with configuration import. There are a couple of implementations out there:

- by TheKoadToad (#1765)
- by @ScattrdBlade (https://github.com/ScattrdBlade/customSounds)
- by Equicord's team (https://github.com/Equicord/Equicord/blob/main/src/equicordplugins/customSounds)

...and neither of those could actually satisfy my requirements:

- TheKoadToad's plugin is **very** dated and lacks configuration import;
- Scattrd's file storage uses randomly generated IDs, which makes imports *almost completely* useless. I did make a [hotfix PR](https://github.com/ScattrdBlade/customSounds/pull/20) by utilizing file contents hashes as IDs, but Scattrd [reverted](https://github.com/ScattrdBlade/customSounds/commit/263108006d1c4edbb68f81658244de6dbfbd44c4#diff-751dcb032a615aeaaf802914775e6c2731dad7727a767e85071ca13fa70caa11R20) the change later on by pulling code from Equicord's repo, *which also removed the migration mechanism, breaking existing configurations* (?);
- Equicord's plugin also uses randomly generated IDs, as well as an outdated sounds list, which now includes some unused ones.

But I was (and still is) very glad those do exist.

I have almost no background in Discord modifications, so the code might look weird in some parts or still do some quirky stuff in the background, which I haven't noticed while using it myself for a few months. It also contains some quite opinionated decisions *(like the whole "derived sounds" thingy)*, but I'm open for any suggestions for changes.

While it is a duplicate, I hope at the very least it sparks more activity into making this kind of plugin available for regular Vencord users without a hassle.