### PR TITLE
feat(plugin): add tobezdev's Tweaks plugin 

### DIFF
--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -12,14 +12,24 @@ let style: HTMLStyleElement | null = null;
  * Geneate an equal CSS gradient based on the given colors
  * @param colors The colors
  */
-function generateEquivalentGradient(colors: string[]) {
-	let per = 100 / colors.length;
+function generateEquivalentGradient(colors) {
+	let per = Math.floor(100 / (colors.length - 1));
+	let bonus = 100 - (per * (colors.length - 1));
 	let curr = 0;
 	let str = "linear-gradient(180deg";
 
+	let ind = 0;
 	colors.forEach(color => {
-		str += ", " + color + " " + curr + "%";
+		let to_apply = curr;
+
+		if (ind == colors.length - 1) {
+			to_apply += bonus;
+		}
+
+		str += ", " + color + " " + to_apply + "%";
 		curr += per;
+
+		++ind;
 	});
 
 	return str;

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -1,0 +1,461 @@
+import { definePluginSettings } from "@api/Settings";
+import { managedStyleRootNode } from "@api/Styles";
+import { createAndAppendStyle } from "@utils/css";
+import definePlugin, { OptionType } from "@utils/types";
+import { Devs } from "@utils/constants";
+
+type MentionFlagPreset = "bi" | "pan" | "trans" | "lesbian" | "nonbinary" | "asexual" | "rainbow";
+
+let style: HTMLStyleElement | null = null;
+
+function getMentionGradients(preset: MentionFlagPreset) {
+    switch (preset) {
+        case "pan":
+            return {
+                background: "linear-gradient(100deg, rgba(255, 27, 141, 0.24) 0%, rgba(255, 27, 141, 0.24) 34%, rgba(255, 218, 0, 0.2) 50%, rgba(26, 179, 255, 0.24) 66%, rgba(26, 179, 255, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #ff1b8d 0%, #ffda00 50%, #1ab3ff 100%)"
+            };
+        case "trans":
+            return {
+                background: "linear-gradient(100deg, rgba(91, 206, 250, 0.24) 0%, rgba(245, 169, 184, 0.2) 25%, rgba(255, 255, 255, 0.18) 50%, rgba(245, 169, 184, 0.2) 75%, rgba(91, 206, 250, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #5bcefa 0%, #f5a9b8 25%, #ffffff 50%, #f5a9b8 75%, #5bcefa 100%)"
+            };
+        case "lesbian":
+            return {
+                background: "linear-gradient(100deg, rgba(213, 45, 0, 0.24) 0%, rgba(239, 118, 39, 0.22) 25%, rgba(255, 154, 86, 0.2) 42%, rgba(181, 86, 144, 0.2) 58%, rgba(163, 2, 98, 0.24) 78%, rgba(163, 2, 98, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #d52d00 0%, #ef7627 25%, #ff9a56 42%, #d162a4 58%, #b55690 72%, #a30262 100%)"
+            };
+        case "nonbinary":
+            return {
+                background: "linear-gradient(100deg, rgba(252, 244, 52, 0.24) 0%, rgba(252, 244, 52, 0.24) 30%, rgba(252, 252, 252, 0.2) 50%, rgba(156, 89, 209, 0.22) 70%, rgba(45, 45, 45, 0.26) 100%)",
+                bar: "linear-gradient(180deg, #fcf434 0%, #fcfcfc 33%, #9c59d1 66%, #2d2d2d 100%)"
+            };
+        case "asexual":
+            return {
+                background: "linear-gradient(100deg, rgba(18, 18, 18, 0.26) 0%, rgba(163, 163, 163, 0.2) 35%, rgba(255, 255, 255, 0.18) 50%, rgba(128, 0, 128, 0.24) 75%, rgba(128, 0, 128, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #121212 0%, #a3a3a3 33%, #ffffff 66%, #800080 100%)"
+            };
+        case "rainbow":
+            return {
+                background: "linear-gradient(100deg, rgba(229, 0, 0, 0.24) 0%, rgba(255, 141, 0, 0.22) 16%, rgba(255, 238, 0, 0.2) 33%, rgba(2, 129, 33, 0.2) 50%, rgba(0, 76, 255, 0.22) 66%, rgba(119, 0, 136, 0.24) 84%, rgba(119, 0, 136, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #e50000 0%, #ff8d00 16%, #ffee00 33%, #028121 50%, #004cff 66%, #770088 84%, #770088 100%)"
+            };
+        case "bi":
+        default:
+            return {
+                background: "linear-gradient(100deg, rgba(214, 2, 112, 0.26) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.22) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.26) 100%)",
+                bar: "linear-gradient(180deg, #d60270 0%, #bf2a83 30%, #9b4f96 50%, #68479f 72%, #0038a8 100%)"
+            };
+    }
+}
+
+function buildCss() {
+    const css: string[] = [];
+
+    if (settings.store.hideAvatarDecorations) {
+        css.push(`
+/* Hide avatar decorations everywhere */
+[class="avatarDecoration"],
+[class*="avatarDecorationContainer"],
+svg[class="avatarDecoration"],
+img[class*="avatarDecoration"] {
+    display: none !important;
+}
+`);
+    }
+
+    if (settings.store.scaleReadAllButton) {
+        css.push(`
+/* Fix display width of 'read all' button for notifications & unreads */
+button.vc-text-btn-base.vc-text-btn-secondary.vc-ranb-button {
+    scale: 0.8;
+}
+`);
+    }
+
+    if (settings.store.scaleFriendCount) {
+        css.push(`
+/* Fix display width of online friend count */
+span#vc-friendcount {
+    scale: 0.9;
+}
+`);
+    }
+
+    if (settings.store.roundAvatarsAndStatus) {
+        css.push(`
+/* Un-square avatars and online indicators */
+img.avatar_c19a55,
+img.avatar__44b0c,
+svg.svg__2338f > foreignObject > img,
+img.circularImage__1ce5d,
+svg.svg__2338f.mask_a423bd,
+div.wrapper__44b0c::after,
+div.container__1ce5d::after {
+    border-radius: 50% !important;
+}
+`);
+    }
+
+    if (settings.store.smoothAnimations) {
+        css.push(`
+:root {
+    --tbz-ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+    --tbz-ease-soft: cubic-bezier(0.25, 0.8, 0.25, 1);
+    --tbz-dur-fast: 120ms;
+    --tbz-dur-mid: 180ms;
+    --tbz-dur-slow: 260ms;
+    --tbz-scale-press: 0.98;
+    --tbz-scale-hover: 1.015;
+}
+
+@keyframes tbz-fade-in-up {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes tbz-fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes tbz-pop-in {
+    0% {
+        opacity: 0;
+        transform: scale(0.97);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+@keyframes tbz-highlight-pulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(88, 101, 242, 0.35);
+    }
+    100% {
+        box-shadow: 0 0 0 10px rgba(88, 101, 242, 0);
+    }
+}
+
+button,
+a,
+[role="button"],
+[role="tab"],
+[role="menuitem"],
+input,
+textarea,
+select,
+.clickable__972a0,
+.button__201d5,
+.item__48dda,
+.containerDefault__29444,
+.interactive__972a0,
+.channel__972a0,
+.membersWrap_c8ffbb,
+.member__5d473,
+.message_d5deea,
+.listItem__650eb,
+.wrapper__6e9f8,
+.panels_c48ade,
+.sidebarList_c48ade,
+.chatContent_a7d72e,
+.searchBar__35e86,
+.search__49676,
+.bar_c38106,
+.tabBar__133bf,
+.tabBar_d6f9e9,
+.base_c48ade,
+.contentRegionScroller__23e6b,
+.container__133bf,
+.standardSidebarView__23e6b,
+.menu_c1e9c4,
+.root__49fc1,
+.layer_da8173,
+.backdrop__78332,
+.autocomplete__13533,
+.messagesWrapper__36d07,
+.scroller__36d07,
+.scroller_c47fa9,
+.peopleListItem_cc6179,
+.container_c2739c,
+.cardPrimary__73069,
+.card__73069,
+.visual-refresh {
+    transition:
+        transform var(--tbz-dur-mid) var(--tbz-ease-standard),
+        opacity var(--tbz-dur-mid) var(--tbz-ease-soft),
+        background-color var(--tbz-dur-mid) var(--tbz-ease-soft),
+        color var(--tbz-dur-fast) var(--tbz-ease-soft),
+        border-color var(--tbz-dur-mid) var(--tbz-ease-soft),
+        box-shadow var(--tbz-dur-mid) var(--tbz-ease-soft),
+        filter var(--tbz-dur-mid) var(--tbz-ease-soft) !important;
+    will-change: transform, opacity;
+}
+
+button:hover,
+[role="button"]:hover,
+[role="tab"]:hover,
+[role="menuitem"]:hover,
+.clickable__972a0:hover,
+.button__201d5:hover,
+.interactive__972a0:hover,
+.channel__972a0:hover,
+.listItem__650eb:hover,
+.peopleListItem_cc6179:hover,
+.member__5d473:hover {
+    transform: translateY(-1px) scale(var(--tbz-scale-hover));
+}
+
+button:active,
+[role="button"]:active,
+[role="tab"]:active,
+[role="menuitem"]:active,
+.clickable__972a0:active,
+.button__201d5:active,
+.interactive__972a0:active,
+.channel__972a0:active,
+.listItem__650eb:active,
+.peopleListItem_cc6179:active,
+.member__5d473:active {
+    transform: scale(var(--tbz-scale-press));
+    transition-duration: var(--tbz-dur-fast) !important;
+}
+
+.listItem__650eb,
+.containerDefault__29444,
+.member__5d473,
+.peopleListItem_cc6179,
+.privateChannels__35e86 .channel__972a0 {
+    animation: tbz-fade-in-up var(--tbz-dur-slow) var(--tbz-ease-standard);
+}
+
+.message_d5deea,
+.cozy_f5c119.wrapper_c19a55,
+.compact_f5c119.wrapper_c19a55,
+.groupStart__5126c,
+.newMessagesBar__0f481 {
+    animation: tbz-fade-in-up var(--tbz-dur-mid) var(--tbz-ease-standard);
+}
+
+.sidebarList_c48ade,
+.chatContent_a7d72e,
+.contentRegionScroller__23e6b,
+.messagesWrapper__36d07,
+.scroller__36d07,
+.standardSidebarView__23e6b,
+.base_c48ade {
+    animation: tbz-fade-in var(--tbz-dur-slow) var(--tbz-ease-soft);
+}
+
+.menu_c1e9c4,
+.layer_da8173,
+[class*="popout"],
+[class*="Popout"],
+[class*="modal"],
+[class*="Modal"],
+[class*="picker"],
+[class*="Picker"],
+[class*="autocomplete"],
+[class*="Autocomplete"] {
+    transform-origin: top center;
+    animation: tbz-pop-in var(--tbz-dur-mid) var(--tbz-ease-standard);
+}
+
+.root__49fc1,
+.backdrop__78332,
+[class*="backdrop"],
+[class*="BackDrop"] {
+    animation: tbz-fade-in var(--tbz-dur-mid) var(--tbz-ease-soft);
+}
+
+.tabBar__133bf .item__133bf,
+.topPill_b3f026 .item_b3f026,
+.tabBar_d6f9e9 .item_d6f9e9 {
+    position: relative;
+    overflow: hidden;
+}
+
+.tabBar__133bf .item__133bf::after,
+.topPill_b3f026 .item_b3f026::after,
+.tabBar_d6f9e9 .item_d6f9e9::after {
+    content: "";
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    bottom: 4px;
+    height: 2px;
+    transform: scaleX(0);
+    transform-origin: center;
+    background: currentColor;
+    opacity: 0.65;
+    transition: transform var(--tbz-dur-mid) var(--tbz-ease-standard);
+}
+
+.tabBar__133bf .item__133bf[aria-selected="true"]::after,
+.topPill_b3f026 .item_b3f026[aria-selected="true"]::after,
+.tabBar_d6f9e9 .item_d6f9e9[aria-selected="true"]::after {
+    transform: scaleX(1);
+}
+
+.button__201d5:is(.lookFilled__201d5, .colorBrand__201d5):hover,
+.mentioned__5126c,
+.replying__5126c {
+    animation: tbz-highlight-pulse 650ms var(--tbz-ease-soft) 1;
+}
+
+[class*="toast"],
+[class*="notice"],
+.bar_c38106,
+.newMessagesBar__0f481,
+.jumpToPresentBar__0f481 {
+    animation: tbz-fade-in-up var(--tbz-dur-mid) var(--tbz-ease-standard);
+}
+
+input:focus,
+textarea:focus,
+.searchBar__35e86:focus-within,
+.search__49676:focus-within,
+.channelTextArea__74017:focus-within {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.16);
+}
+
+[class*="typing"],
+[class*="status"],
+[class*="badge"],
+.numberBadge__2b1f5 {
+    transition:
+        transform var(--tbz-dur-mid) var(--tbz-ease-standard),
+        opacity var(--tbz-dur-mid) var(--tbz-ease-soft) !important;
+}
+
+[class*="typing"]:hover,
+[class*="status"]:hover,
+[class*="badge"]:hover,
+.numberBadge__2b1f5:hover {
+    transform: scale(1.04);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 1ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 1ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+`);
+    }
+
+    if (settings.store.mentionReplyHighlight) {
+        const { background, bar } = getMentionGradients(settings.store.mentionReplyFlag as MentionFlagPreset);
+        css.push(`
+.mentioned__5126c,
+.replying__5126c,
+.mentioned__5126c:hover,
+.replying__5126c:hover,
+.mentioned__5126c.selected__5126c,
+.replying__5126c.selected__5126c {
+    background: ${background} !important;
+}
+
+.mentioned__5126c::before,
+.replying__5126c::before {
+    background: ${bar} !important;
+}
+`);
+    }
+
+    return css.join("\n");
+}
+
+function applyStyle() {
+    const css = buildCss();
+
+    if (!style) {
+        style = createAndAppendStyle("", managedStyleRootNode);
+    }
+
+    style!.textContent = css;
+}
+
+const settings = definePluginSettings({
+    hideAvatarDecorations: {
+        type: OptionType.BOOLEAN,
+        description: "Hide avatar decorations everywhere",
+        default: true,
+        onChange: applyStyle
+    },
+    scaleReadAllButton: {
+        type: OptionType.BOOLEAN,
+        description: "Scale the Vencord Read All Notifications button",
+        default: true,
+        onChange: applyStyle
+    },
+    scaleFriendCount: {
+        type: OptionType.BOOLEAN,
+        description: "Scale the online friend count label",
+        default: true,
+        onChange: applyStyle
+    },
+    roundAvatarsAndStatus: {
+        type: OptionType.BOOLEAN,
+        description: "Make avatars and status indicators circular",
+        default: true,
+        onChange: applyStyle
+    },
+    smoothAnimations: {
+        type: OptionType.BOOLEAN,
+        description: "Enable broad smooth animations for Discord UI",
+        default: true,
+        onChange: applyStyle
+    },
+    mentionReplyHighlight: {
+        type: OptionType.BOOLEAN,
+        description: "Enable custom mention/reply background highlight",
+        default: true,
+        onChange: applyStyle
+    },
+    mentionReplyFlag: {
+        type: OptionType.SELECT,
+        description: "Pride flag gradient preset for mention/reply highlight",
+        options: [
+            { label: "Pride Rainbow", value: "rainbow", default: true },
+            { label: "Bisexual", value: "bi" },
+            { label: "Pansexual", value: "pan" },
+            { label: "Lesbian", value: "lesbian" },
+            { label: "Asexual", value: "asexual" },
+            { label: "Transgender", value: "trans" },
+            { label: "Non-binary", value: "nonbinary" }
+        ],
+        onChange: applyStyle
+    }
+});
+
+export default definePlugin({
+    name: "tobezdev's Tweaks",
+    description: "QoL client tweaks with various customisable settings.",
+    authors: [Devs.tobezdev],
+    settings,
+    start() {
+        applyStyle();
+    },
+    stop() {
+        style?.remove();
+        style = null;
+    }
+});

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -461,7 +461,7 @@ const settings = definePluginSettings({
 export default definePlugin({
     name: "tobezdev's Tweaks",
     description: "QoL client tweaks with various customisable settings.",
-    authors: [Devs.tobezdev],
+    authors: [Devs.tobezdev, Devs.zffutwo],
     settings,
     start() {
         applyStyle();

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -10,58 +10,58 @@ let style: HTMLStyleElement | null = null;
 
 
 function getMentionGradients(preset: MentionFlagPreset) {
-	switch (preset) {
-		case "pan":
-			return {
-				background: "linear-gradient(100deg, rgba(255, 27, 141, 0.24) 0%, rgba(255, 27, 141, 0.24) 34%, rgba(255, 218, 0, 0.2) 50%, rgba(26, 179, 255, 0.24) 66%, rgba(26, 179, 255, 0.24) 100%)",
-				bar: "linear-gradient(180deg, #ff1b8d 0%, #ffda00 50%, #1ab3ff 100%)"
-			};
+    switch (preset) {
+        case "pan":
+            return {
+                background: "linear-gradient(100deg, rgba(255, 27, 141, 0.24) 0%, rgba(255, 27, 141, 0.24) 34%, rgba(255, 218, 0, 0.2) 50%, rgba(26, 179, 255, 0.24) 66%, rgba(26, 179, 255, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #ff1b8d 0%, #ffda00 50%, #1ab3ff 100%)"
+            };
 
-		case "trans":
-			return {
-				background: "linear-gradient(100deg, rgba(91, 206, 250, 0.24) 0%, rgba(245, 169, 184, 0.2) 25%, rgba(255, 255, 255, 0.18) 50%, rgba(245, 169, 184, 0.2) 75%, rgba(91, 206, 250, 0.24) 100%)",
-				bar: "linear-gradient(180deg, #5bcefa 0%, #f5a9b8 25%, #ffffff 50%, #f5a9b8 75%, #5bcefa 100%)"
-			};
-		case "lesbian":
-			return {
-				background: "linear-gradient(100deg, rgba(213, 45, 0, 0.24) 0%, rgba(239, 118, 39, 0.22) 25%, rgba(255, 154, 86, 0.2) 42%, rgba(181, 86, 144, 0.2) 58%, rgba(163, 2, 98, 0.24) 78%, rgba(163, 2, 98, 0.24) 100%)",
-				bar: "linear-gradient(180deg, #d52d00 0%, #ef7627 25%, #ff9a56 42%, #d162a4 58%, #b55690 72%, #a30262 100%)"
-			};
-		case "nonbinary":
-			return {
-				background: "linear-gradient(100deg, rgba(252, 244, 52, 0.24) 0%, rgba(252, 244, 52, 0.24) 30%, rgba(252, 252, 252, 0.2) 50%, rgba(156, 89, 209, 0.22) 70%, rgba(45, 45, 45, 0.26) 100%)",
-				bar: "linear-gradient(180deg, #fcf434 0%, #fcfcfc 33%, #9c59d1 66%, #2d2d2d 100%)"
-			};
-		case "asexual":
-			return {
-				background: "linear-gradient(100deg, rgba(18, 18, 18, 0.26) 0%, rgba(163, 163, 163, 0.2) 35%, rgba(255, 255, 255, 0.18) 50%, rgba(128, 0, 128, 0.24) 75%, rgba(128, 0, 128, 0.24) 100%)",
-				bar: "linear-gradient(180deg, #121212 0%, #a3a3a3 33%, #ffffff 66%, #800080 100%)"
-			};
-		case "rainbow":
-			return {
-				background: "linear-gradient(100deg, rgba(229, 0, 0, 0.24) 0%, rgba(255, 141, 0, 0.22) 16%, rgba(255, 238, 0, 0.2) 33%, rgba(2, 129, 33, 0.2) 50%, rgba(0, 76, 255, 0.22) 66%, rgba(119, 0, 136, 0.24) 84%, rgba(119, 0, 136, 0.24) 100%)",
-				bar: "linear-gradient(180deg, #e50000 0%, #ff8d00 16%, #ffee00 33%, #028121 50%, #004cff 66%, #770088 84%, #770088 100%)"
-			};
-		case "bi":
-			return {
-				background: "linear-gradient(100deg, rgba(214, 2, 112, 0.26) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.22) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.26) 100%)",
-				bar: "linear-gradient(180deg, #d60270 0%, #bf2a83 30%, #9b4f96 50%, #68479f 72%, #0038a8 100%)"
-			};
+        case "trans":
+            return {
+                background: "linear-gradient(100deg, rgba(91, 206, 250, 0.24) 0%, rgba(245, 169, 184, 0.2) 25%, rgba(255, 255, 255, 0.18) 50%, rgba(245, 169, 184, 0.2) 75%, rgba(91, 206, 250, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #5bcefa 0%, #f5a9b8 25%, #ffffff 50%, #f5a9b8 75%, #5bcefa 100%)"
+            };
+        case "lesbian":
+            return {
+                background: "linear-gradient(100deg, rgba(213, 45, 0, 0.24) 0%, rgba(239, 118, 39, 0.22) 25%, rgba(255, 154, 86, 0.2) 42%, rgba(181, 86, 144, 0.2) 58%, rgba(163, 2, 98, 0.24) 78%, rgba(163, 2, 98, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #d52d00 0%, #ef7627 25%, #ff9a56 42%, #d162a4 58%, #b55690 72%, #a30262 100%)"
+            };
+        case "nonbinary":
+            return {
+                background: "linear-gradient(100deg, rgba(252, 244, 52, 0.24) 0%, rgba(252, 244, 52, 0.24) 30%, rgba(252, 252, 252, 0.2) 50%, rgba(156, 89, 209, 0.22) 70%, rgba(45, 45, 45, 0.26) 100%)",
+                bar: "linear-gradient(180deg, #fcf434 0%, #fcfcfc 33%, #9c59d1 66%, #2d2d2d 100%)"
+            };
+        case "asexual":
+            return {
+                background: "linear-gradient(100deg, rgba(18, 18, 18, 0.26) 0%, rgba(163, 163, 163, 0.2) 35%, rgba(255, 255, 255, 0.18) 50%, rgba(128, 0, 128, 0.24) 75%, rgba(128, 0, 128, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #121212 0%, #a3a3a3 33%, #ffffff 66%, #800080 100%)"
+            };
+        case "rainbow":
+            return {
+                background: "linear-gradient(100deg, rgba(229, 0, 0, 0.24) 0%, rgba(255, 141, 0, 0.22) 16%, rgba(255, 238, 0, 0.2) 33%, rgba(2, 129, 33, 0.2) 50%, rgba(0, 76, 255, 0.22) 66%, rgba(119, 0, 136, 0.24) 84%, rgba(119, 0, 136, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #e50000 0%, #ff8d00 16%, #ffee00 33%, #028121 50%, #004cff 66%, #770088 84%, #770088 100%)"
+            };
+        case "bi":
+            return {
+                background: "linear-gradient(100deg, rgba(214, 2, 112, 0.24) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.24) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #d60270 0%, #bf2a83 30%, #9b4f96 50%, #68479f 72%, #0038a8 100%)"
+            };
 
-		case "femboy": {
-			return {
-				background: "linear-gradient(100deg, rgba(214, 2, 112, 0.26) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.22) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.26) 100%)",
-				bar: generateEquivalentGradient(["#d460a7", "#e4adcd", "#ffffff", "#57cef8", "#ffffff", "#e4adcd", "#d460a7"])
-			};
-		}
+        case "femboy": {
+            return {
+                background: "linear-gradient(100deg, rgba(212, 96, 167, 0.24) 0%, rgba(228, 173, 205, 0.24) 16.67%, rgba(255, 255, 255, 0.24) 33.33%, rgba(87, 206, 248, 0.24) 50%, rgba(255, 255, 255, 0.24) 66.67%, rgba(228, 173, 205, 0.24) 83.33%, rgba(212, 96, 167, 0.24) 100%)",
+                bar: "linear-gradient(180deg, #d460a7 0%, #e4adcd 16.67%, #ffffff 33.33%, #57cef8 50%, #ffffff 66.67%, #e4adcd 83.33%, #d460a7 100%)"
+            };
+        }
 
-		case "none":
-		default:
-			return {
-				background: "none",
-				bar: "none"
-			};
-	}
+        case "none":
+        default:
+            return {
+                background: "none",
+                bar: "none"
+            };
+    }
 }
 
 function buildCss() {

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -4,7 +4,7 @@ import { createAndAppendStyle } from "@utils/css";
 import definePlugin, { OptionType } from "@utils/types";
 import { Devs } from "@utils/constants";
 
-type MentionFlagPreset = "bi" | "pan" | "trans" | "lesbian" | "nonbinary" | "asexual" | "rainbow";
+type MentionFlagPreset = "none" | "disabled" | "bi" | "pan" | "trans" | "lesbian" | "nonbinary" | "asexual" | "rainbow";
 
 let style: HTMLStyleElement | null = null;
 
@@ -41,10 +41,15 @@ function getMentionGradients(preset: MentionFlagPreset) {
                 bar: "linear-gradient(180deg, #e50000 0%, #ff8d00 16%, #ffee00 33%, #028121 50%, #004cff 66%, #770088 84%, #770088 100%)"
             };
         case "bi":
-        default:
             return {
                 background: "linear-gradient(100deg, rgba(214, 2, 112, 0.26) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.22) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.26) 100%)",
                 bar: "linear-gradient(180deg, #d60270 0%, #bf2a83 30%, #9b4f96 50%, #68479f 72%, #0038a8 100%)"
+            };
+        case "none":
+        default:
+            return {
+                background: "none",
+                bar: "none"
             };
     }
 }
@@ -361,8 +366,29 @@ textarea:focus,
 `);
     }
 
-    if (settings.store.mentionReplyHighlight) {
-        const { background, bar } = getMentionGradients(settings.store.mentionReplyFlag as MentionFlagPreset);
+    const mentionReplyFlag = settings.store.mentionReplyFlag as MentionFlagPreset;
+
+    if (mentionReplyFlag === "disabled") {
+        css.push(`
+.mentioned__5126c,
+.replying__5126c,
+.mentioned__5126c:hover,
+.replying__5126c:hover,
+.mentioned__5126c.selected__5126c,
+.replying__5126c.selected__5126c {
+    background: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+}
+
+.mentioned__5126c::before,
+.replying__5126c::before {
+    background: transparent !important;
+    box-shadow: none !important;
+}
+`);
+    } else if (mentionReplyFlag !== "none") {
+        const { background, bar } = getMentionGradients(mentionReplyFlag);
         css.push(`
 .mentioned__5126c,
 .replying__5126c,
@@ -424,17 +450,13 @@ const settings = definePluginSettings({
         default: true,
         onChange: applyStyle
     },
-    mentionReplyHighlight: {
-        type: OptionType.BOOLEAN,
-        description: "Enable custom mention/reply background highlight",
-        default: true,
-        onChange: applyStyle
-    },
     mentionReplyFlag: {
         type: OptionType.SELECT,
-        description: "Pride flag gradient preset for mention/reply highlight",
+        description: "Pride flag gradient preset for mention/reply highlight.",
         options: [
-            { label: "Pride Rainbow", value: "rainbow", default: true },
+            { label: "None (default highlight)", value: "none", default: true },
+            { label: "Disabled (remove highlight)", value: "disabled" },
+            { label: "Pride Rainbow", value: "rainbow" },
             { label: "Bisexual", value: "bi" },
             { label: "Pansexual", value: "pan" },
             { label: "Lesbian", value: "lesbian" },

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -8,6 +8,23 @@ type MentionFlagPreset = "none" | "disabled" | "bi" | "pan" | "trans" | "lesbian
 
 let style: HTMLStyleElement | null = null;
 
+/**
+ * Geneate an equal CSS gradient based on the given colors
+ * @param colors The colors
+ */
+function generateEquivalentGradient(colors: string[]) {
+	let per = 100 / colors.length;
+	let curr = 0;
+	let str = "linear-gradient(180deg";
+
+	colors.forEach(color => {
+		str += ", " + color + " " + curr + "%";
+		curr += per;
+	});
+
+	return str;
+}
+
 function getMentionGradients(preset: MentionFlagPreset) {
 	switch (preset) {
 		case "pan":
@@ -50,7 +67,7 @@ function getMentionGradients(preset: MentionFlagPreset) {
 		case "femboy": {
 			return {
 				background: "linear-gradient(100deg, rgba(214, 2, 112, 0.26) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.22) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.26) 100%)",
-				bar: "linear-gradient(180deg, #d460a7 0%, #e4adcd 17%, #ffffff 34%, #57cef8 51%, #ffffff 68%, #e4adcd 85%, #d460a7 100%)"
+				bar: generateEquivalentGradient(["#d460a7", "#e4adcd", "#ffffff", "#57cef8", "#ffffff", "#e4adcd", "#d460a7"])
 			};
 		}
 

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -97,21 +97,6 @@ span#vc-friendcount {
 `);
     }
 
-    if (settings.store.roundAvatarsAndStatus) {
-        css.push(`
-/* Un-square avatars and online indicators */
-img.avatar_c19a55,
-img.avatar__44b0c,
-svg.svg__2338f > foreignObject > img,
-img.circularImage__1ce5d,
-svg.svg__2338f.mask_a423bd,
-div.wrapper__44b0c::after,
-div.container__1ce5d::after {
-    border-radius: 50% !important;
-}
-`);
-    }
-
     if (settings.store.smoothAnimations) {
         css.push(`
 :root {
@@ -445,12 +430,6 @@ const settings = definePluginSettings({
     scaleFriendCount: {
         type: OptionType.BOOLEAN,
         description: "Scale the online friend count label",
-        default: true,
-        onChange: applyStyle
-    },
-    roundAvatarsAndStatus: {
-        type: OptionType.BOOLEAN,
-        description: "Make avatars and status indicators circular",
         default: true,
         onChange: applyStyle
     },

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -1,64 +1,73 @@
 import { definePluginSettings } from "@api/Settings";
 import { managedStyleRootNode } from "@api/Styles";
+import { Devs } from "@utils/constants";
 import { createAndAppendStyle } from "@utils/css";
 import definePlugin, { OptionType } from "@utils/types";
-import { Devs } from "@utils/constants";
 
-type MentionFlagPreset = "none" | "disabled" | "bi" | "pan" | "trans" | "lesbian" | "nonbinary" | "asexual" | "rainbow";
+type MentionFlagPreset = "none" | "disabled" | "bi" | "pan" | "trans" | "lesbian" | "nonbinary" | "asexual" | "rainbow" | "femboy";
 
 let style: HTMLStyleElement | null = null;
 
 function getMentionGradients(preset: MentionFlagPreset) {
-    switch (preset) {
-        case "pan":
-            return {
-                background: "linear-gradient(100deg, rgba(255, 27, 141, 0.24) 0%, rgba(255, 27, 141, 0.24) 34%, rgba(255, 218, 0, 0.2) 50%, rgba(26, 179, 255, 0.24) 66%, rgba(26, 179, 255, 0.24) 100%)",
-                bar: "linear-gradient(180deg, #ff1b8d 0%, #ffda00 50%, #1ab3ff 100%)"
-            };
-        case "trans":
-            return {
-                background: "linear-gradient(100deg, rgba(91, 206, 250, 0.24) 0%, rgba(245, 169, 184, 0.2) 25%, rgba(255, 255, 255, 0.18) 50%, rgba(245, 169, 184, 0.2) 75%, rgba(91, 206, 250, 0.24) 100%)",
-                bar: "linear-gradient(180deg, #5bcefa 0%, #f5a9b8 25%, #ffffff 50%, #f5a9b8 75%, #5bcefa 100%)"
-            };
-        case "lesbian":
-            return {
-                background: "linear-gradient(100deg, rgba(213, 45, 0, 0.24) 0%, rgba(239, 118, 39, 0.22) 25%, rgba(255, 154, 86, 0.2) 42%, rgba(181, 86, 144, 0.2) 58%, rgba(163, 2, 98, 0.24) 78%, rgba(163, 2, 98, 0.24) 100%)",
-                bar: "linear-gradient(180deg, #d52d00 0%, #ef7627 25%, #ff9a56 42%, #d162a4 58%, #b55690 72%, #a30262 100%)"
-            };
-        case "nonbinary":
-            return {
-                background: "linear-gradient(100deg, rgba(252, 244, 52, 0.24) 0%, rgba(252, 244, 52, 0.24) 30%, rgba(252, 252, 252, 0.2) 50%, rgba(156, 89, 209, 0.22) 70%, rgba(45, 45, 45, 0.26) 100%)",
-                bar: "linear-gradient(180deg, #fcf434 0%, #fcfcfc 33%, #9c59d1 66%, #2d2d2d 100%)"
-            };
-        case "asexual":
-            return {
-                background: "linear-gradient(100deg, rgba(18, 18, 18, 0.26) 0%, rgba(163, 163, 163, 0.2) 35%, rgba(255, 255, 255, 0.18) 50%, rgba(128, 0, 128, 0.24) 75%, rgba(128, 0, 128, 0.24) 100%)",
-                bar: "linear-gradient(180deg, #121212 0%, #a3a3a3 33%, #ffffff 66%, #800080 100%)"
-            };
-        case "rainbow":
-            return {
-                background: "linear-gradient(100deg, rgba(229, 0, 0, 0.24) 0%, rgba(255, 141, 0, 0.22) 16%, rgba(255, 238, 0, 0.2) 33%, rgba(2, 129, 33, 0.2) 50%, rgba(0, 76, 255, 0.22) 66%, rgba(119, 0, 136, 0.24) 84%, rgba(119, 0, 136, 0.24) 100%)",
-                bar: "linear-gradient(180deg, #e50000 0%, #ff8d00 16%, #ffee00 33%, #028121 50%, #004cff 66%, #770088 84%, #770088 100%)"
-            };
-        case "bi":
-            return {
-                background: "linear-gradient(100deg, rgba(214, 2, 112, 0.26) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.22) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.26) 100%)",
-                bar: "linear-gradient(180deg, #d60270 0%, #bf2a83 30%, #9b4f96 50%, #68479f 72%, #0038a8 100%)"
-            };
-        case "none":
-        default:
-            return {
-                background: "none",
-                bar: "none"
-            };
-    }
+	switch (preset) {
+		case "pan":
+			return {
+				background: "linear-gradient(100deg, rgba(255, 27, 141, 0.24) 0%, rgba(255, 27, 141, 0.24) 34%, rgba(255, 218, 0, 0.2) 50%, rgba(26, 179, 255, 0.24) 66%, rgba(26, 179, 255, 0.24) 100%)",
+				bar: "linear-gradient(180deg, #ff1b8d 0%, #ffda00 50%, #1ab3ff 100%)"
+			};
+
+		case "trans":
+			return {
+				background: "linear-gradient(100deg, rgba(91, 206, 250, 0.24) 0%, rgba(245, 169, 184, 0.2) 25%, rgba(255, 255, 255, 0.18) 50%, rgba(245, 169, 184, 0.2) 75%, rgba(91, 206, 250, 0.24) 100%)",
+				bar: "linear-gradient(180deg, #5bcefa 0%, #f5a9b8 25%, #ffffff 50%, #f5a9b8 75%, #5bcefa 100%)"
+			};
+		case "lesbian":
+			return {
+				background: "linear-gradient(100deg, rgba(213, 45, 0, 0.24) 0%, rgba(239, 118, 39, 0.22) 25%, rgba(255, 154, 86, 0.2) 42%, rgba(181, 86, 144, 0.2) 58%, rgba(163, 2, 98, 0.24) 78%, rgba(163, 2, 98, 0.24) 100%)",
+				bar: "linear-gradient(180deg, #d52d00 0%, #ef7627 25%, #ff9a56 42%, #d162a4 58%, #b55690 72%, #a30262 100%)"
+			};
+		case "nonbinary":
+			return {
+				background: "linear-gradient(100deg, rgba(252, 244, 52, 0.24) 0%, rgba(252, 244, 52, 0.24) 30%, rgba(252, 252, 252, 0.2) 50%, rgba(156, 89, 209, 0.22) 70%, rgba(45, 45, 45, 0.26) 100%)",
+				bar: "linear-gradient(180deg, #fcf434 0%, #fcfcfc 33%, #9c59d1 66%, #2d2d2d 100%)"
+			};
+		case "asexual":
+			return {
+				background: "linear-gradient(100deg, rgba(18, 18, 18, 0.26) 0%, rgba(163, 163, 163, 0.2) 35%, rgba(255, 255, 255, 0.18) 50%, rgba(128, 0, 128, 0.24) 75%, rgba(128, 0, 128, 0.24) 100%)",
+				bar: "linear-gradient(180deg, #121212 0%, #a3a3a3 33%, #ffffff 66%, #800080 100%)"
+			};
+		case "rainbow":
+			return {
+				background: "linear-gradient(100deg, rgba(229, 0, 0, 0.24) 0%, rgba(255, 141, 0, 0.22) 16%, rgba(255, 238, 0, 0.2) 33%, rgba(2, 129, 33, 0.2) 50%, rgba(0, 76, 255, 0.22) 66%, rgba(119, 0, 136, 0.24) 84%, rgba(119, 0, 136, 0.24) 100%)",
+				bar: "linear-gradient(180deg, #e50000 0%, #ff8d00 16%, #ffee00 33%, #028121 50%, #004cff 66%, #770088 84%, #770088 100%)"
+			};
+		case "bi":
+			return {
+				background: "linear-gradient(100deg, rgba(214, 2, 112, 0.26) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.22) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.26) 100%)",
+				bar: "linear-gradient(180deg, #d60270 0%, #bf2a83 30%, #9b4f96 50%, #68479f 72%, #0038a8 100%)"
+			};
+
+		case "femboy": {
+			return {
+				background: "linear-gradient(100deg, rgba(214, 2, 112, 0.26) 0%, rgba(190, 42, 131, 0.24) 28%, rgba(155, 79, 150, 0.22) 50%, rgba(104, 71, 159, 0.24) 72%, rgba(0, 56, 168, 0.26) 100%)",
+				bar: "linear-gradient(180deg, #d460a7 0%, #e4adcd 17%, #ffffff 34%, #57cef8 51%, #ffffff 68%, #e4adcd 85%, #d460a7 100%)"
+			};
+		}
+
+		case "none":
+		default:
+			return {
+				background: "none",
+				bar: "none"
+			};
+	}
 }
 
 function buildCss() {
-    const css: string[] = [];
+	const css: string[] = [];
 
-    if (settings.store.hideAvatarDecorations) {
-        css.push(`
+	if (settings.store.hideAvatarDecorations) {
+		css.push(`
 /* Hide avatar decorations everywhere */
 [class="avatarDecoration"],
 [class*="avatarDecorationContainer"],
@@ -67,28 +76,28 @@ img[class*="avatarDecoration"] {
     display: none !important;
 }
 `);
-    }
+	}
 
-    if (settings.store.scaleReadAllButton) {
-        css.push(`
+	if (settings.store.scaleReadAllButton) {
+		css.push(`
 /* Fix display width of 'read all' button for notifications & unreads */
 button.vc-text-btn-base.vc-text-btn-secondary.vc-ranb-button {
     scale: 0.8;
 }
 `);
-    }
+	}
 
-    if (settings.store.scaleFriendCount) {
-        css.push(`
+	if (settings.store.scaleFriendCount) {
+		css.push(`
 /* Fix display width of online friend count */
 span#vc-friendcount {
     scale: 0.9;
 }
 `);
-    }
+	}
 
-    if (settings.store.roundAvatarsAndStatus) {
-        css.push(`
+	if (settings.store.roundAvatarsAndStatus) {
+		css.push(`
 /* Un-square avatars and online indicators */
 img.avatar_c19a55,
 img.avatar__44b0c,
@@ -100,10 +109,10 @@ div.container__1ce5d::after {
     border-radius: 50% !important;
 }
 `);
-    }
+	}
 
-    if (settings.store.smoothAnimations) {
-        css.push(`
+	if (settings.store.smoothAnimations) {
+		css.push(`
 :root {
     --tbz-ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
     --tbz-ease-soft: cubic-bezier(0.25, 0.8, 0.25, 1);
@@ -364,12 +373,12 @@ textarea:focus,
     }
 }
 `);
-    }
+	}
 
-    const mentionReplyFlag = settings.store.mentionReplyFlag as MentionFlagPreset;
+	const mentionReplyFlag = settings.store.mentionReplyFlag as MentionFlagPreset;
 
-    if (mentionReplyFlag === "disabled") {
-        css.push(`
+	if (mentionReplyFlag === "disabled") {
+		css.push(`
 .mentioned__5126c,
 .replying__5126c,
 .mentioned__5126c:hover,
@@ -387,9 +396,9 @@ textarea:focus,
     box-shadow: none !important;
 }
 `);
-    } else if (mentionReplyFlag !== "none") {
-        const { background, bar } = getMentionGradients(mentionReplyFlag);
-        css.push(`
+	} else if (mentionReplyFlag !== "none") {
+		const { background, bar } = getMentionGradients(mentionReplyFlag);
+		css.push(`
 .mentioned__5126c,
 .replying__5126c,
 .mentioned__5126c:hover,
@@ -404,80 +413,80 @@ textarea:focus,
     background: ${bar} !important;
 }
 `);
-    }
+	}
 
-    return css.join("\n");
+	return css.join("\n");
 }
 
 function applyStyle() {
-    const css = buildCss();
+	const css = buildCss();
 
-    if (!style) {
-        style = createAndAppendStyle("", managedStyleRootNode);
-    }
+	if (!style) {
+		style = createAndAppendStyle("", managedStyleRootNode);
+	}
 
-    style!.textContent = css;
+	style!.textContent = css;
 }
 
 const settings = definePluginSettings({
-    hideAvatarDecorations: {
-        type: OptionType.BOOLEAN,
-        description: "Hide avatar decorations everywhere",
-        default: true,
-        onChange: applyStyle
-    },
-    scaleReadAllButton: {
-        type: OptionType.BOOLEAN,
-        description: "Scale the Vencord Read All Notifications button",
-        default: true,
-        onChange: applyStyle
-    },
-    scaleFriendCount: {
-        type: OptionType.BOOLEAN,
-        description: "Scale the online friend count label",
-        default: true,
-        onChange: applyStyle
-    },
-    roundAvatarsAndStatus: {
-        type: OptionType.BOOLEAN,
-        description: "Make avatars and status indicators circular",
-        default: true,
-        onChange: applyStyle
-    },
-    smoothAnimations: {
-        type: OptionType.BOOLEAN,
-        description: "Enable broad smooth animations for Discord UI",
-        default: true,
-        onChange: applyStyle
-    },
-    mentionReplyFlag: {
-        type: OptionType.SELECT,
-        description: "Pride flag gradient preset for mention/reply highlight.",
-        options: [
-            { label: "None (default highlight)", value: "none", default: true },
-            { label: "Disabled (remove highlight)", value: "disabled" },
-            { label: "Pride Rainbow", value: "rainbow" },
-            { label: "Bisexual", value: "bi" },
-            { label: "Pansexual", value: "pan" },
-            { label: "Lesbian", value: "lesbian" },
-            { label: "Asexual", value: "asexual" },
-            { label: "Transgender", value: "trans" },
-            { label: "Non-binary", value: "nonbinary" }
-        ],
-        onChange: applyStyle
-    }
+	hideAvatarDecorations: {
+		type: OptionType.BOOLEAN,
+		description: "Hide avatar decorations everywhere",
+		default: true,
+		onChange: applyStyle
+	},
+	scaleReadAllButton: {
+		type: OptionType.BOOLEAN,
+		description: "Scale the Vencord Read All Notifications button",
+		default: true,
+		onChange: applyStyle
+	},
+	scaleFriendCount: {
+		type: OptionType.BOOLEAN,
+		description: "Scale the online friend count label",
+		default: true,
+		onChange: applyStyle
+	},
+	roundAvatarsAndStatus: {
+		type: OptionType.BOOLEAN,
+		description: "Make avatars and status indicators circular",
+		default: true,
+		onChange: applyStyle
+	},
+	smoothAnimations: {
+		type: OptionType.BOOLEAN,
+		description: "Enable broad smooth animations for Discord UI",
+		default: true,
+		onChange: applyStyle
+	},
+	mentionReplyFlag: {
+		type: OptionType.SELECT,
+		description: "Pride flag gradient preset for mention/reply highlight.",
+		options: [
+			{ label: "None (default highlight)", value: "none", default: true },
+			{ label: "Disabled (remove highlight)", value: "disabled" },
+			{ label: "Pride Rainbow", value: "rainbow" },
+			{ label: "Bisexual", value: "bi" },
+			{ label: "Pansexual", value: "pan" },
+			{ label: "Lesbian", value: "lesbian" },
+			{ label: "Asexual", value: "asexual" },
+			{ label: "Transgender", value: "trans" },
+			{ label: "Non-binary", value: "nonbinary" }
+		],
+		onChange: applyStyle
+	}
 });
 
 export default definePlugin({
-    name: "tobezdev's Tweaks",
-    description: "QoL client tweaks with various customisable settings.",
-    authors: [Devs.tobezdev],
-    settings,
-    start() {
-        applyStyle();
-    },
-    stop() {
-        style?.remove();
-        style = null;
-    }
+	name: "tobezdev's Tweaks",
+	description: "QoL client tweaks with various customisable settings.",
+	authors: [Devs.tobezdev],
+	settings,
+	start() {
+		applyStyle();
+	},
+	stop() {
+		style?.remove();
+		style = null;
+	}
 });

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -8,32 +8,6 @@ type MentionFlagPreset = "none" | "disabled" | "bi" | "pan" | "trans" | "lesbian
 
 let style: HTMLStyleElement | null = null;
 
-/**
- * Geneate an equal CSS gradient based on the given colors
- * @param colors The colors
- */
-function generateEquivalentGradient(colors) {
-	let per = Math.floor(100 / (colors.length - 1));
-	let bonus = 100 - (per * (colors.length - 1));
-	let curr = 0;
-	let str = "linear-gradient(180deg";
-
-	let ind = 0;
-	colors.forEach(color => {
-		let to_apply = curr;
-
-		if (ind == colors.length - 1) {
-			to_apply += bonus;
-		}
-
-		str += ", " + color + " " + to_apply + "%";
-		curr += per;
-
-		++ind;
-	});
-
-	return str;
-}
 
 function getMentionGradients(preset: MentionFlagPreset) {
 	switch (preset) {
@@ -91,10 +65,10 @@ function getMentionGradients(preset: MentionFlagPreset) {
 }
 
 function buildCss() {
-	const css: string[] = [];
+    const css: string[] = [];
 
-	if (settings.store.hideAvatarDecorations) {
-		css.push(`
+    if (settings.store.hideAvatarDecorations) {
+        css.push(`
 /* Hide avatar decorations everywhere */
 [class="avatarDecoration"],
 [class*="avatarDecorationContainer"],
@@ -103,28 +77,28 @@ img[class*="avatarDecoration"] {
     display: none !important;
 }
 `);
-	}
+    }
 
-	if (settings.store.scaleReadAllButton) {
-		css.push(`
+    if (settings.store.scaleReadAllButton) {
+        css.push(`
 /* Fix display width of 'read all' button for notifications & unreads */
 button.vc-text-btn-base.vc-text-btn-secondary.vc-ranb-button {
     scale: 0.8;
 }
 `);
-	}
+    }
 
-	if (settings.store.scaleFriendCount) {
-		css.push(`
+    if (settings.store.scaleFriendCount) {
+        css.push(`
 /* Fix display width of online friend count */
 span#vc-friendcount {
     scale: 0.9;
 }
 `);
-	}
+    }
 
-	if (settings.store.roundAvatarsAndStatus) {
-		css.push(`
+    if (settings.store.roundAvatarsAndStatus) {
+        css.push(`
 /* Un-square avatars and online indicators */
 img.avatar_c19a55,
 img.avatar__44b0c,
@@ -136,10 +110,10 @@ div.container__1ce5d::after {
     border-radius: 50% !important;
 }
 `);
-	}
+    }
 
-	if (settings.store.smoothAnimations) {
-		css.push(`
+    if (settings.store.smoothAnimations) {
+        css.push(`
 :root {
     --tbz-ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
     --tbz-ease-soft: cubic-bezier(0.25, 0.8, 0.25, 1);
@@ -400,12 +374,12 @@ textarea:focus,
     }
 }
 `);
-	}
+    }
 
-	const mentionReplyFlag = settings.store.mentionReplyFlag as MentionFlagPreset;
+    const mentionReplyFlag = settings.store.mentionReplyFlag as MentionFlagPreset;
 
-	if (mentionReplyFlag === "disabled") {
-		css.push(`
+    if (mentionReplyFlag === "disabled") {
+        css.push(`
 .mentioned__5126c,
 .replying__5126c,
 .mentioned__5126c:hover,
@@ -423,9 +397,9 @@ textarea:focus,
     box-shadow: none !important;
 }
 `);
-	} else if (mentionReplyFlag !== "none") {
-		const { background, bar } = getMentionGradients(mentionReplyFlag);
-		css.push(`
+    } else if (mentionReplyFlag !== "none") {
+        const { background, bar } = getMentionGradients(mentionReplyFlag);
+        css.push(`
 .mentioned__5126c,
 .replying__5126c,
 .mentioned__5126c:hover,
@@ -440,80 +414,81 @@ textarea:focus,
     background: ${bar} !important;
 }
 `);
-	}
+    }
 
-	return css.join("\n");
+    return css.join("\n");
 }
 
 function applyStyle() {
-	const css = buildCss();
+    const css = buildCss();
 
-	if (!style) {
-		style = createAndAppendStyle("", managedStyleRootNode);
-	}
+    if (!style) {
+        style = createAndAppendStyle("", managedStyleRootNode);
+    }
 
-	style!.textContent = css;
+    style!.textContent = css;
 }
 
 const settings = definePluginSettings({
-	hideAvatarDecorations: {
-		type: OptionType.BOOLEAN,
-		description: "Hide avatar decorations everywhere",
-		default: true,
-		onChange: applyStyle
-	},
-	scaleReadAllButton: {
-		type: OptionType.BOOLEAN,
-		description: "Scale the Vencord Read All Notifications button",
-		default: true,
-		onChange: applyStyle
-	},
-	scaleFriendCount: {
-		type: OptionType.BOOLEAN,
-		description: "Scale the online friend count label",
-		default: true,
-		onChange: applyStyle
-	},
-	roundAvatarsAndStatus: {
-		type: OptionType.BOOLEAN,
-		description: "Make avatars and status indicators circular",
-		default: true,
-		onChange: applyStyle
-	},
-	smoothAnimations: {
-		type: OptionType.BOOLEAN,
-		description: "Enable broad smooth animations for Discord UI",
-		default: true,
-		onChange: applyStyle
-	},
-	mentionReplyFlag: {
-		type: OptionType.SELECT,
-		description: "Pride flag gradient preset for mention/reply highlight.",
-		options: [
-			{ label: "None (default highlight)", value: "none", default: true },
-			{ label: "Disabled (remove highlight)", value: "disabled" },
-			{ label: "Pride Rainbow", value: "rainbow" },
-			{ label: "Bisexual", value: "bi" },
-			{ label: "Pansexual", value: "pan" },
-			{ label: "Lesbian", value: "lesbian" },
-			{ label: "Asexual", value: "asexual" },
-			{ label: "Transgender", value: "trans" },
-			{ label: "Non-binary", value: "nonbinary" }
-		],
-		onChange: applyStyle
-	}
+    hideAvatarDecorations: {
+        type: OptionType.BOOLEAN,
+        description: "Hide avatar decorations everywhere",
+        default: true,
+        onChange: applyStyle
+    },
+    scaleReadAllButton: {
+        type: OptionType.BOOLEAN,
+        description: "Scale the Vencord Read All Notifications button",
+        default: true,
+        onChange: applyStyle
+    },
+    scaleFriendCount: {
+        type: OptionType.BOOLEAN,
+        description: "Scale the online friend count label",
+        default: true,
+        onChange: applyStyle
+    },
+    roundAvatarsAndStatus: {
+        type: OptionType.BOOLEAN,
+        description: "Make avatars and status indicators circular",
+        default: true,
+        onChange: applyStyle
+    },
+    smoothAnimations: {
+        type: OptionType.BOOLEAN,
+        description: "Enable broad smooth animations for Discord UI",
+        default: true,
+        onChange: applyStyle
+    },
+    mentionReplyFlag: {
+        type: OptionType.SELECT,
+        description: "Pride flag gradient preset for mention/reply highlight.",
+        options: [
+            { label: "None (default highlight)", value: "none", default: true },
+            { label: "Disabled (remove highlight)", value: "disabled" },
+            { label: "Pride Rainbow", value: "rainbow" },
+            { label: "Bisexual", value: "bi" },
+            { label: "Pansexual", value: "pan" },
+            { label: "Lesbian", value: "lesbian" },
+            { label: "Asexual", value: "asexual" },
+            { label: "Transgender", value: "trans" },
+            { label: "Non-binary", value: "nonbinary" },
+            { label: "Femboy", value: "femboy" }
+        ],
+        onChange: applyStyle
+    }
 });
 
 export default definePlugin({
-	name: "tobezdev's Tweaks",
-	description: "QoL client tweaks with various customisable settings.",
-	authors: [Devs.tobezdev],
-	settings,
-	start() {
-		applyStyle();
-	},
-	stop() {
-		style?.remove();
-		style = null;
-	}
+    name: "tobezdev's Tweaks",
+    description: "QoL client tweaks with various customisable settings.",
+    authors: [Devs.tobezdev],
+    settings,
+    start() {
+        applyStyle();
+    },
+    stop() {
+        style?.remove();
+        style = null;
+    }
 });

--- a/src/plugins/tobezdevsTweaks/index.ts
+++ b/src/plugins/tobezdevsTweaks/index.ts
@@ -4,6 +4,15 @@ import { Devs } from "@utils/constants";
 import { createAndAppendStyle } from "@utils/css";
 import definePlugin, { OptionType } from "@utils/types";
 
+import {
+    buildMentionReplyFlag,
+    HIDE_AVATAR_DECORATIONS,
+    MENTION_REPLY_DISABLED,
+    SCALE_FRIEND_COUNT,
+    SCALE_READ_ALL_BUTTON,
+    SMOOTH_ANIMATIONS
+} from "./styleSnippets";
+
 type MentionFlagPreset = "none" | "disabled" | "bi" | "pan" | "trans" | "lesbian" | "nonbinary" | "asexual" | "rainbow" | "femboy";
 
 let style: HTMLStyleElement | null = null;
@@ -68,337 +77,28 @@ function buildCss() {
     const css: string[] = [];
 
     if (settings.store.hideAvatarDecorations) {
-        css.push(`
-/* Hide avatar decorations everywhere */
-[class="avatarDecoration"],
-[class*="avatarDecorationContainer"],
-svg[class="avatarDecoration"],
-img[class*="avatarDecoration"] {
-    display: none !important;
-}
-`);
+        css.push(HIDE_AVATAR_DECORATIONS);
     }
 
     if (settings.store.scaleReadAllButton) {
-        css.push(`
-/* Fix display width of 'read all' button for notifications & unreads */
-button.vc-text-btn-base.vc-text-btn-secondary.vc-ranb-button {
-    scale: 0.8;
-}
-`);
+        css.push(SCALE_READ_ALL_BUTTON);
     }
 
     if (settings.store.scaleFriendCount) {
-        css.push(`
-/* Fix display width of online friend count */
-span#vc-friendcount {
-    scale: 0.9;
-}
-`);
+        css.push(SCALE_FRIEND_COUNT);
     }
 
     if (settings.store.smoothAnimations) {
-        css.push(`
-:root {
-    --tbz-ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
-    --tbz-ease-soft: cubic-bezier(0.25, 0.8, 0.25, 1);
-    --tbz-dur-fast: 120ms;
-    --tbz-dur-mid: 180ms;
-    --tbz-dur-slow: 260ms;
-    --tbz-scale-press: 0.98;
-    --tbz-scale-hover: 1.015;
-}
-
-@keyframes tbz-fade-in-up {
-    from {
-        opacity: 0;
-        transform: translateY(8px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes tbz-fade-in {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-@keyframes tbz-pop-in {
-    0% {
-        opacity: 0;
-        transform: scale(0.97);
-    }
-    100% {
-        opacity: 1;
-        transform: scale(1);
-    }
-}
-
-@keyframes tbz-highlight-pulse {
-    0% {
-        box-shadow: 0 0 0 0 rgba(88, 101, 242, 0.35);
-    }
-    100% {
-        box-shadow: 0 0 0 10px rgba(88, 101, 242, 0);
-    }
-}
-
-button,
-a,
-[role="button"],
-[role="tab"],
-[role="menuitem"],
-input,
-textarea,
-select,
-.clickable__972a0,
-.button__201d5,
-.item__48dda,
-.containerDefault__29444,
-.interactive__972a0,
-.channel__972a0,
-.membersWrap_c8ffbb,
-.member__5d473,
-.message_d5deea,
-.listItem__650eb,
-.wrapper__6e9f8,
-.panels_c48ade,
-.sidebarList_c48ade,
-.chatContent_a7d72e,
-.searchBar__35e86,
-.search__49676,
-.bar_c38106,
-.tabBar__133bf,
-.tabBar_d6f9e9,
-.base_c48ade,
-.contentRegionScroller__23e6b,
-.container__133bf,
-.standardSidebarView__23e6b,
-.menu_c1e9c4,
-.root__49fc1,
-.layer_da8173,
-.backdrop__78332,
-.autocomplete__13533,
-.messagesWrapper__36d07,
-.scroller__36d07,
-.scroller_c47fa9,
-.peopleListItem_cc6179,
-.container_c2739c,
-.cardPrimary__73069,
-.card__73069,
-.visual-refresh {
-    transition:
-        transform var(--tbz-dur-mid) var(--tbz-ease-standard),
-        opacity var(--tbz-dur-mid) var(--tbz-ease-soft),
-        background-color var(--tbz-dur-mid) var(--tbz-ease-soft),
-        color var(--tbz-dur-fast) var(--tbz-ease-soft),
-        border-color var(--tbz-dur-mid) var(--tbz-ease-soft),
-        box-shadow var(--tbz-dur-mid) var(--tbz-ease-soft),
-        filter var(--tbz-dur-mid) var(--tbz-ease-soft) !important;
-    will-change: transform, opacity;
-}
-
-button:hover,
-[role="button"]:hover,
-[role="tab"]:hover,
-[role="menuitem"]:hover,
-.clickable__972a0:hover,
-.button__201d5:hover,
-.interactive__972a0:hover,
-.channel__972a0:hover,
-.listItem__650eb:hover,
-.peopleListItem_cc6179:hover,
-.member__5d473:hover {
-    transform: translateY(-1px) scale(var(--tbz-scale-hover));
-}
-
-button:active,
-[role="button"]:active,
-[role="tab"]:active,
-[role="menuitem"]:active,
-.clickable__972a0:active,
-.button__201d5:active,
-.interactive__972a0:active,
-.channel__972a0:active,
-.listItem__650eb:active,
-.peopleListItem_cc6179:active,
-.member__5d473:active {
-    transform: scale(var(--tbz-scale-press));
-    transition-duration: var(--tbz-dur-fast) !important;
-}
-
-.listItem__650eb,
-.containerDefault__29444,
-.member__5d473,
-.peopleListItem_cc6179,
-.privateChannels__35e86 .channel__972a0 {
-    animation: tbz-fade-in-up var(--tbz-dur-slow) var(--tbz-ease-standard);
-}
-
-.message_d5deea,
-.cozy_f5c119.wrapper_c19a55,
-.compact_f5c119.wrapper_c19a55,
-.groupStart__5126c,
-.newMessagesBar__0f481 {
-    animation: tbz-fade-in-up var(--tbz-dur-mid) var(--tbz-ease-standard);
-}
-
-.sidebarList_c48ade,
-.chatContent_a7d72e,
-.contentRegionScroller__23e6b,
-.messagesWrapper__36d07,
-.scroller__36d07,
-.standardSidebarView__23e6b,
-.base_c48ade {
-    animation: tbz-fade-in var(--tbz-dur-slow) var(--tbz-ease-soft);
-}
-
-.menu_c1e9c4,
-.layer_da8173,
-[class*="popout"],
-[class*="Popout"],
-[class*="modal"],
-[class*="Modal"],
-[class*="picker"],
-[class*="Picker"],
-[class*="autocomplete"],
-[class*="Autocomplete"] {
-    transform-origin: top center;
-    animation: tbz-pop-in var(--tbz-dur-mid) var(--tbz-ease-standard);
-}
-
-.root__49fc1,
-.backdrop__78332,
-[class*="backdrop"],
-[class*="BackDrop"] {
-    animation: tbz-fade-in var(--tbz-dur-mid) var(--tbz-ease-soft);
-}
-
-.tabBar__133bf .item__133bf,
-.topPill_b3f026 .item_b3f026,
-.tabBar_d6f9e9 .item_d6f9e9 {
-    position: relative;
-    overflow: hidden;
-}
-
-.tabBar__133bf .item__133bf::after,
-.topPill_b3f026 .item_b3f026::after,
-.tabBar_d6f9e9 .item_d6f9e9::after {
-    content: "";
-    position: absolute;
-    left: 8px;
-    right: 8px;
-    bottom: 4px;
-    height: 2px;
-    transform: scaleX(0);
-    transform-origin: center;
-    background: currentColor;
-    opacity: 0.65;
-    transition: transform var(--tbz-dur-mid) var(--tbz-ease-standard);
-}
-
-.tabBar__133bf .item__133bf[aria-selected="true"]::after,
-.topPill_b3f026 .item_b3f026[aria-selected="true"]::after,
-.tabBar_d6f9e9 .item_d6f9e9[aria-selected="true"]::after {
-    transform: scaleX(1);
-}
-
-.button__201d5:is(.lookFilled__201d5, .colorBrand__201d5):hover,
-.mentioned__5126c,
-.replying__5126c {
-    animation: tbz-highlight-pulse 650ms var(--tbz-ease-soft) 1;
-}
-
-[class*="toast"],
-[class*="notice"],
-.bar_c38106,
-.newMessagesBar__0f481,
-.jumpToPresentBar__0f481 {
-    animation: tbz-fade-in-up var(--tbz-dur-mid) var(--tbz-ease-standard);
-}
-
-input:focus,
-textarea:focus,
-.searchBar__35e86:focus-within,
-.search__49676:focus-within,
-.channelTextArea__74017:focus-within {
-    transform: translateY(-1px);
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.16);
-}
-
-[class*="typing"],
-[class*="status"],
-[class*="badge"],
-.numberBadge__2b1f5 {
-    transition:
-        transform var(--tbz-dur-mid) var(--tbz-ease-standard),
-        opacity var(--tbz-dur-mid) var(--tbz-ease-soft) !important;
-}
-
-[class*="typing"]:hover,
-[class*="status"]:hover,
-[class*="badge"]:hover,
-.numberBadge__2b1f5:hover {
-    transform: scale(1.04);
-}
-
-@media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-        animation-duration: 1ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 1ms !important;
-        scroll-behavior: auto !important;
-    }
-}
-`);
+        css.push(SMOOTH_ANIMATIONS);
     }
 
     const mentionReplyFlag = settings.store.mentionReplyFlag as MentionFlagPreset;
 
     if (mentionReplyFlag === "disabled") {
-        css.push(`
-.mentioned__5126c,
-.replying__5126c,
-.mentioned__5126c:hover,
-.replying__5126c:hover,
-.mentioned__5126c.selected__5126c,
-.replying__5126c.selected__5126c {
-    background: transparent !important;
-    background-image: none !important;
-    box-shadow: none !important;
-}
-
-.mentioned__5126c::before,
-.replying__5126c::before {
-    background: transparent !important;
-    box-shadow: none !important;
-}
-`);
+        css.push(MENTION_REPLY_DISABLED);
     } else if (mentionReplyFlag !== "none") {
         const { background, bar } = getMentionGradients(mentionReplyFlag);
-        css.push(`
-.mentioned__5126c,
-.replying__5126c,
-.mentioned__5126c:hover,
-.replying__5126c:hover,
-.mentioned__5126c.selected__5126c,
-.replying__5126c.selected__5126c {
-    background: ${background} !important;
-}
-
-.mentioned__5126c::before,
-.replying__5126c::before {
-    background: ${bar} !important;
-}
-`);
+        css.push(buildMentionReplyFlag(background, bar));
     }
 
     return css.join("\n");

--- a/src/plugins/tobezdevsTweaks/styleSnippets.ts
+++ b/src/plugins/tobezdevsTweaks/styleSnippets.ts
@@ -1,0 +1,320 @@
+export const HIDE_AVATAR_DECORATIONS = `
+/* Hide avatar decorations everywhere */
+[class="avatarDecoration"],
+[class*="avatarDecorationContainer"],
+svg[class="avatarDecoration"],
+img[class*="avatarDecoration"] {
+    display: none !important;
+}
+`;
+
+export const SCALE_READ_ALL_BUTTON = `
+/* Fix display width of 'read all' button for notifications & unreads */
+button.vc-text-btn-base.vc-text-btn-secondary.vc-ranb-button {
+    scale: 0.8;
+}
+`;
+
+export const SCALE_FRIEND_COUNT = `
+/* Fix display width of online friend count */
+span#vc-friendcount {
+    scale: 0.9;
+}
+`;
+
+export const SMOOTH_ANIMATIONS = `
+:root {
+    --tbz-ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+    --tbz-ease-soft: cubic-bezier(0.25, 0.8, 0.25, 1);
+    --tbz-dur-fast: 120ms;
+    --tbz-dur-mid: 180ms;
+    --tbz-dur-slow: 260ms;
+    --tbz-scale-press: 0.98;
+    --tbz-scale-hover: 1.015;
+}
+
+@keyframes tbz-fade-in-up {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes tbz-fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes tbz-pop-in {
+    0% {
+        opacity: 0;
+        transform: scale(0.97);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+@keyframes tbz-highlight-pulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(88, 101, 242, 0.35);
+    }
+    100% {
+        box-shadow: 0 0 0 10px rgba(88, 101, 242, 0);
+    }
+}
+
+button,
+a,
+[role="button"],
+[role="tab"],
+[role="menuitem"],
+input,
+textarea,
+select,
+.clickable__972a0,
+.button__201d5,
+.item__48dda,
+.containerDefault__29444,
+.interactive__972a0,
+.channel__972a0,
+.membersWrap_c8ffbb,
+.member__5d473,
+.message_d5deea,
+.listItem__650eb,
+.wrapper__6e9f8,
+.panels_c48ade,
+.sidebarList_c48ade,
+.chatContent_a7d72e,
+.searchBar__35e86,
+.search__49676,
+.bar_c38106,
+.tabBar__133bf,
+.tabBar_d6f9e9,
+.base_c48ade,
+.contentRegionScroller__23e6b,
+.container__133bf,
+.standardSidebarView__23e6b,
+.menu_c1e9c4,
+.root__49fc1,
+.layer_da8173,
+.backdrop__78332,
+.autocomplete__13533,
+.messagesWrapper__36d07,
+.scroller__36d07,
+.scroller_c47fa9,
+.peopleListItem_cc6179,
+.container_c2739c,
+.cardPrimary__73069,
+.card__73069,
+.visual-refresh {
+    transition:
+        transform var(--tbz-dur-mid) var(--tbz-ease-standard),
+        opacity var(--tbz-dur-mid) var(--tbz-ease-soft),
+        background-color var(--tbz-dur-mid) var(--tbz-ease-soft),
+        color var(--tbz-dur-fast) var(--tbz-ease-soft),
+        border-color var(--tbz-dur-mid) var(--tbz-ease-soft),
+        box-shadow var(--tbz-dur-mid) var(--tbz-ease-soft),
+        filter var(--tbz-dur-mid) var(--tbz-ease-soft) !important;
+    will-change: transform, opacity;
+}
+
+button:hover,
+[role="button"]:hover,
+[role="tab"]:hover,
+[role="menuitem"]:hover,
+.clickable__972a0:hover,
+.button__201d5:hover,
+.interactive__972a0:hover,
+.channel__972a0:hover,
+.listItem__650eb:hover,
+.peopleListItem_cc6179:hover,
+.member__5d473:hover {
+    transform: translateY(-1px) scale(var(--tbz-scale-hover));
+}
+
+button:active,
+[role="button"]:active,
+[role="tab"]:active,
+[role="menuitem"]:active,
+.clickable__972a0:active,
+.button__201d5:active,
+.interactive__972a0:active,
+.channel__972a0:active,
+.listItem__650eb:active,
+.peopleListItem_cc6179:active,
+.member__5d473:active {
+    transform: scale(var(--tbz-scale-press));
+    transition-duration: var(--tbz-dur-fast) !important;
+}
+
+.listItem__650eb,
+.containerDefault__29444,
+.member__5d473,
+.peopleListItem_cc6179,
+.privateChannels__35e86 .channel__972a0 {
+    animation: tbz-fade-in-up var(--tbz-dur-slow) var(--tbz-ease-standard);
+}
+
+.message_d5deea,
+.cozy_f5c119.wrapper_c19a55,
+.compact_f5c119.wrapper_c19a55,
+.groupStart__5126c,
+.newMessagesBar__0f481 {
+    animation: tbz-fade-in-up var(--tbz-dur-mid) var(--tbz-ease-standard);
+}
+
+.sidebarList_c48ade,
+.chatContent_a7d72e,
+.contentRegionScroller__23e6b,
+.messagesWrapper__36d07,
+.scroller__36d07,
+.standardSidebarView__23e6b,
+.base_c48ade {
+    animation: tbz-fade-in var(--tbz-dur-slow) var(--tbz-ease-soft);
+}
+
+.menu_c1e9c4,
+.layer_da8173,
+[class*="popout"],
+[class*="Popout"],
+[class*="modal"],
+[class*="Modal"],
+[class*="picker"],
+[class*="Picker"],
+[class*="autocomplete"],
+[class*="Autocomplete"] {
+    transform-origin: top center;
+    animation: tbz-pop-in var(--tbz-dur-mid) var(--tbz-ease-standard);
+}
+
+.root__49fc1,
+.backdrop__78332,
+[class*="backdrop"],
+[class*="BackDrop"] {
+    animation: tbz-fade-in var(--tbz-dur-mid) var(--tbz-ease-soft);
+}
+
+.tabBar__133bf .item__133bf,
+.topPill_b3f026 .item_b3f026,
+.tabBar_d6f9e9 .item_d6f9e9 {
+    position: relative;
+    overflow: hidden;
+}
+
+.tabBar__133bf .item__133bf::after,
+.topPill_b3f026 .item_b3f026::after,
+.tabBar_d6f9e9 .item_d6f9e9::after {
+    content: "";
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    bottom: 4px;
+    height: 2px;
+    transform: scaleX(0);
+    transform-origin: center;
+    background: currentColor;
+    opacity: 0.65;
+    transition: transform var(--tbz-dur-mid) var(--tbz-ease-standard);
+}
+
+.tabBar__133bf .item__133bf[aria-selected="true"]::after,
+.topPill_b3f026 .item_b3f026[aria-selected="true"]::after,
+.tabBar_d6f9e9 .item_d6f9e9[aria-selected="true"]::after {
+    transform: scaleX(1);
+}
+
+.button__201d5:is(.lookFilled__201d5, .colorBrand__201d5):hover,
+.mentioned__5126c,
+.replying__5126c {
+    animation: tbz-highlight-pulse 650ms var(--tbz-ease-soft) 1;
+}
+
+[class*="toast"],
+[class*="notice"],
+.bar_c38106,
+.newMessagesBar__0f481,
+.jumpToPresentBar__0f481 {
+    animation: tbz-fade-in-up var(--tbz-dur-mid) var(--tbz-ease-standard);
+}
+
+input:focus,
+textarea:focus,
+.searchBar__35e86:focus-within,
+.search__49676:focus-within,
+.channelTextArea__74017:focus-within {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.16);
+}
+
+[class*="typing"],
+[class*="status"],
+[class*="badge"],
+.numberBadge__2b1f5 {
+    transition:
+        transform var(--tbz-dur-mid) var(--tbz-ease-standard),
+        opacity var(--tbz-dur-mid) var(--tbz-ease-soft) !important;
+}
+
+[class*="typing"]:hover,
+[class*="status"]:hover,
+[class*="badge"]:hover,
+.numberBadge__2b1f5:hover {
+    transform: scale(1.04);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 1ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 1ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+`;
+
+export const MENTION_REPLY_DISABLED = `
+.mentioned__5126c,
+.replying__5126c,
+.mentioned__5126c:hover,
+.replying__5126c:hover,
+.mentioned__5126c.selected__5126c,
+.replying__5126c.selected__5126c {
+    background: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+}
+
+.mentioned__5126c::before,
+.replying__5126c::before {
+    background: transparent !important;
+    box-shadow: none !important;
+}
+`;
+
+export const buildMentionReplyFlag = (background: string, bar: string) => `
+.mentioned__5126c,
+.replying__5126c,
+.mentioned__5126c:hover,
+.replying__5126c:hover,
+.mentioned__5126c.selected__5126c,
+.replying__5126c.selected__5126c {
+    background: ${background} !important;
+}
+
+.mentioned__5126c::before,
+.replying__5126c::before {
+    background: ${bar} !important;
+}
+`;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    tobezdev: {
+        name: "tobezdev",
+        id: 969254887621820526n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -645,7 +645,7 @@ export const Devs = /* #__PURE__*/ Object.freeze({
 	zffutwo: {
 		name: "zffutwo",
 		id: 1392866325755334739n
-	},
+	}
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -35,9 +35,9 @@ export const IS_LINUX = platform.startsWith("linux");
 export const IS_MOBILE = navigator.userAgent.includes("Mobi");
 
 export interface Dev {
-    name: string;
-    id: bigint;
-    badge?: boolean;
+	name: string;
+	id: bigint;
+	badge?: boolean;
 }
 
 /**
@@ -47,608 +47,612 @@ export interface Dev {
  * If you are fine with attribution but don't want the badge, add badge: false
  */
 export const Devs = /* #__PURE__*/ Object.freeze({
-    Ven: {
-        name: "V",
-        id: 343383572805058560n
-    },
-    Apexo: {
-        name: "Apexo",
-        id: 228548952687902720n
-    },
-    Arjix: {
-        name: "ArjixWasTaken",
-        id: 674710789138939916n,
-        badge: false
-    },
-    Cyn: {
-        name: "Cynosphere",
-        id: 150745989836308480n
-    },
-    Trwy: {
-        name: "trey",
-        id: 354427199023218689n
-    },
-    Megu: {
-        name: "Megumin",
-        id: 545581357812678656n
-    },
-    botato: {
-        name: "botato",
-        id: 440990343899643943n
-    },
-    fawn: {
-        name: "fawn",
-        id: 336678828233588736n,
-    },
-    rushii: {
-        name: "rushii",
-        id: 295190422244950017n
-    },
-    Glitch: {
-        name: "Glitchy",
-        id: 269567451199569920n
-    },
-    Samu: {
-        name: "Samu",
-        id: 702973430449832038n,
-    },
-    Nyako: {
-        name: "nyako",
-        id: 118437263754395652n
-    },
-    MaiKokain: {
-        name: "Mai",
-        id: 722647978577363026n
-    },
-    amy: {
-        name: "Amy",
-        id: 603229858612510720n
-    },
-    katlyn: {
-        name: "katlyn",
-        id: 250322741406859265n
-    },
-    nea: {
-        name: "nea",
-        id: 310702108997320705n,
-    },
-    Nuckyz: {
-        name: "Nuckyz",
-        id: 235834946571337729n
-    },
-    D3SOX: {
-        name: "D3SOX",
-        id: 201052085641281538n
-    },
-    Nickyux: {
-        name: "Nickyux",
-        id: 427146305651998721n
-    },
-    mantikafasi: {
-        name: "mantikafasi",
-        id: 287555395151593473n
-    },
-    Xinto: {
-        name: "Xinto",
-        id: 423915768191647755n
-    },
-    JacobTm: {
-        name: "Jacob.Tm",
-        id: 302872992097107991n
-    },
-    DustyAngel47: {
-        name: "DustyAngel47",
-        id: 714583473804935238n
-    },
-    BanTheNons: {
-        name: "BanTheNons",
-        id: 460478012794863637n
-    },
-    BigDuck: {
-        name: "BigDuck",
-        id: 1024588272623681609n
-    },
-    AverageReactEnjoyer: {
-        name: "Average React Enjoyer",
-        id: 1004904120056029256n
-    },
-    adryd: {
-        name: "adryd",
-        id: 0n
-    },
-    Tyman: {
-        name: "Tyman",
-        id: 487443883127472129n
-    },
-    afn: {
-        name: "afn",
-        id: 420043923822608384n
-    },
-    KraXen72: {
-        name: "KraXen72",
-        id: 379304073515499530n
-    },
-    kemo: {
-        name: "kemo",
-        id: 715746190813298788n
-    },
-    dzshn: {
-        name: "dzshn",
-        id: 310449948011528192n
-    },
-    Ducko: {
-        name: "Ducko",
-        id: 506482395269169153n
-    },
-    jewdev: {
-        name: "jewdev",
-        id: 222369866529636353n
-    },
-    Luna: {
-        name: "Luny",
-        id: 821472922140803112n
-    },
-    Vap: {
-        name: "Vap0r1ze",
-        id: 454072114492866560n
-    },
-    KingFish: {
-        name: "King Fish",
-        id: 499400512559382538n
-    },
-    Commandtechno: {
-        name: "Commandtechno",
-        id: 296776625432035328n,
-    },
-    TheSun: {
-        name: "sunnie",
-        id: 406028027768733696n
-    },
-    rae: {
-        name: "rae",
-        id: 1398136199503282277n
-    },
-    pointy: {
-        name: "pointy",
-        id: 99914384989519872n
-    },
-    SammCheese: {
-        name: "Samm-Cheese",
-        id: 372148345894076416n
-    },
-    zt: {
-        name: "zt",
-        id: 289556910426816513n
-    },
-    captain: {
-        name: "Captain",
-        id: 347366054806159360n
-    },
-    nick: {
-        name: "nick",
-        id: 347884694408265729n,
-        badge: false
-    },
-    whqwert: {
-        name: "whqwert",
-        id: 586239091520176128n
-    },
-    lewisakura: {
-        name: "lewisakura",
-        id: 96269247411400704n
-    },
-    RuiNtD: {
-        name: "RuiNtD",
-        id: 157917665162297344n
-    },
-    hunt: {
-        name: "hunt-g",
-        id: 222800179697287168n
-    },
-    cloudburst: {
-        name: "cloudburst",
-        id: 892128204150685769n
-    },
-    Aria: {
-        name: "Syncxv",
-        id: 549244932213309442n,
-    },
-    TheKodeToad: {
-        name: "TheKodeToad",
-        id: 706152404072267788n
-    },
-    LordElias: {
-        name: "LordElias",
-        id: 319460781567639554n
-    },
-    juby: {
-        name: "Juby210",
-        id: 324622488644616195n
-    },
-    Alyxia: {
-        name: "Alyxia Sother",
-        id: 952185386350829688n
-    },
-    Remty: {
-        name: "Remty",
-        id: 335055032204656642n
-    },
-    skyevg: {
-        name: "skyevg",
-        id: 1090310844283363348n
-    },
-    Dziurwa: {
-        name: "Dziurwa",
-        id: 1001086404203389018n
-    },
-    arHSM: {
-        name: "arHSM",
-        id: 841509053422632990n
-    },
-    AutumnVN: {
-        name: "AutumnVN",
-        id: 393694671383166998n
-    },
-    pylix: {
-        name: "pylix",
-        id: 492949202121261067n
-    },
-    Tyler: {
-        name: "\\\\GGTyler\\\\",
-        id: 143117463788191746n
-    },
-    RyanCaoDev: {
-        name: "RyanCaoDev",
-        id: 952235800110694471n,
-    },
-    FieryFlames: {
-        name: "Fiery",
-        id: 890228870559698955n
-    },
-    KannaDev: {
-        name: "Kanna",
-        id: 317728561106518019n
-    },
-    carince: {
-        name: "carince",
-        id: 818323528755314698n
-    },
-    PandaNinjas: {
-        name: "PandaNinjas",
-        id: 455128749071925248n
-    },
-    CatNoir: {
-        name: "CatNoir",
-        id: 260371016348336128n
-    },
-    outfoxxed: {
-        name: "outfoxxed",
-        id: 837425748435796060n
-    },
-    UwUDev: {
-        name: "UwU",
-        id: 691413039156690994n,
-    },
-    amia: {
-        name: "amia",
-        id: 142007603549962240n
-    },
-    phil: {
-        name: "phil",
-        id: 305288513941667851n
-    },
-    ImLvna: {
-        name: "lillith <3",
-        id: 799319081723232267n
-    },
-    rad: {
-        name: "rad",
-        id: 610945092504780823n
-    },
-    AndrewDLO: {
-        name: "Andrew-DLO",
-        id: 434135504792059917n
-    },
-    HypedDomi: {
-        name: "HypedDomi",
-        id: 354191516979429376n
-    },
-    Rini: {
-        name: "Rini",
-        id: 1079479184478441643n
-    },
-    castdrian: {
-        name: "castdrian",
-        id: 224617799434108928n
-    },
-    Arrow: {
-        name: "arrow",
-        id: 958158495302176778n
-    },
-    bb010g: {
-        name: "bb010g",
-        id: 72791153467990016n,
-    },
-    Dolfies: {
-        name: "Dolfies",
-        id: 852892297661906993n,
-    },
-    RuukuLada: {
-        name: "RuukuLada",
-        id: 119705748346241027n,
-    },
-    blahajZip: {
-        name: "blahaj.zip",
-        id: 683954422241427471n,
-    },
-    archeruwu: {
-        name: "archer_uwu",
-        id: 160068695383736320n
-    },
-    ProffDea: {
-        name: "ProffDea",
-        id: 609329952180928513n
-    },
-    UlyssesZhan: {
-        name: "UlyssesZhan",
-        id: 586808226058862623n
-    },
-    ant0n: {
-        name: "ant0n",
-        id: 145224646868860928n
-    },
-    Board: {
-        name: "BoardTM",
-        id: 285475344817848320n,
-    },
-    philipbry: {
-        name: "philipbry",
-        id: 554994003318276106n
-    },
-    Korbo: {
-        name: "Korbo",
-        id: 455856406420258827n
-    },
-    maisymoe: {
-        name: "maisy",
-        id: 257109471589957632n,
-    },
-    Lexi: {
-        name: "Lexi",
-        id: 506101469787717658n
-    },
-    Mopi: {
-        name: "Mopi",
-        id: 1022189106614243350n
-    },
-    Grzesiek11: {
-        name: "Grzesiek11",
-        id: 368475654662127616n,
-    },
-    Samwich: {
-        name: "Samwich",
-        id: 976176454511509554n,
-    },
-    coolelectronics: {
-        name: "coolelectronics",
-        id: 696392247205298207n,
-    },
-    Av32000: {
-        name: "Av32000",
-        id: 593436735380127770n,
-    },
-    Noxillio: {
-        name: "Noxillio",
-        id: 138616536502894592n,
-    },
-    Kyuuhachi: {
-        name: "Kyuuhachi",
-        id: 236588665420251137n,
-    },
-    nin0dev: {
-        name: "nin0dev",
-        id: 1395533040914141235n
-    },
-    Elvyra: {
-        name: "Elvyra",
-        id: 708275751816003615n,
-    },
-    HappyEnderman: {
-        name: "Happy enderman",
-        id: 1083437693347827764n
-    },
-    Vishnya: {
-        name: "Vishnya",
-        id: 282541644484575233n
-    },
-    Inbestigator: {
-        name: "Inbestigator",
-        id: 761777382041714690n
-    },
-    newwares: {
-        name: "newwares",
-        id: 421405303951851520n
-    },
-    JohnyTheCarrot: {
-        name: "JohnyTheCarrot",
-        id: 132819036282159104n
-    },
-    puv: {
-        name: "puv",
-        id: 469441552251355137n
-    },
-    IcedMarina: {
-        name: "icedmarina",
-        id: 594406131670188042n
-    },
-    nakoyasha: {
-        name: "nakoyasha",
-        id: 222069018507345921n
-    },
-    Sqaaakoi: {
-        name: "Sqaaakoi",
-        id: 259558259491340288n
-    },
-    iamme: {
-        name: "i am me",
-        id: 984392761929256980n
-    },
-    Byeoon: {
-        name: "byeoon",
-        id: 1167275288036655133n
-    },
-    Kaitlyn: {
-        name: "kaitlyn",
-        id: 306158896630988801n
-    },
-    PolisanTheEasyNick: {
-        name: "Oleh Polisan",
-        id: 242305263313485825n
-    },
-    HAHALOSAH: {
-        name: "HAHALOSAH",
-        id: 903418691268513883n
-    },
-    GabiRP: {
-        name: "GabiRP",
-        id: 507955112027750401n
-    },
-    ImBanana: {
-        name: "Im_Banana",
-        id: 635250116688871425n
-    },
-    xocherry: {
-        name: "xocherry",
-        id: 221288171013406720n
-    },
-    ScattrdBlade: {
-        name: "ScattrdBlade",
-        id: 678007540608532491n
-    },
-    goodbee: {
-        name: "goodbee",
-        id: 658968552606400512n
-    },
-    Moxxie: {
-        name: "Moxxie",
-        id: 712653921692155965n,
-    },
-    Ethan: {
-        name: "Ethan",
-        id: 721717126523781240n,
-    },
-    nyx: {
-        name: "verticalsync.",
-        id: 1207087393929171095n
-    },
-    nekohaxx: {
-        name: "nekohaxx",
-        id: 1176270221628153886n
-    },
-    Antti: {
-        name: "Antti",
-        id: 312974985876471810n
-    },
-    Joona: {
-        name: "Joona",
-        id: 297410829589020673n
-    },
-    sadan: {
-        name: "sadan",
-        id: 521819891141967883n,
-    },
-    Kylie: {
-        name: "Cookie",
-        id: 721853658941227088n
-    },
-    AshtonMemer: {
-        name: "AshtonMemer",
-        id: 373657230530052099n
-    },
-    surgedevs: {
-        name: "Chloe",
-        id: 1084592643784331324n
-    },
-    Lumap: {
-        name: "Lumap",
-        id: 585278686291427338n,
-    },
-    Obsidian: {
-        name: "Obsidian",
-        id: 683171006717755446n,
-    },
-    SerStars: {
-        name: "SerStars",
-        id: 861631850681729045n,
-    },
-    niko: {
-        name: "niko",
-        id: 341377368075796483n,
-    },
-    relitrix: {
-        name: "Relitrix",
-        id: 423165393901715456n,
-    },
-    RamziAH: {
-        name: "RamziAH",
-        id: 1279957227612147747n,
-    },
-    SomeAspy: {
-        name: "SomeAspy",
-        id: 516750892372852754n,
-    },
-    jamesbt365: {
-        name: "jamesbt365",
-        id: 158567567487795200n,
-    },
-    Darxoon: {
-        name: "Darxoon",
-        id: 409745838898937866n
-    },
-    samsam: {
-        name: "samsam",
-        id: 400482410279469056n,
-    },
-    Cootshk: {
-        name: "Cootshk",
-        id: 921605971577548820n
-    },
-    koish1: {
-        name: "koish1",
-        id: 291089948709486593n,
-        badge: false,
-    },
-    thororen: {
-        name: "thororen",
-        id: 848339671629299742n
-    },
-    alfred: {
-        name: "alfred",
-        id: 1038466644353232967n
-    },
-    vv: {
-        name: "VV",
-        id: 254866377087778816n
-    },
-    u32: {
-        name: "u32",
-        id: 1063237286818488351n,
-    },
-    prism: {
-        name: "prism",
-        id: 390884143749136386n,
-    },
-    tobezdev: {
-        name: "tobezdev",
-        id: 969254887621820526n,
-    }
+	Ven: {
+		name: "V",
+		id: 343383572805058560n
+	},
+	Apexo: {
+		name: "Apexo",
+		id: 228548952687902720n
+	},
+	Arjix: {
+		name: "ArjixWasTaken",
+		id: 674710789138939916n,
+		badge: false
+	},
+	Cyn: {
+		name: "Cynosphere",
+		id: 150745989836308480n
+	},
+	Trwy: {
+		name: "trey",
+		id: 354427199023218689n
+	},
+	Megu: {
+		name: "Megumin",
+		id: 545581357812678656n
+	},
+	botato: {
+		name: "botato",
+		id: 440990343899643943n
+	},
+	fawn: {
+		name: "fawn",
+		id: 336678828233588736n,
+	},
+	rushii: {
+		name: "rushii",
+		id: 295190422244950017n
+	},
+	Glitch: {
+		name: "Glitchy",
+		id: 269567451199569920n
+	},
+	Samu: {
+		name: "Samu",
+		id: 702973430449832038n,
+	},
+	Nyako: {
+		name: "nyako",
+		id: 118437263754395652n
+	},
+	MaiKokain: {
+		name: "Mai",
+		id: 722647978577363026n
+	},
+	amy: {
+		name: "Amy",
+		id: 603229858612510720n
+	},
+	katlyn: {
+		name: "katlyn",
+		id: 250322741406859265n
+	},
+	nea: {
+		name: "nea",
+		id: 310702108997320705n,
+	},
+	Nuckyz: {
+		name: "Nuckyz",
+		id: 235834946571337729n
+	},
+	D3SOX: {
+		name: "D3SOX",
+		id: 201052085641281538n
+	},
+	Nickyux: {
+		name: "Nickyux",
+		id: 427146305651998721n
+	},
+	mantikafasi: {
+		name: "mantikafasi",
+		id: 287555395151593473n
+	},
+	Xinto: {
+		name: "Xinto",
+		id: 423915768191647755n
+	},
+	JacobTm: {
+		name: "Jacob.Tm",
+		id: 302872992097107991n
+	},
+	DustyAngel47: {
+		name: "DustyAngel47",
+		id: 714583473804935238n
+	},
+	BanTheNons: {
+		name: "BanTheNons",
+		id: 460478012794863637n
+	},
+	BigDuck: {
+		name: "BigDuck",
+		id: 1024588272623681609n
+	},
+	AverageReactEnjoyer: {
+		name: "Average React Enjoyer",
+		id: 1004904120056029256n
+	},
+	adryd: {
+		name: "adryd",
+		id: 0n
+	},
+	Tyman: {
+		name: "Tyman",
+		id: 487443883127472129n
+	},
+	afn: {
+		name: "afn",
+		id: 420043923822608384n
+	},
+	KraXen72: {
+		name: "KraXen72",
+		id: 379304073515499530n
+	},
+	kemo: {
+		name: "kemo",
+		id: 715746190813298788n
+	},
+	dzshn: {
+		name: "dzshn",
+		id: 310449948011528192n
+	},
+	Ducko: {
+		name: "Ducko",
+		id: 506482395269169153n
+	},
+	jewdev: {
+		name: "jewdev",
+		id: 222369866529636353n
+	},
+	Luna: {
+		name: "Luny",
+		id: 821472922140803112n
+	},
+	Vap: {
+		name: "Vap0r1ze",
+		id: 454072114492866560n
+	},
+	KingFish: {
+		name: "King Fish",
+		id: 499400512559382538n
+	},
+	Commandtechno: {
+		name: "Commandtechno",
+		id: 296776625432035328n,
+	},
+	TheSun: {
+		name: "sunnie",
+		id: 406028027768733696n
+	},
+	rae: {
+		name: "rae",
+		id: 1398136199503282277n
+	},
+	pointy: {
+		name: "pointy",
+		id: 99914384989519872n
+	},
+	SammCheese: {
+		name: "Samm-Cheese",
+		id: 372148345894076416n
+	},
+	zt: {
+		name: "zt",
+		id: 289556910426816513n
+	},
+	captain: {
+		name: "Captain",
+		id: 347366054806159360n
+	},
+	nick: {
+		name: "nick",
+		id: 347884694408265729n,
+		badge: false
+	},
+	whqwert: {
+		name: "whqwert",
+		id: 586239091520176128n
+	},
+	lewisakura: {
+		name: "lewisakura",
+		id: 96269247411400704n
+	},
+	RuiNtD: {
+		name: "RuiNtD",
+		id: 157917665162297344n
+	},
+	hunt: {
+		name: "hunt-g",
+		id: 222800179697287168n
+	},
+	cloudburst: {
+		name: "cloudburst",
+		id: 892128204150685769n
+	},
+	Aria: {
+		name: "Syncxv",
+		id: 549244932213309442n,
+	},
+	TheKodeToad: {
+		name: "TheKodeToad",
+		id: 706152404072267788n
+	},
+	LordElias: {
+		name: "LordElias",
+		id: 319460781567639554n
+	},
+	juby: {
+		name: "Juby210",
+		id: 324622488644616195n
+	},
+	Alyxia: {
+		name: "Alyxia Sother",
+		id: 952185386350829688n
+	},
+	Remty: {
+		name: "Remty",
+		id: 335055032204656642n
+	},
+	skyevg: {
+		name: "skyevg",
+		id: 1090310844283363348n
+	},
+	Dziurwa: {
+		name: "Dziurwa",
+		id: 1001086404203389018n
+	},
+	arHSM: {
+		name: "arHSM",
+		id: 841509053422632990n
+	},
+	AutumnVN: {
+		name: "AutumnVN",
+		id: 393694671383166998n
+	},
+	pylix: {
+		name: "pylix",
+		id: 492949202121261067n
+	},
+	Tyler: {
+		name: "\\\\GGTyler\\\\",
+		id: 143117463788191746n
+	},
+	RyanCaoDev: {
+		name: "RyanCaoDev",
+		id: 952235800110694471n,
+	},
+	FieryFlames: {
+		name: "Fiery",
+		id: 890228870559698955n
+	},
+	KannaDev: {
+		name: "Kanna",
+		id: 317728561106518019n
+	},
+	carince: {
+		name: "carince",
+		id: 818323528755314698n
+	},
+	PandaNinjas: {
+		name: "PandaNinjas",
+		id: 455128749071925248n
+	},
+	CatNoir: {
+		name: "CatNoir",
+		id: 260371016348336128n
+	},
+	outfoxxed: {
+		name: "outfoxxed",
+		id: 837425748435796060n
+	},
+	UwUDev: {
+		name: "UwU",
+		id: 691413039156690994n,
+	},
+	amia: {
+		name: "amia",
+		id: 142007603549962240n
+	},
+	phil: {
+		name: "phil",
+		id: 305288513941667851n
+	},
+	ImLvna: {
+		name: "lillith <3",
+		id: 799319081723232267n
+	},
+	rad: {
+		name: "rad",
+		id: 610945092504780823n
+	},
+	AndrewDLO: {
+		name: "Andrew-DLO",
+		id: 434135504792059917n
+	},
+	HypedDomi: {
+		name: "HypedDomi",
+		id: 354191516979429376n
+	},
+	Rini: {
+		name: "Rini",
+		id: 1079479184478441643n
+	},
+	castdrian: {
+		name: "castdrian",
+		id: 224617799434108928n
+	},
+	Arrow: {
+		name: "arrow",
+		id: 958158495302176778n
+	},
+	bb010g: {
+		name: "bb010g",
+		id: 72791153467990016n,
+	},
+	Dolfies: {
+		name: "Dolfies",
+		id: 852892297661906993n,
+	},
+	RuukuLada: {
+		name: "RuukuLada",
+		id: 119705748346241027n,
+	},
+	blahajZip: {
+		name: "blahaj.zip",
+		id: 683954422241427471n,
+	},
+	archeruwu: {
+		name: "archer_uwu",
+		id: 160068695383736320n
+	},
+	ProffDea: {
+		name: "ProffDea",
+		id: 609329952180928513n
+	},
+	UlyssesZhan: {
+		name: "UlyssesZhan",
+		id: 586808226058862623n
+	},
+	ant0n: {
+		name: "ant0n",
+		id: 145224646868860928n
+	},
+	Board: {
+		name: "BoardTM",
+		id: 285475344817848320n,
+	},
+	philipbry: {
+		name: "philipbry",
+		id: 554994003318276106n
+	},
+	Korbo: {
+		name: "Korbo",
+		id: 455856406420258827n
+	},
+	maisymoe: {
+		name: "maisy",
+		id: 257109471589957632n,
+	},
+	Lexi: {
+		name: "Lexi",
+		id: 506101469787717658n
+	},
+	Mopi: {
+		name: "Mopi",
+		id: 1022189106614243350n
+	},
+	Grzesiek11: {
+		name: "Grzesiek11",
+		id: 368475654662127616n,
+	},
+	Samwich: {
+		name: "Samwich",
+		id: 976176454511509554n,
+	},
+	coolelectronics: {
+		name: "coolelectronics",
+		id: 696392247205298207n,
+	},
+	Av32000: {
+		name: "Av32000",
+		id: 593436735380127770n,
+	},
+	Noxillio: {
+		name: "Noxillio",
+		id: 138616536502894592n,
+	},
+	Kyuuhachi: {
+		name: "Kyuuhachi",
+		id: 236588665420251137n,
+	},
+	nin0dev: {
+		name: "nin0dev",
+		id: 1395533040914141235n
+	},
+	Elvyra: {
+		name: "Elvyra",
+		id: 708275751816003615n,
+	},
+	HappyEnderman: {
+		name: "Happy enderman",
+		id: 1083437693347827764n
+	},
+	Vishnya: {
+		name: "Vishnya",
+		id: 282541644484575233n
+	},
+	Inbestigator: {
+		name: "Inbestigator",
+		id: 761777382041714690n
+	},
+	newwares: {
+		name: "newwares",
+		id: 421405303951851520n
+	},
+	JohnyTheCarrot: {
+		name: "JohnyTheCarrot",
+		id: 132819036282159104n
+	},
+	puv: {
+		name: "puv",
+		id: 469441552251355137n
+	},
+	IcedMarina: {
+		name: "icedmarina",
+		id: 594406131670188042n
+	},
+	nakoyasha: {
+		name: "nakoyasha",
+		id: 222069018507345921n
+	},
+	Sqaaakoi: {
+		name: "Sqaaakoi",
+		id: 259558259491340288n
+	},
+	iamme: {
+		name: "i am me",
+		id: 984392761929256980n
+	},
+	Byeoon: {
+		name: "byeoon",
+		id: 1167275288036655133n
+	},
+	Kaitlyn: {
+		name: "kaitlyn",
+		id: 306158896630988801n
+	},
+	PolisanTheEasyNick: {
+		name: "Oleh Polisan",
+		id: 242305263313485825n
+	},
+	HAHALOSAH: {
+		name: "HAHALOSAH",
+		id: 903418691268513883n
+	},
+	GabiRP: {
+		name: "GabiRP",
+		id: 507955112027750401n
+	},
+	ImBanana: {
+		name: "Im_Banana",
+		id: 635250116688871425n
+	},
+	xocherry: {
+		name: "xocherry",
+		id: 221288171013406720n
+	},
+	ScattrdBlade: {
+		name: "ScattrdBlade",
+		id: 678007540608532491n
+	},
+	goodbee: {
+		name: "goodbee",
+		id: 658968552606400512n
+	},
+	Moxxie: {
+		name: "Moxxie",
+		id: 712653921692155965n,
+	},
+	Ethan: {
+		name: "Ethan",
+		id: 721717126523781240n,
+	},
+	nyx: {
+		name: "verticalsync.",
+		id: 1207087393929171095n
+	},
+	nekohaxx: {
+		name: "nekohaxx",
+		id: 1176270221628153886n
+	},
+	Antti: {
+		name: "Antti",
+		id: 312974985876471810n
+	},
+	Joona: {
+		name: "Joona",
+		id: 297410829589020673n
+	},
+	sadan: {
+		name: "sadan",
+		id: 521819891141967883n,
+	},
+	Kylie: {
+		name: "Cookie",
+		id: 721853658941227088n
+	},
+	AshtonMemer: {
+		name: "AshtonMemer",
+		id: 373657230530052099n
+	},
+	surgedevs: {
+		name: "Chloe",
+		id: 1084592643784331324n
+	},
+	Lumap: {
+		name: "Lumap",
+		id: 585278686291427338n,
+	},
+	Obsidian: {
+		name: "Obsidian",
+		id: 683171006717755446n,
+	},
+	SerStars: {
+		name: "SerStars",
+		id: 861631850681729045n,
+	},
+	niko: {
+		name: "niko",
+		id: 341377368075796483n,
+	},
+	relitrix: {
+		name: "Relitrix",
+		id: 423165393901715456n,
+	},
+	RamziAH: {
+		name: "RamziAH",
+		id: 1279957227612147747n,
+	},
+	SomeAspy: {
+		name: "SomeAspy",
+		id: 516750892372852754n,
+	},
+	jamesbt365: {
+		name: "jamesbt365",
+		id: 158567567487795200n,
+	},
+	Darxoon: {
+		name: "Darxoon",
+		id: 409745838898937866n
+	},
+	samsam: {
+		name: "samsam",
+		id: 400482410279469056n,
+	},
+	Cootshk: {
+		name: "Cootshk",
+		id: 921605971577548820n
+	},
+	koish1: {
+		name: "koish1",
+		id: 291089948709486593n,
+		badge: false,
+	},
+	thororen: {
+		name: "thororen",
+		id: 848339671629299742n
+	},
+	alfred: {
+		name: "alfred",
+		id: 1038466644353232967n
+	},
+	vv: {
+		name: "VV",
+		id: 254866377087778816n
+	},
+	u32: {
+		name: "u32",
+		id: 1063237286818488351n,
+	},
+	prism: {
+		name: "prism",
+		id: 390884143749136386n,
+	},
+	tobezdev: {
+		name: "tobezdev",
+		id: 969254887621820526n,
+	},
+	zffutwo: {
+		name: "zffutwo",
+		id: 1392866325755334739n
+	},
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly
 export const DevsById = /* #__PURE__*/ (() =>
-    Object.freeze(Object.fromEntries(
-        Object.entries(Devs)
-            .filter(d => d[1].id !== 0n)
-            .map(([_, v]) => [v.id, v] as const)
-    ))
+	Object.freeze(Object.fromEntries(
+		Object.entries(Devs)
+			.filter(d => d[1].id !== 0n)
+			.map(([_, v]) => [v.id, v] as const)
+	))
 )() as Record<string, Dev>;


### PR DESCRIPTION
Adds the `tobezdev's Tweaks` plugin which provides the following features:
- option to disable avatar decorations
- option to reduce the scale of the read all notifications button provided by 
- option to reduce the scale of the online friends indicator provided by 
- option to enable smooth animations client-wide
- option to edit the reply/mention highlight background & bar to one of the following present themes:
  - None (keep default highlight)
  - Disabled (removes highlight entirely)
  - Pride Rainbow
  - Bisexual
  - Pansexual
  - Lesbian
  - Asexual
  - Transgender
  - Non-binary
  - Femboy (added by @Zffu)

<br>

TL;DR - adds these options:
<img width="312" height="302" alt="image" src="https://github.com/user-attachments/assets/1be9f72d-195b-4785-8f59-2cbb806e81db" />
