### PR TITLE
feat(plugin): add OnlineThemeInstaller

### DIFF
--- a/src/plugins/onlineThemeInstaller/README.md
+++ b/src/plugins/onlineThemeInstaller/README.md
@@ -1,0 +1,21 @@
+# OnlineThemeInstaller
+
+Browse the [BetterDiscord theme store](https://betterdiscord.app/themes) and install themes into Vencord's **Online Themes** with one click. Stylesheets are resolved from GitHub source URLs when available.
+
+![Enable the plugin and open settings](https://github.com/user-attachments/assets/1fbbbedb-d234-4c11-8f6a-66a82503420c)
+
+## How to use
+
+1. Enable **OnlineThemeInstaller** under **Vencord → Plugins**.
+2. Click the **gear** icon on the plugin card to open the theme browser.
+3. Search or scroll, then click **Install** on a theme.
+
+![Install a theme](https://github.com/user-attachments/assets/fe27afb1-4167-4326-b8b7-1b1cd1dfc9a5)
+
+4. Installed themes move to the top of the list. Click **Remove** to uninstall.
+
+![Remove an installed theme](https://github.com/user-attachments/assets/da7435b1-e316-4556-bed8-edf49659ef56)
+
+You can also open the browser from **Vencord → Themes → Online Themes → Browse themes**, the toolbox **Browse themes** action, or `/onlineThemes`.
+
+Installed themes appear under **Settings → Themes → Online Themes**.

--- a/src/plugins/onlineThemeInstaller/api.ts
+++ b/src/plugins/onlineThemeInstaller/api.ts
@@ -1,0 +1,117 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { BDTheme } from "./types";
+import { BD_THEMES_PAGE, themeDownloadUrl } from "./types";
+
+function parseStatValue(title: string | null): string {
+    if (!title) return "0";
+    const match = /:\s*(.+)$/.exec(title);
+    return match?.[1]?.trim() ?? "0";
+}
+
+export function parseThemesHtml(html: string): BDTheme[] {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const themes: BDTheme[] = [];
+
+    for (const card of doc.querySelectorAll("a.card-wrap")) {
+        const path = card.getAttribute("href") ?? "";
+        const slugMatch = /^\/themes\/(.+)$/.exec(path);
+        if (!slugMatch) continue;
+
+        const slug = decodeURIComponent(slugMatch[1]);
+        const name = card.querySelector(".card-title")?.textContent?.trim();
+        if (!name) continue;
+
+        const downloadAnchor = card.querySelector('a[href*="download?id="]');
+        const downloadHref = downloadAnchor?.getAttribute("href") ?? "";
+        const idMatch = /[?&]id=(\d+)/.exec(downloadHref);
+        if (!idMatch) continue;
+
+        const id = Number(idMatch[1]);
+        const description = card.querySelector(".card-description")?.textContent?.trim() ?? "";
+        const author = card.querySelector(".author-link")?.textContent?.trim() ?? "Unknown";
+        const tags = [...card.querySelectorAll(".addon-tag")]
+            .map(el => el.textContent?.trim() ?? "")
+            .filter(Boolean);
+
+        const stats = card.querySelectorAll(".card-stat");
+        const downloads = parseStatValue(stats[0]?.getAttribute("title") ?? null);
+        const likes = parseStatValue(stats[1]?.getAttribute("title") ?? null);
+
+        const imgSrc = card.querySelector(".card-image")?.getAttribute("src") ?? "";
+        const thumbMatch = /\/image\/(\d+)/.exec(imgSrc);
+        const thumbnailUrl = thumbMatch
+            ? `https://betterdiscord.app/image/${thumbMatch[1]}`
+            : null;
+
+        themes.push({
+            id,
+            name,
+            slug,
+            description,
+            author,
+            tags,
+            downloads,
+            likes,
+            thumbnailUrl,
+            pageUrl: `https://betterdiscord.app/themes/${encodeURIComponent(slug)}`,
+            downloadUrl: themeDownloadUrl(id),
+        });
+    }
+
+    return themes;
+}
+
+export function parseThemePageSource(html: string): string | null {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+
+    for (const anchor of doc.querySelectorAll('a[href*="github.com"]')) {
+        const href = anchor.getAttribute("href");
+        if (!href) continue;
+
+        if (/\/blob\//i.test(href)) {
+            const block = anchor.closest("div, section, article, li, p, td, dd");
+            const blockText = block?.textContent?.toLowerCase() ?? "";
+            if (blockText.includes("source") || anchor.textContent?.toLowerCase().includes("github")) {
+                return href;
+            }
+        }
+    }
+
+    const blobLink = doc.querySelector('a[href*="github.com"][href*="/blob/"]');
+    if (blobLink?.getAttribute("href")?.includes(".css")) {
+        return blobLink.getAttribute("href");
+    }
+
+    for (const anchor of doc.querySelectorAll('a[href*="github.com"]')) {
+        const href = anchor.getAttribute("href");
+        if (!href || /\/blob\//.test(href)) continue;
+        const context = anchor.parentElement?.textContent?.toLowerCase() ?? "";
+        if (context.includes("source")) {
+            return href;
+        }
+    }
+
+    return null;
+}
+
+export async function fetchThemesCatalog(fetchHtml: (url: string) => Promise<string>): Promise<BDTheme[]> {
+    const html = await fetchHtml(BD_THEMES_PAGE);
+    return parseThemesHtml(html);
+}

--- a/src/plugins/onlineThemeInstaller/components/ThemeBrowser.tsx
+++ b/src/plugins/onlineThemeInstaller/components/ThemeBrowser.tsx
@@ -1,0 +1,201 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { fetchThemesCatalog } from "../api";
+import { installTheme, isThemeInstalled, uninstallTheme } from "../themeInstall";
+import type { BDTheme } from "../types";
+import { BD_THEME_STORE } from "../types";
+import "../styles.css";
+
+import { classNameFactory } from "@utils/css";
+import { Button, Forms, React, useEffect, useMemo, useState } from "@webpack/common";
+import { showToast, Toasts } from "@webpack/common";
+
+const cl = classNameFactory("vc-oti-");
+
+export interface ThemeBrowserProps {
+    fetchHtml: (url: string) => Promise<string>;
+}
+
+function filterThemes(themes: BDTheme[], query: string): BDTheme[] {
+    const q = query.trim().toLowerCase();
+    if (!q) return themes;
+
+    return themes.filter(theme => {
+        const haystack = [
+            theme.name,
+            theme.author,
+            theme.description,
+            theme.tags.join(" "),
+        ].join(" ").toLowerCase();
+
+        return haystack.includes(q);
+    });
+}
+
+function sortInstalledFirst(themes: BDTheme[]): BDTheme[] {
+    return [...themes].sort((a, b) => {
+        const aInstalled = isThemeInstalled(a);
+        const bInstalled = isThemeInstalled(b);
+        if (aInstalled === bInstalled) return 0;
+        return aInstalled ? -1 : 1;
+    });
+}
+
+export function ThemeBrowser({ fetchHtml }: ThemeBrowserProps) {
+    const [themes, setThemes] = useState<BDTheme[]>([]);
+    const [search, setSearch] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [installingId, setInstallingId] = useState<number | null>(null);
+    const [installedRevision, setInstalledRevision] = useState(0);
+
+    const refreshInstalled = () => setInstalledRevision(n => n + 1);
+
+    const loadCatalog = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const list = await fetchThemesCatalog(fetchHtml);
+            setThemes(list);
+            if (!list.length) {
+                setError("No themes found. The BetterDiscord store page layout may have changed.");
+            }
+        } catch (e) {
+            console.error("[OnlineThemeInstaller]", e);
+            setError(e instanceof Error ? e.message : "Failed to load themes from BetterDiscord.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void loadCatalog();
+    }, []);
+
+    const filtered = useMemo(
+        () => sortInstalledFirst(filterThemes(themes, search)),
+        [themes, search, installedRevision]
+    );
+
+    const handleInstall = async (theme: BDTheme) => {
+        if (isThemeInstalled(theme)) {
+            uninstallTheme(theme);
+            refreshInstalled();
+            showToast(`Removed "${theme.name}"`, Toasts.Type.MESSAGE);
+            return;
+        }
+
+        setInstallingId(theme.id);
+        try {
+            const result = await installTheme(theme, fetchHtml);
+            refreshInstalled();
+            if (result.localFile) {
+                showToast(
+                    `Installed "${theme.name}" as a local theme (${result.localFile})`,
+                    Toasts.Type.SUCCESS
+                );
+            } else {
+                showToast(
+                    `Installed "${theme.name}" — ${result.urls.length} stylesheet URL(s) added to Online Themes`,
+                    Toasts.Type.SUCCESS
+                );
+            }
+        } catch (e) {
+            console.error("[OnlineThemeInstaller]", e);
+            showToast(
+                e instanceof Error ? e.message : "Failed to install theme",
+                Toasts.Type.FAILURE
+            );
+        } finally {
+            setInstallingId(null);
+        }
+    };
+
+    const openStore = () => VencordNative.native.openExternal(BD_THEME_STORE);
+
+    if (loading) {
+        return <div className={cl("loading")}>Loading themes…</div>;
+    }
+
+    if (error && !themes.length) {
+        return (
+            <div className={cl("root")}>
+                <div className={cl("error")}>{error}</div>
+                <Button onClick={() => void loadCatalog()}>Retry</Button>
+            </div>
+        );
+    }
+
+    return (
+        <div className={cl("root")}>
+            <Forms.FormText className={cl("intro")}>
+                Themes from the{" "}
+                <a onClick={openStore} style={{ cursor: "pointer" }}>BetterDiscord store</a>.
+            </Forms.FormText>
+
+            <div className={cl("toolbar")}>
+                <input
+                    type="search"
+                    className={cl("search-input")}
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    placeholder="Search themes…"
+                    spellCheck={false}
+                />
+                <Button size={Button.Sizes.SMALL} onClick={() => void loadCatalog()}>
+                    Refresh
+                </Button>
+                <span className={cl("meta")}>
+                    {filtered.length} / {themes.length}
+                </span>
+            </div>
+
+            {error && <div className={cl("error")}>{error}</div>}
+
+            {!filtered.length ? (
+                <div className={cl("empty")}>No themes match your search.</div>
+            ) : (
+                <div className={cl("list")}>
+                    {filtered.map(theme => {
+                        const installed = isThemeInstalled(theme);
+                        const busy = installingId === theme.id;
+                        return (
+                            <div key={theme.id} className={cl("row")}>
+                                <div className={cl("text")}>
+                                    <div className={cl("name")}>{theme.name}</div>
+                                    <div className={cl("desc")}>
+                                        {theme.description || "No description provided."}
+                                    </div>
+                                </div>
+                                <Button
+                                    size={Button.Sizes.SMALL}
+                                    color={installed ? Button.Colors.RED : Button.Colors.BRAND}
+                                    disabled={busy}
+                                    onClick={() => void handleInstall(theme)}
+                                >
+                                    {busy ? "…" : installed ? "Remove" : "Install"}
+                                </Button>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/plugins/onlineThemeInstaller/fetchHtml.ts
+++ b/src/plugins/onlineThemeInstaller/fetchHtml.ts
@@ -1,0 +1,96 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { PluginNative } from "@utils/types";
+
+const NATIVE_HELPER_KEYS = ["OnlineThemeInstaller", "BDThemeSelector", "BdThemeSelector"] as const;
+
+type NativeExports = typeof import("./native");
+
+function getNativeFetchText(): ((url: string) => Promise<string>) | null {
+    for (const key of NATIVE_HELPER_KEYS) {
+        const helper = VencordNative.pluginHelpers[key] as PluginNative<NativeExports> | undefined;
+        const fetchText = helper?.fetchText;
+        if (fetchText) {
+            return (url: string) => fetchText(url);
+        }
+    }
+    return null;
+}
+
+async function ensureConnectCsp(): Promise<void> {
+    if (IS_WEB) return;
+
+    try {
+        await VencordNative.csp.requestAddOverride(
+            "https://betterdiscord.app",
+            ["connect-src"],
+            "OnlineThemeInstaller"
+        );
+    } catch { }
+}
+
+async function fetchHtmlInRenderer(url: string): Promise<string> {
+    await ensureConnectCsp();
+
+    const res = await fetch(url, {
+        headers: { Accept: "text/html,application/xhtml+xml" },
+    });
+
+    if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+    }
+
+    return res.text();
+}
+
+function buildLoadError(browserError: unknown): Error {
+    const browserMsg = browserError instanceof Error ? browserError.message : String(browserError);
+    const helpers = Object.keys(VencordNative.pluginHelpers ?? {}).sort().join(", ") || "(none)";
+
+    if (IS_DISCORD_DESKTOP || IS_VESKTOP) {
+        return new Error(
+            "Could not load themes from betterdiscord.app. " +
+            "Run setup.ps1 (or pnpm build && pnpm inject in your Vencord folder), then fully quit and restart Discord. " +
+            `Browser fetch: ${browserMsg}. Loaded native helpers: ${helpers}.`
+        );
+    }
+
+    return new Error(`Could not load themes from betterdiscord.app (${browserMsg}).`);
+}
+
+export async function fetchHtml(url: string): Promise<string> {
+    const nativeFetch = getNativeFetchText();
+
+    if ((IS_DISCORD_DESKTOP || IS_VESKTOP) && nativeFetch) {
+        try {
+            return await nativeFetch(url);
+        } catch (e) {
+            console.warn("[OnlineThemeInstaller] native fetch failed, trying renderer fetch", e);
+        }
+    }
+
+    try {
+        return await fetchHtmlInRenderer(url);
+    } catch (browserError) {
+        if (nativeFetch) {
+            return nativeFetch(url);
+        }
+        throw buildLoadError(browserError);
+    }
+}

--- a/src/plugins/onlineThemeInstaller/githubSource.ts
+++ b/src/plugins/onlineThemeInstaller/githubSource.ts
@@ -1,0 +1,111 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+const COMMIT_SHA_RE = /^[0-9a-f]{7,40}$/i;
+
+export function githubBlobToStylesheetUrl(url: string): string | null {
+    try {
+        const parsed = new URL(url);
+        if (!parsed.hostname.endsWith("github.com")) return null;
+        if (!parsed.pathname.includes("/blob/")) return null;
+
+        parsed.searchParams.set("raw", "true");
+        return parsed.toString();
+    } catch {
+        return null;
+    }
+}
+
+export function githubSourceToStylesheetUrl(sourceUrl: string): string | null {
+    const trimmed = sourceUrl.trim();
+    if (!trimmed) return null;
+
+    if (trimmed.includes("raw.githubusercontent.com")) {
+        return normalizeRawGithubUrl(trimmed.split("?")[0]);
+    }
+
+    const blobStylesheet = githubBlobToStylesheetUrl(trimmed);
+    if (blobStylesheet) return blobStylesheet;
+
+    const fromBlob = githubBlobToRawUrl(trimmed.split("?")[0]);
+    if (fromBlob) return fromBlob;
+
+    const repoOnly = parseGithubRepoOnly(trimmed.split("?")[0]);
+    if (repoOnly) {
+        return rawGithubUrl(repoOnly.owner, repoOnly.repo, repoOnly.branch, `${repoOnly.repo}.theme.css`);
+    }
+
+    return null;
+}
+
+export function normalizeRawGithubUrl(url: string): string {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    if (parts.length < 4) return url;
+
+    const [owner, repo, maybeRef, ...rest] = parts;
+    if (maybeRef === "refs" && parts[3] === "heads" && parts.length >= 6) {
+        return url;
+    }
+
+    const ref = maybeRef;
+    const path = rest.join("/");
+    if (!path) return url;
+
+    if (COMMIT_SHA_RE.test(ref)) {
+        return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`;
+    }
+
+    return `https://raw.githubusercontent.com/${owner}/${repo}/refs/heads/${ref}/${path}`;
+}
+
+export function githubBlobToRawUrl(url: string): string | null {
+    const match = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/(.+)$/i.exec(url);
+    if (!match) return null;
+
+    const [, owner, repo, ref, filePath] = match;
+    return rawGithubUrl(owner, repo, ref, filePath);
+}
+
+export function rawGithubUrl(owner: string, repo: string, ref: string, filePath: string): string {
+    const path = filePath.replace(/^\//, "");
+    if (COMMIT_SHA_RE.test(ref)) {
+        return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`;
+    }
+    return `https://raw.githubusercontent.com/${owner}/${repo}/refs/heads/${ref}/${path}`;
+}
+
+interface GithubRepoOnly {
+    owner: string;
+    repo: string;
+    branch: string;
+}
+
+function parseGithubRepoOnly(url: string): GithubRepoOnly | null {
+    const treeMatch = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/?$/i.exec(url);
+    if (treeMatch) {
+        return { owner: treeMatch[1], repo: treeMatch[2], branch: treeMatch[3] };
+    }
+
+    const repoMatch = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/i.exec(url.replace(/\.git$/, ""));
+    if (repoMatch) {
+        return { owner: repoMatch[1], repo: repoMatch[2], branch: "master" };
+    }
+
+    return null;
+}

--- a/src/plugins/onlineThemeInstaller/index.tsx
+++ b/src/plugins/onlineThemeInstaller/index.tsx
@@ -1,0 +1,96 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { ApplicationCommandInputType } from "@api/Commands";
+import { isPluginEnabled } from "@api/PluginManager";
+import { definePluginSettings } from "@api/Settings";
+import { Card } from "@components/Card";
+import { openPluginModal } from "@components/settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { Button, Forms, React } from "@webpack/common";
+
+import { ThemeBrowser } from "./components/ThemeBrowser";
+import { fetchHtml } from "./fetchHtml";
+import { BD_THEMES_PAGE } from "./types";
+
+export const settings = definePluginSettings({
+    installMap: {
+        type: OptionType.STRING,
+        description: "Internal install tracking",
+        hidden: true,
+        default: "{}",
+    },
+    browser: {
+        type: OptionType.COMPONENT,
+        description: "Browse and install BetterDiscord themes from the official store.",
+        component: () => <ThemeBrowser fetchHtml={fetchHtml} />,
+    },
+});
+
+const plugin = definePlugin({
+    name: "OnlineThemeInstaller",
+    description: "Browse the BetterDiscord theme store and install themes into Online Themes via GitHub source URLs",
+    authors: [Devs.bulwarked],
+    tags: ["Appearance", "Customisation"],
+    settings,
+
+    settingsAboutComponent: () => (
+        <Forms.FormText>
+            Install custom client themes with a single click.
+        </Forms.FormText>
+    ),
+
+    commands: [{
+        name: "onlineThemes",
+        description: "Open the BetterDiscord theme browser",
+        inputType: ApplicationCommandInputType.BUILT_IN,
+        execute: () => openPluginModal(plugin),
+    }],
+
+    toolboxActions: {
+        "Browse themes": () => openPluginModal(plugin),
+        "Open BD theme store": () => VencordNative.native.openExternal(BD_THEMES_PAGE),
+    },
+
+    patches: [
+        {
+            find: "vc-settings-theme-links",
+            predicate: () => isPluginEnabled("OnlineThemeInstaller"),
+            replacement: {
+                match: /(<Flex flexDirection="column" gap="1em">)/,
+                replace: "$1<$self.ThemesTabPromo/>,",
+            },
+        },
+    ],
+
+    ThemesTabPromo: ErrorBoundary.wrap(() => (
+        <Card defaultPadding>
+            <Forms.FormTitle tag="h5">BetterDiscord theme store</Forms.FormTitle>
+            <Forms.FormText>
+                Browse and install community themes; installs use raw stylesheet URLs from theme metadata.
+            </Forms.FormText>
+            <Button onClick={() => openPluginModal(plugin)} style={{ marginTop: 8 }}>
+                Browse themes
+            </Button>
+        </Card>
+    ), { noop: true }),
+});
+
+export default plugin;

--- a/src/plugins/onlineThemeInstaller/native.ts
+++ b/src/plugins/onlineThemeInstaller/native.ts
@@ -1,0 +1,86 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { THEMES_DIR } from "@main/utils/constants";
+import { IpcMainInvokeEvent } from "electron";
+import { writeFile, unlink } from "fs/promises";
+import { request } from "https";
+import { join, normalize } from "path";
+
+const ALLOWED_HOSTS = new Set(["betterdiscord.app", "www.betterdiscord.app"]);
+
+function ensureSafeThemePath(fileName: string): string {
+    if (!fileName.endsWith(".css")) {
+        throw new Error("Theme file must end with .css");
+    }
+    const normalizedBase = normalize(THEMES_DIR + "/");
+    const fullPath = normalize(join(THEMES_DIR, fileName));
+    if (!fullPath.startsWith(normalizedBase)) {
+        throw new Error("Unsafe theme path");
+    }
+    return fullPath;
+}
+
+function fetchUrl(url: URL): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const req = request(
+            url,
+            {
+                method: "GET",
+                headers: {
+                    "User-Agent": "Vencord-OnlineThemeInstaller/1.0",
+                    Accept: "text/html,application/xhtml+xml,text/css,*/*",
+                },
+            },
+            res => {
+                const status = res.statusCode ?? 0;
+
+                if (status >= 300 && status < 400 && res.headers.location) {
+                    res.resume();
+                    const next = new URL(res.headers.location, url);
+                    if (!ALLOWED_HOSTS.has(next.hostname)) {
+                        reject(new Error("Redirect blocked"));
+                        return;
+                    }
+                    resolve(fetchUrl(next));
+                    return;
+                }
+
+                if (status < 200 || status >= 300) {
+                    reject(new Error(`HTTP ${status}`));
+                    res.resume();
+                    return;
+                }
+
+                const chunks: Buffer[] = [];
+                res.on("data", chunk => chunks.push(chunk));
+                res.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+            }
+        );
+
+        req.on("error", reject);
+        req.end();
+    });
+}
+
+export async function fetchText(_: IpcMainInvokeEvent, url: string): Promise<string> {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" || !ALLOWED_HOSTS.has(parsed.hostname)) {
+        throw new Error("Only https://betterdiscord.app URLs are allowed");
+    }
+
+    return fetchUrl(parsed);
+}
+
+export async function saveThemeFile(_: IpcMainInvokeEvent, fileName: string, content: string): Promise<void> {
+    const path = ensureSafeThemePath(fileName);
+    await writeFile(path, content, "utf8");
+}
+
+export async function deleteThemeFile(_: IpcMainInvokeEvent, fileName: string): Promise<void> {
+    const path = ensureSafeThemePath(fileName);
+    await unlink(path).catch(() => { });
+}

--- a/src/plugins/onlineThemeInstaller/native.ts
+++ b/src/plugins/onlineThemeInstaller/native.ts
@@ -82,5 +82,5 @@ export async function saveThemeFile(_: IpcMainInvokeEvent, fileName: string, con
 
 export async function deleteThemeFile(_: IpcMainInvokeEvent, fileName: string): Promise<void> {
     const path = ensureSafeThemePath(fileName);
-    await unlink(path).catch(() => { });
+await unlink(path).catch(err => { if (err.code !== "ENOENT") throw err; });
 }

--- a/src/plugins/onlineThemeInstaller/resolveThemeCss.ts
+++ b/src/plugins/onlineThemeInstaller/resolveThemeCss.ts
@@ -1,0 +1,136 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { githubSourceToStylesheetUrl } from "./githubSource";
+
+const IMPORT_RE = /@import\s+url\(\s*['"]?([^'")\s]+)['"]?\s*\)/gi;
+
+const SKIP_IMPORT_HOSTS = new Set([
+    "fonts.googleapis.com",
+    "fonts.gstatic.com",
+]);
+
+const SKIP_IMPORT_SNIPPETS = [
+    "BetterDiscordAddons",
+    "usrbg.dist",
+];
+
+export interface BdThemeMeta {
+    name?: string;
+    source?: string;
+}
+
+export interface ResolvedThemeCss {
+    urls: string[];
+    source?: string;
+    saveLocal: boolean;
+}
+
+export function parseBdThemeMeta(css: string): BdThemeMeta {
+    const block = css.split("/**", 2)?.[1]?.split("*/", 1)?.[0];
+    if (!block) return {};
+
+    const meta: BdThemeMeta = {};
+    const lines = block.split(/\r?\n/);
+
+    for (const line of lines) {
+        const trimmed = line.replace(/^\s*\*\s?/, "").trim();
+        if (!trimmed.startsWith("@")) continue;
+
+        const space = trimmed.indexOf(" ");
+        if (space === -1) continue;
+
+        const key = trimmed.slice(1, space).toLowerCase();
+        const value = trimmed.slice(space + 1).trim();
+        if (key === "source") meta.source = value;
+        if (key === "name") meta.name = value;
+    }
+
+    return meta;
+}
+
+function parseImports(css: string): string[] {
+    const urls: string[] = [];
+    for (const match of css.matchAll(IMPORT_RE)) {
+        if (match[1]) urls.push(match[1]);
+    }
+    return urls;
+}
+
+function isSkippedImport(url: string): boolean {
+    try {
+        const { hostname } = new URL(url);
+        if (SKIP_IMPORT_HOSTS.has(hostname)) return true;
+    } catch {
+        return true;
+    }
+    return SKIP_IMPORT_SNIPPETS.some(snippet => url.includes(snippet));
+}
+
+function resolveImportUrl(url: string): string | null {
+    if (isSkippedImport(url)) return null;
+
+    const fromGithub = githubSourceToStylesheetUrl(url);
+    if (fromGithub) return fromGithub;
+
+    if (url.endsWith(".css")) return url;
+    return null;
+}
+
+export function resolveThemeStylesheetUrls(
+    css: string,
+    pageSourceUrl?: string | null
+): ResolvedThemeCss {
+    if (pageSourceUrl) {
+        const fromPage = githubSourceToStylesheetUrl(pageSourceUrl);
+        if (fromPage) {
+            return {
+                urls: [fromPage],
+                source: pageSourceUrl,
+                saveLocal: false,
+            };
+        }
+    }
+
+    const meta = parseBdThemeMeta(css);
+    const headerSource = meta.source ? githubSourceToStylesheetUrl(meta.source) : null;
+    if (headerSource) {
+        return {
+            urls: [headerSource],
+            source: meta.source,
+            saveLocal: false,
+        };
+    }
+
+    const imports = parseImports(css);
+    const importUrls: string[] = [];
+
+    for (const imp of imports) {
+        const resolved = resolveImportUrl(imp);
+        if (resolved) importUrls.push(resolved);
+    }
+
+    const unique = [...new Set(importUrls)];
+    const body = css.replace(/\/\*[\s\S]*?\*\//g, "").replace(IMPORT_RE, "").trim();
+
+    return {
+        urls: unique,
+        source: meta.source,
+        saveLocal: unique.length === 0 && body.length > 40,
+    };
+}

--- a/src/plugins/onlineThemeInstaller/styles.css
+++ b/src/plugins/onlineThemeInstaller/styles.css
@@ -1,0 +1,114 @@
+.vc-oti-root {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    color: var(--header-primary);
+    font-family: var(--font-primary);
+}
+
+.vc-oti-intro {
+    margin-bottom: 0;
+}
+
+.vc-oti-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.vc-oti-search-input {
+    flex: 1 1 200px;
+    min-width: 160px;
+    height: 40px;
+    box-sizing: border-box;
+    margin: 0;
+    color-scheme: dark;
+    background-color: var(--input-background-default);
+    border: 1px solid var(--input-border-default);
+    border-radius: 4px;
+    color: var(--header-primary);
+    font-family: var(--font-primary);
+    font-size: 13px;
+    font-weight: 400;
+    line-height: 20px;
+    padding: 10px 16px;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.vc-oti-search-input:focus {
+    border-color: var(--input-border-focused, var(--brand-500));
+    outline: none;
+}
+
+.vc-oti-search-input::placeholder {
+    color: var(--text-muted);
+    font-family: var(--font-primary);
+    font-size: 13px;
+}
+
+.vc-oti-meta {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.vc-oti-list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--background-modifier-accent);
+    border-radius: 8px;
+}
+
+.vc-oti-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--background-modifier-accent);
+}
+
+.vc-oti-row:last-child {
+    border-bottom: none;
+}
+
+.vc-oti-row:hover {
+    background: var(--background-modifier-hover);
+}
+
+.vc-oti-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.vc-oti-name {
+    color: var(--header-primary);
+    font-family: var(--font-primary);
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 1.25;
+    margin-bottom: 4px;
+}
+
+.vc-oti-desc {
+    color: var(--text-muted);
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.vc-oti-row > button {
+    flex-shrink: 0;
+    margin-top: 2px;
+    min-width: 72px;
+}
+
+.vc-oti-empty,
+.vc-oti-error,
+.vc-oti-loading {
+    padding: 20px;
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.vc-oti-error {
+    color: var(--text-danger);
+}

--- a/src/plugins/onlineThemeInstaller/themeInstall.ts
+++ b/src/plugins/onlineThemeInstaller/themeInstall.ts
@@ -1,0 +1,170 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Settings } from "@api/Settings";
+import { PluginNative } from "@utils/types";
+
+import { parseThemePageSource } from "./api";
+import { resolveThemeStylesheetUrls } from "./resolveThemeCss";
+import type { BDTheme } from "./types";
+
+const PLUGIN = "OnlineThemeInstaller";
+const LEGACY_PLUGIN = "BDThemeSelector";
+const NATIVE_KEYS = ["OnlineThemeInstaller", "BDThemeSelector", "BdThemeSelector"] as const;
+
+export interface ThemeInstallRecord {
+    urls: string[];
+    localFile?: string;
+}
+
+type InstallMap = Record<string, ThemeInstallRecord>;
+
+function getNative(): PluginNative<typeof import("./native")> | null {
+    for (const key of NATIVE_KEYS) {
+        const helper = VencordNative.pluginHelpers[key] as PluginNative<typeof import("./native")> | undefined;
+        if (helper?.fetchText && helper?.saveThemeFile) return helper;
+        if (helper?.fetchText) return helper;
+    }
+    return null;
+}
+
+type PluginSettings = { installMap?: string; };
+
+function getInstallMap(): InstallMap {
+    const plugins = Settings.plugins as Record<string, PluginSettings | undefined>;
+    const raw = plugins?.[PLUGIN]?.installMap ?? plugins?.[LEGACY_PLUGIN]?.installMap;
+    if (!raw) return {};
+    try {
+        return JSON.parse(raw) as InstallMap;
+    } catch {
+        return {};
+    }
+}
+
+function setInstallMap(map: InstallMap): void {
+    const plugins = Settings.plugins as Record<string, PluginSettings>;
+    plugins[PLUGIN] = {
+        ...plugins[PLUGIN],
+        installMap: JSON.stringify(map),
+    };
+}
+
+function sanitizeFileName(name: string, id: number): string {
+    const base = name.replace(/[^\w.-]+/g, "_").replace(/_+/g, "_").slice(0, 72);
+    return `oti-${id}-${base || "theme"}.css`;
+}
+
+export function getInstalledThemeUrls(): string[] {
+    return Settings.themeLinks ?? [];
+}
+
+export function getInstallRecord(theme: BDTheme): ThemeInstallRecord | undefined {
+    return getInstallMap()[String(theme.id)];
+}
+
+export function isThemeInstalled(theme: BDTheme): boolean {
+    const record = getInstallRecord(theme);
+    if (record) {
+        if (record.localFile && Settings.enabledThemes?.includes(record.localFile)) return true;
+        if (record.urls.some(url => getInstalledThemeUrls().includes(url))) return true;
+    }
+    return getInstalledThemeUrls().includes(theme.downloadUrl);
+}
+
+export async function installTheme(
+    theme: BDTheme,
+    fetchText: (url: string) => Promise<string>
+): Promise<{ urls: string[]; localFile?: string; }> {
+    let pageSource: string | null = null;
+    const pageUrls = [
+        theme.pageUrl,
+        theme.pageUrl.replace("/themes/", "/theme/"),
+    ];
+    for (const pageUrl of [...new Set(pageUrls)]) {
+        try {
+            const pageHtml = await fetchText(pageUrl);
+            pageSource = parseThemePageSource(pageHtml);
+            if (pageSource) break;
+        } catch (e) {
+            console.warn("[OnlineThemeInstaller] theme page fetch failed:", pageUrl, e);
+        }
+    }
+
+    const css = await fetchText(theme.downloadUrl);
+    const resolved = resolveThemeStylesheetUrls(css, pageSource);
+    const map = getInstallMap();
+    const key = String(theme.id);
+
+    if (resolved.urls.length) {
+        const links = getInstalledThemeUrls().filter(link => link !== theme.downloadUrl);
+        const merged = [...new Set([...links, ...resolved.urls])];
+        Settings.themeLinks = merged;
+
+        map[key] = { urls: resolved.urls };
+        setInstallMap(map);
+
+        return { urls: resolved.urls };
+    }
+
+    if (!resolved.saveLocal) {
+        throw new Error("Could not find a stylesheet URL in this theme. Open its store page and add the CSS link manually.");
+    }
+
+    const native = getNative();
+    if (!native?.saveThemeFile) {
+        throw new Error("Could not save theme locally. Rebuild Vencord and run pnpm inject, then restart Discord.");
+    }
+
+    const fileName = sanitizeFileName(theme.name, theme.id);
+    await native.saveThemeFile(fileName, css);
+
+    const enabled = Settings.enabledThemes ?? [];
+    if (!enabled.includes(fileName)) {
+        Settings.enabledThemes = [...enabled, fileName];
+    }
+
+    map[key] = { urls: [], localFile: fileName };
+    setInstallMap(map);
+
+    return { urls: [], localFile: fileName };
+}
+
+export function uninstallTheme(theme: BDTheme): void {
+    const map = getInstallMap();
+    const key = String(theme.id);
+    const record = map[key];
+
+    let links = getInstalledThemeUrls();
+
+    if (record) {
+        if (record.urls.length) {
+            links = links.filter(link => !record.urls.includes(link));
+        }
+        if (record.localFile) {
+            Settings.enabledThemes = (Settings.enabledThemes ?? []).filter(f => f !== record.localFile);
+            const native = getNative();
+            void native?.deleteThemeFile?.(record.localFile);
+        }
+        delete map[key];
+        setInstallMap(map);
+    } else {
+        links = links.filter(link => link !== theme.downloadUrl);
+    }
+
+    Settings.themeLinks = links;
+}

--- a/src/plugins/onlineThemeInstaller/types.ts
+++ b/src/plugins/onlineThemeInstaller/types.ts
@@ -1,0 +1,38 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2025 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export interface BDTheme {
+    id: number;
+    name: string;
+    slug: string;
+    description: string;
+    author: string;
+    tags: string[];
+    downloads: string;
+    likes: string;
+    thumbnailUrl: string | null;
+    pageUrl: string;
+    downloadUrl: string;
+}
+
+export const BD_THEMES_PAGE = "https://betterdiscord.app/themes";
+export const BD_THEME_STORE = BD_THEMES_PAGE;
+
+export function themeDownloadUrl(id: number): string {
+    return `https://betterdiscord.app/download?id=${id}`;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -381,6 +381,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "blahaj.zip",
         id: 683954422241427471n,
     },
+    bulwarked: {
+        name: "0xbulwarked",
+        id: 148190966929424385n,
+    },
     archeruwu: {
         name: "archer_uwu",
         id: 160068695383736320n


### PR DESCRIPTION
## Summary

Adds **OnlineThemeInstaller** — browse the [BetterDiscord theme store](https://betterdiscord.app/themes) and install themes into Vencord's **Online Themes** with one click. Resolves stylesheet URLs from GitHub source / `@import` when available.

## Test plan

- [x] Built with `pnpm build` and injected on Discord Stable
- [x] Enabled plugin, opened theme browser, installed and removed a theme
- [x] Verified themes appear under Settings → Themes → Online Themes

Here are some pictures.
<img width="1135" height="901" alt="image" src="https://github.com/user-attachments/assets/b18fde50-6d5e-460e-bda4-97c1b864a333" />
<img width="676" height="932" alt="image" src="https://github.com/user-attachments/assets/9c2ebdbf-e821-4650-b866-bbf9808cf979" />
<img width="1827" height="827" alt="image" src="https://github.com/user-attachments/assets/5368505d-fc81-4d60-9ffa-790e5bac11b0" />



