### PR TITLE
New plugin: SpoofDevice

### DIFF
--- a/src/plugins/spoofDevice/index.tsx
+++ b/src/plugins/spoofDevice/index.tsx
@@ -1,0 +1,101 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import { Card } from "@components/Card";
+import { Forms, UserStore } from "@webpack/common";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    platform: {
+        type: OptionType.SELECT,
+        description: "What platform to show up as",
+        restartNeeded: true,
+        default: "desktop",
+        options: [
+            { label: "Desktop", value: "desktop" },
+            { label: "Web", value: "web" },
+            { label: "Android", value: "android" },
+            { label: "iOS", value: "ios" },
+            { label: "Xbox", value: "xbox" },
+            { label: "Playstation", value: "playstation" },
+            { label: "VR", value: "vr" },
+        ]
+    }
+});
+
+export default definePlugin({
+    name: "SpoofDevice",
+    description: "Spoof your reported platform/device",
+    tags: ["Utility"],
+    authors: [Devs.SkyDash, Devs.Nro],
+    settings,
+
+    settingsAboutComponent: () => (
+        <Card variant="warning">
+            <Forms.FormTitle tag="h3">Warning</Forms.FormTitle>
+            <Forms.FormText>
+                USE AT YOUR OWN RISK! It is unknown if this can get you banned.
+            </Forms.FormText>
+        </Card>
+    ),
+
+    patches: [
+        {
+            find: "_doIdentify(){",
+            replacement: [
+                {
+                    match: /window._ws=null,null!=\i/,
+                    replace: "false"
+                },
+                {
+                    match: /(?<="GatewaySocket"\)\}\),properties:)(\i)/,
+                    replace: "{...$1,...$self.getPlatform(true)}"
+                },
+            ]
+        }
+    ],
+
+    getPlatform(bypass: boolean, userId?: string) {
+        const platform = settings.store.platform ?? "desktop";
+
+        if (bypass || userId === UserStore.getCurrentUser().id) {
+            switch (platform) {
+                case "desktop":
+                    return { browser: "Discord Client" };
+                case "web":
+                    return { browser: "Discord Web" };
+                case "ios":
+                    return { browser: "Discord iOS" };
+                case "android":
+                    return { browser: "Discord Android" };
+                case "xbox":
+                    return { browser: "Discord Embedded" };
+                case "playstation":
+                    return { browser: "Discord Embedded" };
+                case "vr":
+                    return { browser: "Discord VR" };
+                default:
+                    return null;
+            }
+        }
+
+        return null;
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,14 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    SkyDash: {
+        name: "SkyDash",
+        id: 628963286213197838n
+    },
+    Nro: {
+        name: "Nro772",
+        id: 636505364631781387n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This pull request introduces the SpoofDevice plugin, which allows users to spoof the platform and browser information reported by their client. This can be used to appear as if you are connecting from different devices such as iOS, Android, Xbox, or PlayStation.

## What's Changed: 
   * Added SpoofDevice Plugin: A new utility plugin located in src/plugins/spoofDevice.
   * Platform Options: Users can select between Desktop, Web, Android, iOS, Xbox, PlayStation, and VR.
   * Contributor Updates: Added SkyDash and Nro to the global Devs list in src/utils/constants.ts.
   * Refactoring: Migrated plugin-specific developer constants to the global constants file for better integration.

## Warning
* USE AT YOUR OWN RISK. This plugin modifies the gateway identify properties. It is unknown if spoofing your device can lead to account bans or other actions from Discord. By using this plugin, you acknowledge this risk.

## Images
<img width="623" height="489" alt="image" src="https://github.com/user-attachments/assets/d3e3064a-2278-49f8-9412-e69c65f54dd1" />
<img width="559" height="268" alt="image" src="https://github.com/user-attachments/assets/dcf71c0b-9e89-43c1-9e00-05e970cb0a5e" />

* Here it's active
<img width="359" height="114" alt="image" src="https://github.com/user-attachments/assets/e06801e5-a6b6-433b-9102-cf6b7e5fe3e8" />
<img width="175" height="69" alt="image" src="https://github.com/user-attachments/assets/0f8aa181-e9ce-4b81-8673-a4c1ee42c599" />
