### PR TITLE
feat: add AutoReactMention plugin

### DIFF
--- a/src/plugins/autoReactMention/index.ts
+++ b/src/plugins/autoReactMention/index.ts
@@ -1,0 +1,49 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { RestAPI, UserStore } from "@webpack/common";
+
+const settings = definePluginSettings({
+    emoji: {
+        type: OptionType.STRING,
+        description: "Unicode emoji (👍) or custom (name:id)",
+        default: "",
+        placeholder: "👍 or pepeping:1447716977375313920"
+    }
+});
+
+export default definePlugin({
+    name: "AutoReactMention",
+    description: "Automatically reacts to messages where you are mentioned with a configurable emoji",
+    authors: [Devs.lucauy],
+    tags: ["Chat", "Reactions", "Fun"],
+    settings,
+
+    flux: {
+        MESSAGE_CREATE({ message }) {
+            const emoji = settings.store.emoji?.trim();
+            if (!emoji) return;
+
+            const currentUserId = UserStore.getCurrentUser()?.id;
+            if (!currentUserId) return;
+
+            const mentioned = message.mentions?.some((m: any) => m.id === currentUserId || m === currentUserId);
+            if (!mentioned) return;
+
+            if (message.author?.id === currentUserId) return;
+
+            const emojiIdentifier = emoji.includes(":") ? emoji : encodeURIComponent(emoji);
+
+            RestAPI.put({
+                url: `/channels/${message.channel_id}/messages/${message.id}/reactions/${emojiIdentifier}/@me`,
+                auth: true
+            }).catch(() => { });
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    lucauy: {
+        name: "lucauy",
+        id: 387704105566601226n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Summary
- Adds a new plugin that automatically reacts to messages where the user is mentioned
- Supports both unicode emojis (👍, 😂, etc.) and custom server emojis (name:id format)
- Configurable via plugin settings
## Context
A small, fun plugin for users who don’t like to be notified and want to add a touch of humor to mentions. Although not essential, it can add a bit of fun to mentions.
## How it works
Listens to `MESSAGE_CREATE` flux events, checks if the current user is mentioned, and automatically adds a reaction using the configured emoji.