### PR TITLE
fix(PermissionsViewer): View Role Members not working

### DIFF
--- a/src/plugins/betterRoleContext/index.tsx
+++ b/src/plugins/betterRoleContext/index.tsx
@@ -82,9 +82,13 @@ interface RoleMemberPopoutProps {
     channelId: string;
     roleId: string;
 }
-type RoleMemberPopout = ComponentType<RoleMemberPopoutProps>;
+export type RoleMemberPopout = ComponentType<RoleMemberPopoutProps>;
 
 let RoleMemberPopout: RoleMemberPopout = () => null;
+
+export function setRoleMemberPopout(component: RoleMemberPopout) {
+    RoleMemberPopout = component;
+}
 
 export function buildExtraRoleContextMenuItems(role: Role, guild: Guild, popoutRef?: React.RefObject<any>) {
     if (!role) return { before: [], after: [] };
@@ -184,7 +188,7 @@ export default definePlugin({
         find: ".ROLE_MENTION)",
         replacement: {
             match: /function (\i)(?=.+?renderPopout:.{0,20}\1,\{guildId:\i,channelId:\i)/,
-            replace: "$self.RoleMembers=$1;$&"
+            replace: "$self.setRoleMemberPopout($1);$&"
         }
     }],
 
@@ -193,9 +197,7 @@ export default definePlugin({
         DeveloperMode.updateSetting(true);
     },
 
-    set RoleMembers(component: RoleMemberPopout) {
-        RoleMemberPopout = component;
-    },
+    setRoleMemberPopout,
 
     contextMenus: {
         "dev-context"(children, { id }: { id: string; }) {

--- a/src/plugins/permissionsViewer/index.tsx
+++ b/src/plugins/permissionsViewer/index.tsx
@@ -23,6 +23,7 @@ import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { SafetyIcon } from "@components/Icons";
 import { TooltipContainer } from "@components/TooltipContainer";
+import { setRoleMemberPopout } from "@plugins/betterRoleContext";
 import { Devs } from "@utils/constants";
 import { classes } from "@utils/misc";
 import definePlugin, { OptionType } from "@utils/types";
@@ -171,8 +172,17 @@ export default definePlugin({
                 match: /(?<=\i\.id\)\),\i\(\))(?=,\i\?)/,
                 replace: ",$self.ViewPermissionsButton(arguments[0])"
             }
+        },
+        {
+            find: ".ROLE_MENTION)",
+            replacement: {
+                match: /function (\i)(?=.+?renderPopout:.{0,20}\1,\{guildId:\i,channelId:\i)/,
+                replace: "$self.setRoleMemberPopout($1);$&"
+            }
         }
     ],
+
+    setRoleMemberPopout,
 
     ViewPermissionsButton: ErrorBoundary.wrap(({ className, guild, userId }: { className: string; guild: Guild; userId: string; }) => {
         const buttonRef = useRef(null);


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
The "View Role Members" button didn't work because PermissionsViewer relied on the RoleMemberPopout patch from BetterRoleContext. If BetterRoleContext was disabled, the popout rendered empty.

Duplicated the patch in PermissionsViewer so it works independently.
## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
