### PR TITLE
New plugin: PdfViewer (supersedes #2876)

### DIFF
--- a/src/plugins/pdfViewer.desktop/README.md
+++ b/src/plugins/pdfViewer.desktop/README.md
@@ -1,0 +1,12 @@
+# PdfViewer
+
+Preview PDF attachments inline without having to download them first.
+
+## How it works
+
+PDFs are fetched through a small desktop-native helper (CORS would otherwise block the renderer when downloading from `cdn.discordapp.com`) and rendered with [PDF.js](https://mozilla.github.io/pdf.js/), loaded lazily from `cdnjs.cloudflare.com`. The viewer supports zoom, fit-to-width and lazy per-page rasterisation, so even large documents stay responsive.
+
+## Settings
+
+- **Largest PDF that can be previewed inline** — above this size the inline preview is disabled. The file remains downloadable from Discord's normal attachment UI.
+- **Number of recently opened PDFs to keep in memory** — LRU cache size for the fetched bytes. `0` disables caching.

--- a/src/plugins/pdfViewer.desktop/index.tsx
+++ b/src/plugins/pdfViewer.desktop/index.tsx
@@ -721,7 +721,7 @@ export default definePlugin({
     name: "PdfViewer",
     description: "Preview PDF attachments inline without downloading them first",
     tags: ["Media", "Utility", "Chat"],
-    authors: [Devs.vp9],
+    authors: [Devs.vp9, Devs.semon009],
     settings,
 
     renderMessageAccessory({ message }) {

--- a/src/plugins/pdfViewer.desktop/index.tsx
+++ b/src/plugins/pdfViewer.desktop/index.tsx
@@ -278,6 +278,18 @@ const ZoomOutIcon = (props: SvgIconProps) => (
     </SvgIcon>
 );
 
+const FitWidthIcon = (props: SvgIconProps) => (
+    <SvgIcon {...props}>
+        <path d="M4 5v14" />
+        <path d="M20 5v14" />
+        <path d="M8 12h8" />
+        <path d="m8 12 3-3" />
+        <path d="m8 12 3 3" />
+        <path d="m16 12-3-3" />
+        <path d="m16 12-3 3" />
+    </SvgIcon>
+);
+
 function Spinner() {
     return <span aria-hidden="true" className="vc-pdfViewer-spinner" />;
 }
@@ -383,6 +395,7 @@ function PdfPage({
             {shouldRender
                 ? <canvas ref={canvasRef} />
                 : <div className="vc-pdfViewer-pagePlaceholder"><Spinner /></div>}
+            <div aria-hidden="true" className="vc-pdfViewer-pageBadge">page {state.pageNumber}</div>
         </div>
     );
 }
@@ -578,7 +591,7 @@ function PdfDocumentView({ bytes }: { bytes: Uint8Array; }) {
                     <ZoomInIcon />
                 </IconButton>
                 <IconButton label="Fit width" active={scale == null} onClick={() => setScale(null)}>
-                    <span className="vc-pdfViewer-fitLabel">Fit</span>
+                    <FitWidthIcon />
                 </IconButton>
             </div>
             <div className="vc-pdfViewer-pages" ref={containerRef}>

--- a/src/plugins/pdfViewer.desktop/index.tsx
+++ b/src/plugins/pdfViewer.desktop/index.tsx
@@ -1,0 +1,733 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles.css";
+
+import { definePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { Devs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+import definePlugin, { IconProps, OptionType, PluginNative } from "@utils/types";
+import { Message, MessageAttachment } from "@vencord/discord-types";
+import { Tooltip, useEffect, useMemo, useRef, useState } from "@webpack/common";
+import type { ReactNode } from "react";
+
+const Native = VencordNative.pluginHelpers.PdfViewer as PluginNative<typeof import("./native")>;
+
+const logger = new Logger("PdfViewer");
+
+const PDFJS_VERSION = "3.11.174";
+const PDFJS_LIB_URL = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}/pdf.min.js`;
+const PDFJS_WORKER_URL = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}/pdf.worker.min.js`;
+
+const ZOOM_LEVELS = [0.5, 0.75, 1, 1.25, 1.5, 2, 3];
+const RENDER_PAGE_NEIGHBOURS = 1;
+
+const settings = definePluginSettings({
+    maxFileSizeMb: {
+        type: OptionType.SLIDER,
+        description: "Largest PDF that can be previewed inline",
+        markers: [5, 10, 25, 50, 100],
+        stickToMarkers: true,
+        default: 25,
+    },
+    cacheEntries: {
+        type: OptionType.SLIDER,
+        description: "Number of recently opened PDFs to keep in memory",
+        markers: [0, 1, 3, 5, 10],
+        stickToMarkers: true,
+        default: 3,
+        onChange: () => trimCache(),
+    },
+});
+
+interface PdfPageProxy {
+    pageNumber: number;
+    getViewport(opts: { scale: number; }): { width: number; height: number; };
+    render(opts: { canvasContext: CanvasRenderingContext2D; viewport: any; }): { promise: Promise<void>; cancel(): void; };
+    cleanup(): void;
+}
+
+interface PdfDocumentProxy {
+    numPages: number;
+    getPage(pageNumber: number): Promise<PdfPageProxy>;
+    destroy(): Promise<void>;
+}
+
+interface PdfJsLib {
+    GlobalWorkerOptions: { workerSrc: string; };
+    getDocument(opts: any): { promise: Promise<PdfDocumentProxy>; };
+}
+
+declare global {
+    interface Window { pdfjsLib?: PdfJsLib; }
+}
+
+interface CacheEntry {
+    bytes: Uint8Array;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function maxFileSizeBytes() {
+    return Math.max(1, settings.store.maxFileSizeMb) * 1024 * 1024;
+}
+
+function cacheKey(attachment: MessageAttachment) {
+    return `${attachment.id}:${attachment.url}`;
+}
+
+function trimCache() {
+    const max = Math.max(0, Math.round(settings.store.cacheEntries));
+    while (cache.size > max) {
+        const oldest = cache.keys().next().value;
+        if (!oldest) break;
+        cache.delete(oldest);
+    }
+}
+
+function clearCache() {
+    cache.clear();
+}
+
+function getCached(key: string) {
+    const entry = cache.get(key);
+    if (!entry) return null;
+    cache.delete(key);
+    cache.set(key, entry);
+    return entry.bytes;
+}
+
+function setCached(key: string, bytes: Uint8Array) {
+    if (settings.store.cacheEntries <= 0) return;
+    cache.delete(key);
+    cache.set(key, { bytes });
+    trimCache();
+}
+
+function toUint8Array(value: unknown): Uint8Array {
+    if (value instanceof Uint8Array) return value;
+    if (value instanceof ArrayBuffer) return new Uint8Array(value);
+    if (ArrayBuffer.isView(value)) {
+        const v = value as ArrayBufferView;
+        return new Uint8Array(v.buffer as ArrayBuffer, v.byteOffset, v.byteLength);
+    }
+    if (Array.isArray(value)) return new Uint8Array(value);
+    if (value && typeof value === "object") {
+        const obj = value as { data?: unknown; length?: number; };
+        if (Array.isArray(obj.data)) return new Uint8Array(obj.data);
+        if (typeof obj.length === "number") return new Uint8Array(value as ArrayLike<number>);
+    }
+    throw new Error("Native fetcher returned non-binary data");
+}
+
+async function loadBytes(attachment: MessageAttachment) {
+    const key = cacheKey(attachment);
+    const cached = getCached(key);
+    if (cached) return cached;
+
+    const raw = await Native.fetchPdf(attachment.url, maxFileSizeBytes());
+    if (!raw) throw new Error("Native fetcher returned an empty payload");
+
+    const view = toUint8Array(raw);
+    if (view.byteLength < 4) throw new Error("Native fetcher returned a truncated payload");
+
+    const dest = new Uint8Array(view.byteLength);
+    dest.set(view);
+
+    setCached(key, dest);
+    return dest;
+}
+
+let pdfjsLoadPromise: Promise<PdfJsLib> | null = null;
+
+function loadPdfJs(): Promise<PdfJsLib> {
+    if (window.pdfjsLib) return Promise.resolve(window.pdfjsLib);
+    if (pdfjsLoadPromise) return pdfjsLoadPromise;
+
+    pdfjsLoadPromise = new Promise<PdfJsLib>((resolve, reject) => {
+        const finish = () => {
+            if (window.pdfjsLib) {
+                window.pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_URL;
+                resolve(window.pdfjsLib);
+            } else {
+                reject(new Error("PDF.js loaded but window.pdfjsLib is missing"));
+            }
+        };
+
+        const existing = document.querySelector(`script[data-vc-pdfjs="${PDFJS_VERSION}"]`) as HTMLScriptElement | null;
+        if (existing) {
+            existing.addEventListener("load", finish);
+            existing.addEventListener("error", () => reject(new Error("Failed to load PDF.js")));
+            return;
+        }
+
+        const script = document.createElement("script");
+        script.src = PDFJS_LIB_URL;
+        script.async = true;
+        script.dataset.vcPdfjs = PDFJS_VERSION;
+        script.addEventListener("load", finish);
+        script.addEventListener("error", () => {
+            pdfjsLoadPromise = null;
+            reject(new Error("Failed to load PDF.js from cdnjs"));
+        });
+        document.head.appendChild(script);
+    });
+
+    return pdfjsLoadPromise;
+}
+
+function isPdfAttachment(attachment: MessageAttachment) {
+    if (attachment.content_type === "application/pdf") return true;
+    return attachment.filename?.toLowerCase().endsWith(".pdf") ?? false;
+}
+
+function formatBytes(bytes: number) {
+    if (!Number.isFinite(bytes) || bytes < 0) return "Unknown size";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function getErrorMessage(error: unknown) {
+    if (error instanceof Error && error.message) return error.message;
+    if (typeof error === "string" && error) return error;
+    if (error && typeof error === "object" && "message" in (error as any) && (error as any).message) return String((error as any).message);
+    return "Unknown error";
+}
+
+type SvgIconProps = IconProps & { size?: number; };
+
+function SvgIcon({ children, size, height, width, className }: SvgIconProps & { children: ReactNode; }) {
+    const dimension = size ?? height ?? width ?? 18;
+    return (
+        <svg
+            aria-hidden="true"
+            className={className}
+            fill="none"
+            height={dimension}
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width={dimension}
+        >
+            {children}
+        </svg>
+    );
+}
+
+const FileIcon = (props: SvgIconProps) => (
+    <SvgIcon {...props}>
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" />
+        <path d="M14 2v6h6" />
+        <path d="M9 13h6" />
+        <path d="M9 17h6" />
+    </SvgIcon>
+);
+
+const EyeIcon = (props: SvgIconProps) => (
+    <SvgIcon {...props}>
+        <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12Z" />
+        <circle cx="12" cy="12" r="3" />
+    </SvgIcon>
+);
+
+const EyeOffIcon = (props: SvgIconProps) => (
+    <SvgIcon {...props}>
+        <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+        <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
+        <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+        <path d="m2 2 20 20" />
+    </SvgIcon>
+);
+
+const ExternalIcon = (props: SvgIconProps) => (
+    <SvgIcon {...props}>
+        <path d="M15 3h6v6" />
+        <path d="M10 14 21 3" />
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    </SvgIcon>
+);
+
+const RetryIcon = (props: SvgIconProps) => (
+    <SvgIcon {...props}>
+        <path d="M21 12a9 9 0 1 1-3-6.7" />
+        <path d="M21 4v5h-5" />
+    </SvgIcon>
+);
+
+const ZoomInIcon = (props: SvgIconProps) => (
+    <SvgIcon {...props}>
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+        <path d="M11 8v6" />
+        <path d="M8 11h6" />
+    </SvgIcon>
+);
+
+const ZoomOutIcon = (props: SvgIconProps) => (
+    <SvgIcon {...props}>
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+        <path d="M8 11h6" />
+    </SvgIcon>
+);
+
+function Spinner() {
+    return <span aria-hidden="true" className="vc-pdfViewer-spinner" />;
+}
+
+interface IconButtonProps {
+    label: string;
+    children: ReactNode;
+    disabled?: boolean;
+    active?: boolean;
+    onClick(): void;
+}
+
+function IconButton({ label, children, disabled, active, onClick }: IconButtonProps) {
+    return (
+        <Tooltip text={label}>
+            {tooltipProps => (
+                <button
+                    {...tooltipProps}
+                    aria-label={label}
+                    aria-pressed={active ? "true" : undefined}
+                    className={`vc-pdfViewer-button${active ? " vc-pdfViewer-button-active" : ""}`}
+                    disabled={disabled}
+                    onClick={event => {
+                        event.stopPropagation();
+                        if (!disabled) onClick();
+                    }}
+                    type="button"
+                >
+                    {children}
+                </button>
+            )}
+        </Tooltip>
+    );
+}
+
+interface PageState {
+    pageNumber: number;
+    width: number;
+    height: number;
+}
+
+function PdfPage({
+    page,
+    state,
+    scale,
+    shouldRender,
+}: {
+    page: PdfPageProxy | null;
+    state: PageState;
+    scale: number;
+    shouldRender: boolean;
+}) {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const renderedKeyRef = useRef<string | null>(null);
+
+    const { width, height } = useMemo(() => {
+        if (!page) return { width: state.width * scale, height: state.height * scale };
+        const viewport = page.getViewport({ scale });
+        return { width: viewport.width, height: viewport.height };
+    }, [page, scale, state.width, state.height]);
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas || !page || !shouldRender) return;
+
+        const key = `${state.pageNumber}@${scale.toFixed(3)}`;
+        if (renderedKeyRef.current === key) return;
+
+        const dpr = Math.min(2, window.devicePixelRatio || 1);
+        const viewport = page.getViewport({ scale: scale * dpr });
+        canvas.width = Math.floor(viewport.width);
+        canvas.height = Math.floor(viewport.height);
+        canvas.style.width = `${viewport.width / dpr}px`;
+        canvas.style.height = `${viewport.height / dpr}px`;
+
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+
+        const task = page.render({ canvasContext: ctx, viewport });
+        let cancelled = false;
+        task.promise
+            .then(() => {
+                if (!cancelled) renderedKeyRef.current = key;
+            })
+            .catch(err => {
+                if (cancelled) return;
+                if (err?.name === "RenderingCancelledException") return;
+                logger.error("PDF page render failed", err);
+            });
+
+        return () => {
+            cancelled = true;
+            try { task.cancel(); } catch { /* */ }
+        };
+    }, [page, scale, shouldRender, state.pageNumber]);
+
+    return (
+        <div
+            className="vc-pdfViewer-page"
+            data-page-number={state.pageNumber}
+            style={{ width, height }}
+        >
+            {shouldRender
+                ? <canvas ref={canvasRef} />
+                : <div className="vc-pdfViewer-pagePlaceholder"><Spinner /></div>}
+        </div>
+    );
+}
+
+function PdfDocumentView({ bytes }: { bytes: Uint8Array; }) {
+    const [pdf, setPdf] = useState<PdfDocumentProxy | null>(null);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [pageStates, setPageStates] = useState<PageState[]>([]);
+    const [pages, setPages] = useState<Map<number, PdfPageProxy>>(new Map());
+    const [visiblePages, setVisiblePages] = useState<Set<number>>(new Set([1]));
+    const [scale, setScale] = useState<number | null>(null);
+    const [containerWidth, setContainerWidth] = useState(0);
+
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        let docRef: PdfDocumentProxy | null = null;
+
+        (async () => {
+            try {
+                const lib = await loadPdfJs();
+                if (cancelled) return;
+
+                const data = new Uint8Array(bytes.byteLength);
+                data.set(bytes);
+
+                const task = lib.getDocument({
+                    data,
+                    isEvalSupported: false,
+                    disableAutoFetch: true,
+                    disableStream: true,
+                });
+                const doc = await task.promise;
+                if (cancelled) {
+                    doc.destroy().catch(() => null);
+                    return;
+                }
+                docRef = doc;
+                setPdf(doc);
+
+                const firstPage = await doc.getPage(1);
+                if (cancelled) return;
+                const v = firstPage.getViewport({ scale: 1 });
+                const baseStates: PageState[] = [{ pageNumber: 1, width: v.width, height: v.height }];
+                for (let i = 2; i <= doc.numPages; i++) {
+                    baseStates.push({ pageNumber: i, width: v.width, height: v.height });
+                }
+                setPageStates(baseStates);
+                setPages(prev => {
+                    const next = new Map(prev);
+                    next.set(1, firstPage);
+                    return next;
+                });
+            } catch (err) {
+                if (cancelled) return;
+                logger.error("Failed to open PDF", err);
+                const msg = getErrorMessage(err);
+                setLoadError(msg.toLowerCase().includes("password") ? "This PDF is password-protected." : msg);
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+            if (docRef) docRef.destroy().catch(() => null);
+        };
+    }, [bytes]);
+
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+
+        const update = () => setContainerWidth(container.clientWidth);
+        update();
+
+        const ro = new ResizeObserver(update);
+        ro.observe(container);
+        return () => ro.disconnect();
+    }, [pageStates.length]);
+
+    useEffect(() => {
+        if (!pdf || pageStates.length === 0) return;
+        const container = containerRef.current;
+        if (!container) return;
+
+        const observer = new IntersectionObserver(entries => {
+            setVisiblePages(prev => {
+                const next = new Set(prev);
+                let changed = false;
+                for (const entry of entries) {
+                    if (!entry.isIntersecting) continue;
+                    const num = Number((entry.target as HTMLElement).dataset.pageNumber);
+                    if (!Number.isFinite(num)) continue;
+                    for (let i = num - RENDER_PAGE_NEIGHBOURS; i <= num + RENDER_PAGE_NEIGHBOURS; i++) {
+                        if (i >= 1 && i <= pdf.numPages && !next.has(i)) {
+                            next.add(i);
+                            changed = true;
+                        }
+                    }
+                }
+                return changed ? next : prev;
+            });
+        }, { root: container, rootMargin: "200px 0px 200px 0px" });
+
+        for (const el of container.querySelectorAll<HTMLElement>(".vc-pdfViewer-page")) {
+            observer.observe(el);
+        }
+
+        return () => observer.disconnect();
+    }, [pdf, pageStates.length]);
+
+    useEffect(() => {
+        if (!pdf) return;
+        let cancelled = false;
+        const toFetch = [...visiblePages].filter(num => !pages.has(num));
+        if (!toFetch.length) return;
+
+        (async () => {
+            const additions: [number, PdfPageProxy][] = [];
+            for (const num of toFetch) {
+                try {
+                    const page = await pdf.getPage(num);
+                    if (cancelled) return;
+                    additions.push([num, page]);
+                } catch (err) {
+                    logger.error(`Failed to load page ${num}`, err);
+                }
+            }
+            if (!additions.length || cancelled) return;
+            setPages(prev => {
+                const next = new Map(prev);
+                for (const [num, p] of additions) next.set(num, p);
+                return next;
+            });
+            setPageStates(prev => prev.map(state => {
+                const fetched = additions.find(([n]) => n === state.pageNumber);
+                if (!fetched) return state;
+                const v = fetched[1].getViewport({ scale: 1 });
+                return { pageNumber: state.pageNumber, width: v.width, height: v.height };
+            }));
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [visiblePages, pdf]);
+
+    const effectiveScale = useMemo(() => {
+        if (scale != null) return scale;
+        if (!pageStates.length || containerWidth <= 0) return 1;
+        return Math.max(0.25, Math.min(3, (containerWidth - 32) / pageStates[0].width));
+    }, [scale, pageStates, containerWidth]);
+
+    const zoomIn = () => setScale(current => {
+        const base = current ?? effectiveScale;
+        return ZOOM_LEVELS.find(level => level > base + 0.001) ?? base;
+    });
+
+    const zoomOut = () => setScale(current => {
+        const base = current ?? effectiveScale;
+        return [...ZOOM_LEVELS].reverse().find(level => level < base - 0.001) ?? base;
+    });
+
+    if (loadError) {
+        return (
+            <div className="vc-pdfViewer-centeredState vc-pdfViewer-error">
+                <span>Couldn't open PDF: {loadError}</span>
+            </div>
+        );
+    }
+
+    if (!pdf) {
+        return (
+            <div className="vc-pdfViewer-centeredState">
+                <Spinner />
+                <span>Opening PDF…</span>
+            </div>
+        );
+    }
+
+    return (
+        <div className="vc-pdfViewer-document">
+            <div className="vc-pdfViewer-toolbar">
+                <span className="vc-pdfViewer-pageCount">
+                    {pdf.numPages} {pdf.numPages === 1 ? "page" : "pages"}
+                </span>
+                <span className="vc-pdfViewer-toolbarSpacer" />
+                <IconButton label="Zoom out" onClick={zoomOut}>
+                    <ZoomOutIcon />
+                </IconButton>
+                <span className="vc-pdfViewer-zoomLabel">{Math.round(effectiveScale * 100)}%</span>
+                <IconButton label="Zoom in" onClick={zoomIn}>
+                    <ZoomInIcon />
+                </IconButton>
+                <IconButton label="Fit width" active={scale == null} onClick={() => setScale(null)}>
+                    <span className="vc-pdfViewer-fitLabel">Fit</span>
+                </IconButton>
+            </div>
+            <div className="vc-pdfViewer-pages" ref={containerRef}>
+                {pageStates.map(state => (
+                    <PdfPage
+                        key={state.pageNumber}
+                        page={pages.get(state.pageNumber) ?? null}
+                        scale={effectiveScale}
+                        shouldRender={visiblePages.has(state.pageNumber) && pages.has(state.pageNumber)}
+                        state={state}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function PdfPreviewBody({ attachment }: { attachment: MessageAttachment; }) {
+    const [bytes, setBytes] = useState<Uint8Array | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [reloadId, setReloadId] = useState(0);
+
+    useEffect(() => {
+        let cancelled = false;
+        setBytes(null);
+        setError(null);
+
+        loadBytes(attachment)
+            .then(buffer => {
+                if (!cancelled) setBytes(buffer);
+            })
+            .catch(loadError => {
+                logger.error("Failed to fetch PDF", loadError);
+                if (!cancelled) setError(getErrorMessage(loadError));
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [attachment.id, attachment.url, reloadId]);
+
+    if (error) {
+        return (
+            <div className="vc-pdfViewer-centeredState vc-pdfViewer-error">
+                <span>Couldn't load PDF: {error}</span>
+                <button
+                    className="vc-pdfViewer-textButton"
+                    onClick={event => {
+                        event.stopPropagation();
+                        setReloadId(id => id + 1);
+                    }}
+                    type="button"
+                >
+                    <RetryIcon size={14} /> Retry
+                </button>
+            </div>
+        );
+    }
+
+    if (!bytes) {
+        return (
+            <div className="vc-pdfViewer-centeredState">
+                <Spinner />
+                <span>Loading PDF…</span>
+            </div>
+        );
+    }
+
+    return <PdfDocumentView bytes={bytes} />;
+}
+
+function PdfAttachmentPreview({ attachment }: { attachment: MessageAttachment; }) {
+    const tooLarge = attachment.size > maxFileSizeBytes();
+    const [open, setOpen] = useState(false);
+    const sizeLabel = useMemo(() => formatBytes(attachment.size), [attachment.size]);
+
+    const togglePreview = () => {
+        if (tooLarge) return;
+        setOpen(value => !value);
+    };
+
+    return (
+        <div className="vc-pdfViewer-shell" onClick={event => event.stopPropagation()}>
+            <div className="vc-pdfViewer-fileBar">
+                <FileIcon size={22} />
+                <div className="vc-pdfViewer-fileMeta">
+                    <span className="vc-pdfViewer-fileName" title={attachment.filename}>
+                        {attachment.filename}
+                    </span>
+                    <span className="vc-pdfViewer-fileSize">
+                        PDF · {sizeLabel}
+                        {tooLarge && (
+                            <span className="vc-pdfViewer-fileWarn">
+                                {" "}· exceeds {settings.store.maxFileSizeMb} MB limit
+                            </span>
+                        )}
+                    </span>
+                </div>
+
+                <IconButton
+                    active={open}
+                    disabled={tooLarge}
+                    label={tooLarge
+                        ? `Preview disabled — PDF is over ${settings.store.maxFileSizeMb} MB`
+                        : open ? "Hide preview" : "Preview PDF"}
+                    onClick={togglePreview}
+                >
+                    {open ? <EyeOffIcon /> : <EyeIcon />}
+                </IconButton>
+
+                <IconButton
+                    label="Open in browser"
+                    onClick={() => VencordNative.native.openExternal(attachment.url)}
+                >
+                    <ExternalIcon />
+                </IconButton>
+            </div>
+
+            {open && <PdfPreviewBody attachment={attachment} />}
+        </div>
+    );
+}
+
+const WrappedPreview = ErrorBoundary.wrap(PdfAttachmentPreview, { noop: true });
+
+export default definePlugin({
+    name: "PdfViewer",
+    description: "Preview PDF attachments inline without downloading them first",
+    tags: ["Media", "Utility", "Chat"],
+    authors: [Devs.vp9],
+    settings,
+
+    renderMessageAccessory({ message }) {
+        const msg = message as Message;
+        if (!msg?.attachments?.length) return null;
+
+        const pdfAttachments = msg.attachments.filter(isPdfAttachment);
+        if (!pdfAttachments.length) return null;
+
+        return (
+            <div className="vc-pdfViewer-stack">
+                {pdfAttachments.map((attachment: MessageAttachment) => (
+                    <WrappedPreview attachment={attachment} key={attachment.id} />
+                ))}
+            </div>
+        );
+    },
+
+    stop() {
+        clearCache();
+    },
+});

--- a/src/plugins/pdfViewer.desktop/native.ts
+++ b/src/plugins/pdfViewer.desktop/native.ts
@@ -1,0 +1,121 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { IpcMainInvokeEvent } from "electron";
+
+const ALLOWED_HOSTS = new Set([
+    "cdn.discordapp.com",
+    "media.discordapp.net",
+]);
+
+const ALLOWED_PATH_PREFIXES = [
+    "/attachments/",
+    "/ephemeral-attachments/",
+];
+
+const PDF_MAGIC = [0x25, 0x50, 0x44, 0x46];
+const ABSOLUTE_MIN_BYTES = 1024 * 1024;
+const ABSOLUTE_MAX_BYTES = 200 * 1024 * 1024;
+const DEFAULT_MAX_BYTES = 25 * 1024 * 1024;
+
+function clampMaxBytes(maxBytes: number) {
+    if (!Number.isFinite(maxBytes)) return DEFAULT_MAX_BYTES;
+    return Math.min(ABSOLUTE_MAX_BYTES, Math.max(ABSOLUTE_MIN_BYTES, Math.floor(maxBytes)));
+}
+
+function validateAttachmentUrl(rawUrl: string) {
+    let parsed: URL;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        throw new Error("Invalid attachment URL");
+    }
+
+    if (parsed.protocol !== "https:") throw new Error("Only HTTPS attachments can be previewed");
+    if (!ALLOWED_HOSTS.has(parsed.hostname)) throw new Error("Only Discord CDN attachments can be previewed");
+
+    const pathname = decodeURIComponent(parsed.pathname).toLowerCase();
+    if (!ALLOWED_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix))) {
+        throw new Error("URL is not a Discord attachment path");
+    }
+    if (!pathname.endsWith(".pdf")) throw new Error("Only .pdf attachments can be previewed");
+
+    return parsed;
+}
+
+function hasPdfMagic(bytes: Uint8Array) {
+    if (bytes.byteLength < PDF_MAGIC.length) return false;
+    for (let i = 0; i < PDF_MAGIC.length; i++) {
+        if (bytes[i] !== PDF_MAGIC[i]) return false;
+    }
+    return true;
+}
+
+export async function fetchPdf(_: IpcMainInvokeEvent, url: string, maxBytes: number) {
+    const parsed = validateAttachmentUrl(url);
+    const limit = clampMaxBytes(maxBytes);
+
+    const response = await fetch(parsed, {
+        method: "GET",
+        redirect: "manual",
+        headers: { Accept: "application/pdf,application/octet-stream;q=0.9,*/*;q=0.1" },
+    }).catch(() => null);
+
+    if (!response) throw new Error("Failed to reach Discord CDN");
+    if (response.status >= 300 && response.status < 400) throw new Error("Discord CDN tried to redirect; refusing for safety");
+    if (!response.ok) throw new Error(`Discord CDN returned ${response.status} ${response.statusText || ""}`.trim());
+
+    const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+    if (contentType && contentType !== "application/pdf" && contentType !== "application/octet-stream" && contentType !== "binary/octet-stream") {
+        throw new Error(`Unexpected content-type: ${contentType}`);
+    }
+
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > 0 && declaredLength > limit) {
+        throw new Error(`PDF is ${Math.round(declaredLength / 1024 / 1024)} MB which exceeds the ${Math.round(limit / 1024 / 1024)} MB limit`);
+    }
+
+    let bytes: Uint8Array;
+
+    if (response.body) {
+        const reader = response.body.getReader();
+        const chunks: Uint8Array[] = [];
+        let received = 0;
+
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (!value || value.byteLength === 0) continue;
+
+                received += value.byteLength;
+                if (received > limit) {
+                    throw new Error(`PDF exceeds the ${Math.round(limit / 1024 / 1024)} MB size limit`);
+                }
+                chunks.push(value);
+            }
+        } finally {
+            try { await reader.cancel(); } catch { /* */ }
+        }
+
+        bytes = new Uint8Array(received);
+        let offset = 0;
+        for (const chunk of chunks) {
+            bytes.set(chunk, offset);
+            offset += chunk.byteLength;
+        }
+    } else {
+        const buffer = await response.arrayBuffer();
+        if (buffer.byteLength > limit) {
+            throw new Error(`PDF exceeds the ${Math.round(limit / 1024 / 1024)} MB size limit`);
+        }
+        bytes = new Uint8Array(buffer);
+    }
+
+    if (!hasPdfMagic(bytes)) throw new Error("Downloaded data is not a valid PDF");
+
+    return bytes;
+}

--- a/src/plugins/pdfViewer.desktop/styles.css
+++ b/src/plugins/pdfViewer.desktop/styles.css
@@ -22,6 +22,12 @@
     min-width: 0;
     min-height: 48px;
     padding: 8px 10px;
+    color: var(--text-default, var(--text-normal, #dbdee1));
+}
+
+.vc-pdfViewer-fileBar > svg {
+    color: var(--text-link, var(--brand-360, #00a8fc));
+    flex: 0 0 auto;
 }
 
 .vc-pdfViewer-fileMeta {
@@ -33,7 +39,7 @@
 
 .vc-pdfViewer-fileName {
     overflow: hidden;
-    color: var(--text-normal);
+    color: var(--text-default, var(--text-normal, #dbdee1));
     font-size: 14px;
     font-weight: 600;
     line-height: 18px;
@@ -42,7 +48,7 @@
 }
 
 .vc-pdfViewer-fileSize {
-    color: var(--text-muted);
+    color: var(--text-muted, var(--text-secondary, #b5bac1));
     font-size: 12px;
     line-height: 16px;
 }
@@ -62,10 +68,14 @@
     padding: 0;
     border: 0;
     border-radius: 6px;
-    color: var(--interactive-normal);
+    color: var(--interactive-icon-default, var(--interactive-normal, #b5bac1));
     background: transparent;
     cursor: pointer;
     transition: color 120ms ease, background-color 120ms ease;
+}
+
+.vc-pdfViewer-button svg {
+    color: inherit;
 }
 
 .vc-pdfViewer-button:disabled {
@@ -74,20 +84,25 @@
 }
 
 .vc-pdfViewer-button:hover:not(:disabled) {
-    color: var(--interactive-hover);
-    background: var(--background-modifier-hover);
+    color: var(--interactive-icon-hover, var(--interactive-hover, #dbdee1));
+    background: var(--background-mod-subtle, var(--background-modifier-hover, rgb(255 255 255 / 8%)));
 }
 
 .vc-pdfViewer-button:active:not(:disabled) {
-    background: var(--background-modifier-active);
+    background: var(--background-mod-strong, var(--background-modifier-active, rgb(255 255 255 / 12%)));
 }
 
 .vc-pdfViewer-button-active {
-    color: var(--interactive-active, var(--text-link));
-    background: var(--background-modifier-selected, var(--background-modifier-active));
+    color: var(--text-link, var(--interactive-icon-active, var(--interactive-active, #00a8fc)));
+    background: var(--background-mod-strong, var(--background-modifier-selected, rgb(88 101 242 / 18%)));
+}
+
+.vc-pdfViewer-button-active:hover:not(:disabled) {
+    color: var(--text-link, var(--interactive-icon-active, var(--interactive-active, #00a8fc)));
 }
 
 .vc-pdfViewer-document {
+    position: relative;
     display: flex;
     flex-direction: column;
     border-top: 1px solid var(--border-subtle, var(--background-modifier-accent));
@@ -95,6 +110,25 @@
     height: clamp(420px, 60vh, 720px);
     resize: vertical;
     overflow: hidden;
+}
+
+.vc-pdfViewer-document::after {
+    content: "";
+    position: absolute;
+    right: 10px;
+    bottom: 5px;
+    width: 36px;
+    height: 6px;
+    pointer-events: none;
+    background-image: radial-gradient(circle, var(--interactive-icon-default, var(--text-muted, #b5bac1)) 1.3px, transparent 1.5px);
+    background-repeat: repeat-x;
+    background-size: 8px 6px;
+    opacity: 0.55;
+    transition: opacity 120ms ease;
+}
+
+.vc-pdfViewer-document:hover::after {
+    opacity: 0.85;
 }
 
 .vc-pdfViewer-toolbar {
@@ -113,22 +147,16 @@
 
 .vc-pdfViewer-pageCount {
     font-size: 12px;
-    color: var(--text-muted);
+    color: var(--text-muted, var(--text-secondary, #b5bac1));
     font-variant-numeric: tabular-nums;
 }
 
 .vc-pdfViewer-zoomLabel {
     font-size: 12px;
-    color: var(--text-normal);
+    color: var(--text-default, var(--text-normal, #dbdee1));
     min-width: 40px;
     text-align: center;
     font-variant-numeric: tabular-nums;
-}
-
-.vc-pdfViewer-fitLabel {
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.02em;
 }
 
 .vc-pdfViewer-pages {
@@ -142,12 +170,36 @@
 }
 
 .vc-pdfViewer-page {
+    position: relative;
     background: white;
     box-shadow: 0 4px 12px rgb(0 0 0 / 25%);
     display: flex;
     align-items: center;
     justify-content: center;
     flex: 0 0 auto;
+}
+
+.vc-pdfViewer-pageBadge {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 1;
+    padding: 4px 7px;
+    border-radius: 6px;
+    color: white;
+    background: rgb(0 0 0 / 70%);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.vc-pdfViewer-page:hover .vc-pdfViewer-pageBadge {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .vc-pdfViewer-page canvas {
@@ -173,7 +225,7 @@
     gap: 10px;
     min-height: 160px;
     padding: 24px 16px;
-    color: var(--text-muted);
+    color: var(--text-muted, var(--text-secondary, #b5bac1));
     text-align: center;
     border-top: 1px solid var(--border-subtle, var(--background-modifier-accent));
 }
@@ -189,7 +241,7 @@
     padding: 6px 12px;
     border: 1px solid var(--border-subtle, var(--background-modifier-accent));
     border-radius: 6px;
-    color: var(--text-normal);
+    color: var(--text-default, var(--text-normal, #dbdee1));
     background: var(--background-secondary-alt, var(--background-tertiary));
     font-size: 13px;
     font-weight: 500;
@@ -205,8 +257,8 @@
 .vc-pdfViewer-spinner {
     width: 20px;
     height: 20px;
-    border: 2px solid var(--background-modifier-accent);
-    border-top-color: var(--interactive-active, var(--text-link));
+    border: 2px solid var(--background-modifier-accent, rgb(255 255 255 / 16%));
+    border-top-color: var(--text-link, var(--interactive-icon-active, #00a8fc));
     border-radius: 50%;
     animation: vc-pdf-viewer-spin 800ms linear infinite;
 }

--- a/src/plugins/pdfViewer.desktop/styles.css
+++ b/src/plugins/pdfViewer.desktop/styles.css
@@ -1,0 +1,218 @@
+.vc-pdfViewer-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-width: min(100%, 960px);
+    margin-top: 8px;
+}
+
+.vc-pdfViewer-shell {
+    width: 100%;
+    min-width: 0;
+    border: 1px solid var(--border-subtle, var(--background-modifier-accent));
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--background-secondary);
+}
+
+.vc-pdfViewer-fileBar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    min-height: 48px;
+    padding: 8px 10px;
+}
+
+.vc-pdfViewer-fileMeta {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.vc-pdfViewer-fileName {
+    overflow: hidden;
+    color: var(--text-normal);
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 18px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vc-pdfViewer-fileSize {
+    color: var(--text-muted);
+    font-size: 12px;
+    line-height: 16px;
+}
+
+.vc-pdfViewer-fileWarn {
+    color: var(--text-danger);
+    font-weight: 500;
+}
+
+.vc-pdfViewer-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex: 0 0 auto;
+    padding: 0;
+    border: 0;
+    border-radius: 6px;
+    color: var(--interactive-normal);
+    background: transparent;
+    cursor: pointer;
+    transition: color 120ms ease, background-color 120ms ease;
+}
+
+.vc-pdfViewer-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+}
+
+.vc-pdfViewer-button:hover:not(:disabled) {
+    color: var(--interactive-hover);
+    background: var(--background-modifier-hover);
+}
+
+.vc-pdfViewer-button:active:not(:disabled) {
+    background: var(--background-modifier-active);
+}
+
+.vc-pdfViewer-button-active {
+    color: var(--interactive-active, var(--text-link));
+    background: var(--background-modifier-selected, var(--background-modifier-active));
+}
+
+.vc-pdfViewer-document {
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--border-subtle, var(--background-modifier-accent));
+    background: var(--background-tertiary);
+    height: clamp(420px, 60vh, 720px);
+    resize: vertical;
+    overflow: hidden;
+}
+
+.vc-pdfViewer-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: var(--background-secondary-alt, var(--background-secondary));
+    border-bottom: 1px solid var(--border-subtle, var(--background-modifier-accent));
+    flex: 0 0 auto;
+}
+
+.vc-pdfViewer-toolbarSpacer {
+    flex: 1 1 auto;
+}
+
+.vc-pdfViewer-pageCount {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.vc-pdfViewer-zoomLabel {
+    font-size: 12px;
+    color: var(--text-normal);
+    min-width: 40px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+
+.vc-pdfViewer-fitLabel {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.vc-pdfViewer-pages {
+    flex: 1 1 auto;
+    overflow: auto;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.vc-pdfViewer-page {
+    background: white;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 25%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+}
+
+.vc-pdfViewer-page canvas {
+    display: block;
+    max-width: 100%;
+    height: auto;
+}
+
+.vc-pdfViewer-pagePlaceholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--background-floating);
+}
+
+.vc-pdfViewer-centeredState {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    min-height: 160px;
+    padding: 24px 16px;
+    color: var(--text-muted);
+    text-align: center;
+    border-top: 1px solid var(--border-subtle, var(--background-modifier-accent));
+}
+
+.vc-pdfViewer-error {
+    color: var(--text-danger);
+}
+
+.vc-pdfViewer-textButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border: 1px solid var(--border-subtle, var(--background-modifier-accent));
+    border-radius: 6px;
+    color: var(--text-normal);
+    background: var(--background-secondary-alt, var(--background-tertiary));
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 120ms ease;
+}
+
+.vc-pdfViewer-textButton:hover {
+    background: var(--background-modifier-hover);
+}
+
+.vc-pdfViewer-spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--background-modifier-accent);
+    border-top-color: var(--interactive-active, var(--text-link));
+    border-radius: 50%;
+    animation: vc-pdf-viewer-spin 800ms linear infinite;
+}
+
+@keyframes vc-pdf-viewer-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -642,6 +642,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "vp.9",
         id: 1105670596525834250n,
     },
+    semon009: {
+        name: "semon009",
+        id: 810973438100635688n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    vp9: {
+        name: "vp.9",
+        id: 1105670596525834250n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Adds a `PdfViewer` plugin (`.desktop`) that previews PDF attachments inline so the user no longer has to download them just to see what's inside.

This supersedes the dormant #2876 by @TheGreenPig — the original concept. His last code commit was September 2024 and the PR has been inactive since. This is a fresh implementation that incorporates the review feedback you left there:

- Renamed to `PdfViewer`, folder marked `.desktop` since native is required.
- Strict allowlist using the `URL` API (host + path prefix + `.pdf` extension + `https:` only).
- `fetch` instead of the `https` module, with `.catch(() => null)` so a failed connection produces a meaningful error.
- `redirect: "manual"` so the allowlist cannot be sidestepped through a CDN redirect.
- Streaming download with both a `content-length` pre-check and a per-chunk size cap, so an oversized response is aborted mid-flight rather than buffered to completion.
- `%PDF` magic-byte check before the bytes leave the native side.
- React state for the preview toggle, no DataStore persistence.
- `ErrorBoundary.wrap(..., { noop: true })`.
- All class names prefixed with `vc-`.

### Why PDF.js instead of `<embed>`

The original PR used `<embed type="application/pdf">`, which relies on the host having Chromium's PDF plugin enabled. Recent vanilla Discord builds disable it (`navigator.pdfViewerEnabled` is `false` on current Canary), so the embed would render blank for most users. PDF.js renders to canvas in plain JS so it doesn't depend on the host plugin, and it's loaded lazily from `cdnjs.cloudflare.com` — a host already on Vencord's CSP allow-list (same pattern `shikiCodeblocks.desktop` uses for grammar JSON). No new build dependencies, no CSP changes.

PDF.js is configured with `isEvalSupported: false`, `disableAutoFetch: true`, `disableStream: true`, and pages are rasterised lazily via an `IntersectionObserver` (only the visible page plus its neighbours are rendered at any time).

Happy to add a `<embed>` path back as a runtime fallback for clients where `navigator.pdfViewerEnabled === true` if you'd prefer; left it out here to keep the PR scope tight.

### Settings

- **Largest PDF that can be previewed inline** — slider, 5/10/25/50/100 MB, default 25.
- **Number of recently opened PDFs to keep in memory** — slider, 0/1/3/5/10, default 3 (LRU cache of fetched bytes).

### Files

- `src/plugins/pdfViewer.desktop/{index.tsx,native.ts,styles.css,README.md}` — new
- `src/utils/constants.ts` — adds `Devs` entries for the plugin authors

CSP and every other core file are untouched.

### Screenshots

<img width="574" height="343" alt="Plugin entry in settings" src="https://github.com/user-attachments/assets/85a39fdd-3df8-4146-8928-a0cb32c50ce4" />

<img width="749" height="607" alt="PDF inline preview" src="https://github.com/user-attachments/assets/b0d3f3f5-5f07-4c72-8824-f7b4a67cf4c9" />

<img width="760" height="636" alt="Page rendering with toolbar" src="https://github.com/user-attachments/assets/b06095b5-3054-4973-b524-f83aa0255ec8" />

<img width="735" height="608" alt="image" src="https://github.com/user-attachments/assets/94c38e51-44e1-4f23-a517-999a79bf541d" />

### Tested on

- Discord Canary (Chromium PDF plugin disabled, `navigator.pdfViewerEnabled === false`) — works.

Thanks to @TheGreenPig for the original concept, and to @semon009 for the toolbar's Fit Width icon, the per-page hover badges, the resize grip indicator, and the updated Discord theme variables.
