### PR TITLE
Experiments: improve settings UI

### DIFF
--- a/src/plugins/experiments/index.tsx
+++ b/src/plugins/experiments/index.tsx
@@ -140,8 +140,8 @@ export default definePlugin({
                 <Paragraph size="md">
                     You can open Discord's DevTools via {" "}
                     <div className={KbdStyles.combo} style={{ display: "inline-flex" }}>
-                        <kbd className={KbdStyles.key}>{modKey}</kbd> +{" "}
-                        <kbd className={KbdStyles.key}>{altKey}</kbd> +{" "}
+                        <kbd className={KbdStyles.key}>{modKey}</kbd> {" "}
+                        <kbd className={KbdStyles.key}>{altKey}</kbd> {" "}
                         <kbd className={KbdStyles.key}>O</kbd>{" "}
                     </div>
                 </Paragraph>

--- a/src/plugins/experiments/index.tsx
+++ b/src/plugins/experiments/index.tsx
@@ -140,8 +140,8 @@ export default definePlugin({
                 <Paragraph size="md">
                     You can open Discord's DevTools via {" "}
                     <div className={KbdStyles.combo} style={{ display: "inline-flex" }}>
-                        <kbd className={KbdStyles.key}>{modKey}</kbd> {" "}
-                        <kbd className={KbdStyles.key}>{altKey}</kbd> {" "}
+                        <kbd className={KbdStyles.key}>{modKey}</kbd>{" "}
+                        <kbd className={KbdStyles.key}>{altKey}</kbd>{" "}
                         <kbd className={KbdStyles.key}>O</kbd>{" "}
                     </div>
                 </Paragraph>


### PR DESCRIPTION
Discord writes shortcuts as keyboard keys one after another, like "CTRL K" with its own styling. The plugin description already uses this styling but it combines it with the plus symbol, like you do in text, e.g. CTRL+K. 

However, Discord doesn't use the plus sign when displaying keybinds, as the custom display buttons make this intuitively unnecessary, so this change just standardizes that display to be more in line with other Discord menus. See imgur link below for comparison.

https://imgur.com/a/kDybW16

Super minor thing, but I thought I'd point it out. Found in the description of the Experiments plugin.