### PR TITLE
ShowHiddenChannels: Fix uncategorized channels not showing category and name (#4215)

### DIFF
--- a/src/plugins/showHiddenChannels/index.tsx
+++ b/src/plugins/showHiddenChannels/index.tsx
@@ -65,7 +65,7 @@ export const settings = definePluginSettings({
 });
 
 function isUncategorized(objChannel: { channel: Channel; comparator: number; }) {
-    return objChannel.channel.id === "null" && objChannel.channel.name === "Uncategorized" && objChannel.comparator === -1;
+    return (objChannel.channel.id === "null" || objChannel.channel.id === null) && objChannel.channel.name === "Uncategorized" && objChannel.comparator === -1;
 }
 
 export default definePlugin({

--- a/src/plugins/showHiddenChannels/index.tsx
+++ b/src/plugins/showHiddenChannels/index.tsx
@@ -65,7 +65,7 @@ export const settings = definePluginSettings({
 });
 
 function isUncategorized(objChannel: { channel: Channel; comparator: number; }) {
-    return (objChannel.channel.id === "null" || objChannel.channel.id === null) && objChannel.channel.name === "Uncategorized" && objChannel.comparator === -1;
+    return (objChannel.channel.id == null || objChannel.channel.id === "null") && objChannel.channel.name === "Uncategorized" && objChannel.comparator === -1;
 }
 
 export default definePlugin({


### PR DESCRIPTION
Fixes #4215

Updated isUncategorized function to handle both string "null" and actual null value for channel.id, as Discord likely changed how they represent uncategorized channels.