### PR TITLE
fix(gameActivityToggle): prevent settings gear from overlapping narro…

### DIFF
--- a/src/plugins/gameActivityToggle/style.css
+++ b/src/plugins/gameActivityToggle/style.css
@@ -1,3 +1,7 @@
 [class*="panels"] [class*="avatarWrapper"] {
     min-width: 0;
 }
+
+[class*="panels"] [class*="accountButtons"] {
+    flex-shrink: 0;
+}


### PR DESCRIPTION
Issue:
Resizing the sidebar to a narrow width causes the bottom account controls to compress, making the settings gear icon overlap or disappear.

Fix:
Prevented the account button group from shrinking while allowing the avatar/user section to absorb width compression.

Fixes #4125