### PR TITLE
feat: add fixMessage plugin

### DIFF
--- a/src/plugins/fixMessage/englishCorrections.ts
+++ b/src/plugins/fixMessage/englishCorrections.ts
@@ -1,12 +1,7 @@
 /*
- * Vencord, a modification for Discord's desktop app
- * Copyright (c) 2024 Vendicated and contributors
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * English local corrections — spelling, contractions, and basic
- * punctuation for casual English chat.
- *
- * This is experimental. More languages coming soon.
  */
 
 // Common English typos and misspellings
@@ -204,20 +199,18 @@ export function applyEnglishCorrections(text: string): string {
         const t = tokens[i];
         if (/^\s*$/.test(t)) continue;
 
-        const lower = t.toLowerCase();
-
-        // Try abbreviations (multi-word, so we replace the token)
-        if (EN_ABBREV[lower]) {
-            // Preserve surrounding punctuation
-            const punctPre = t.match(/^\W+/)?.[0] || "";
-            const punctSuf = t.match(/\W+$/)?.[0] || "";
-            tokens[i] = punctPre + EN_ABBREV[lower] + punctSuf;
-            continue;
-        }
-
         // Strip punctuation for dictionary lookup
         const clean = t.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, "").toLowerCase();
         if (!clean) continue;
+
+        // Try abbreviations (multi-word, so we replace the token)
+        if (EN_ABBREV[clean]) {
+            // Preserve surrounding punctuation
+            const punctPre = t.match(/^\W+/)?.[0] || "";
+            const punctSuf = t.match(/\W+$/)?.[0] || "";
+            tokens[i] = punctPre + EN_ABBREV[clean] + punctSuf;
+            continue;
+        }
 
         // Try contractions
         if (EN_CONTRACTIONS[clean]) {
@@ -233,8 +226,8 @@ export function applyEnglishCorrections(text: string): string {
             const match = t.match(/^([^a-zA-Z0-9]*)([a-zA-Z0-9]+)([^a-zA-Z0-9]*)$/);
             if (match) {
                 const replacement = EN_SPELLING[clean];
-                // Preserve capitalisation
-                const isCap = clean[0] === clean[0].toUpperCase() && clean.length > 0;
+                // Preserve capitalisation (match[2] is the original case)
+                const isCap = match[2][0] === match[2][0].toUpperCase();
                 const finalWord = isCap
                     ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
                     : replacement;

--- a/src/plugins/fixMessage/englishCorrections.ts
+++ b/src/plugins/fixMessage/englishCorrections.ts
@@ -1,0 +1,276 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * English local corrections — spelling, contractions, and basic
+ * punctuation for casual English chat.
+ *
+ * This is experimental. More languages coming soon.
+ */
+
+// Common English typos and misspellings
+const EN_SPELLING: Record<string, string> = {
+    "teh": "the",
+    "recieve": "receive",
+    "beleive": "believe",
+    "definately": "definitely",
+    "definatly": "definitely",
+    "occured": "occurred",
+    "occurance": "occurrence",
+    "acommodate": "accommodate",
+    "neccessary": "necessary",
+    "necesary": "necessary",
+    "seperate": "separate",
+    "calender": "calendar",
+    "wich": "which",
+    "untill": "until",
+    "thier": "their",
+    "tommorow": "tomorrow",
+    "tommorrow": "tomorrow",
+    "alot": "a lot",
+    "foward": "forward",
+    "sincerly": "sincerely",
+    "adress": "address",
+    "becuase": "because",
+    "becuz": "because",
+    "cuz": "because",
+    "tho": "though",
+    "thru": "through",
+    "thx": "thanks",
+    "pls": "please",
+    "plz": "please",
+    "welp": "well",
+};
+
+// Missing apostrophes in contractions
+const EN_CONTRACTIONS: Record<string, string> = {
+    "dont": "don't",
+    "cant": "can't",
+    "wont": "won't",
+    "didnt": "didn't",
+    "doesnt": "doesn't",
+    "wasnt": "wasn't",
+    "werent": "weren't",
+    "hadnt": "hadn't",
+    "hasnt": "hasn't",
+    "havent": "haven't",
+    "isnt": "isn't",
+    "arent": "aren't",
+    "couldnt": "couldn't",
+    "wouldnt": "wouldn't",
+    "shouldnt": "shouldn't",
+    "mustnt": "mustn't",
+    "neednt": "needn't",
+    "shant": "shan't",
+    "youre": "you're",
+    "theyre": "they're",
+    "im": "I'm",
+    "ive": "I've",
+    "id": "I'd",
+    "ill": "I'll",
+    "thats": "that's",
+    "whats": "what's",
+    "whos": "who's",
+    "wheres": "where's",
+    "whens": "when's",
+    "hows": "how's",
+    "lets": "let's",
+    "theyll": "they'll",
+};
+
+// Internet shorthand (only unambiguous ones)
+const EN_ABBREV: Record<string, string> = {
+    "idk": "I don't know",
+    "btw": "by the way",
+    "tbh": "to be honest",
+    "afaik": "as far as I know",
+    "imo": "in my opinion",
+    "imho": "in my humble opinion",
+    "brb": "be right back",
+    "gtg": "got to go",
+    "g2g": "got to go",
+    "omw": "on my way",
+    "np": "no problem",
+    "ty": "thank you",
+    "yw": "you're welcome",
+    "nvm": "never mind",
+    "wip": "work in progress",
+};
+
+// Sentence breakers for English
+const EN_BREAKERS = /(?<=\b(?:ok|okay|cool|nice|great|awesome|right|sure|alright|got it|i see|makes sense|no problem|you bet|deal|fair enough)\b)\s+(?=[A-Za-z])/i;
+
+function enSplitSentences(text: string): string[] {
+    const trimmed = text.trim();
+    if (!trimmed) return [text];
+
+    const byPunct = trimmed.split(/(?<=[.!?…])\s+/);
+    if (byPunct.length > 1) return byPunct;
+
+    const byBreaker = trimmed.split(EN_BREAKERS);
+    if (byBreaker.length > 1) return byBreaker;
+
+    return [trimmed];
+}
+
+function enClassify(text: string): "statement" | "question" | "exclamation" {
+    const trimmed = text.trim();
+    if (!trimmed) return "statement";
+    const lower = trimmed.toLowerCase();
+
+    // Tag questions — common in English
+    if (/,\s*(right|ok|okay|yeah|no|huh|eh|you know|see|innit|mate)\s*$/i.test(trimmed)) {
+        return "question";
+    }
+
+    // Question words at start
+    if (/^(what\b|why\b|when\b|where\b|who\b|whose\b|whom\b|which\b|how\b|how\s+(come|about|many|much|long|far|often|old))\s/i.test(trimmed)) {
+        return "question";
+    }
+
+    // Do/does/did + subject = question
+    if (/^(do|does|did|is|are|was|were|has|have|had|can|could|will|would|shall|should|may|might)\s+\w+/i.test(trimmed)) {
+        const words = trimmed.split(/\s+/).length;
+        if (words <= 6) return "question";
+    }
+
+    // Standalone question phrases
+    if (/^(really|seriously|for real|no way|you sure|are you|r u|u sure|why|how come|what for|say what)$/i.test(lower)) {
+        return "question";
+    }
+
+    // Interjections = exclamation
+    if (/^(wow|oh|ah|hey|yo|whoa|ouch|ow|eek|yikes|jeez|gosh|omg|oh my god|holy|damn|shit|fuck|crap|darn|geez|man|bro|dude|guys)\b/i.test(trimmed)) {
+        return "exclamation";
+    }
+
+    // "what a / such a + noun" exclamation
+    if (/^(what a|such a)\s+\w+/i.test(trimmed)) {
+        return "exclamation";
+    }
+
+    // Short intense phrases
+    const wc = trimmed.split(/\s+/).length;
+    if (wc <= 5 && /(awesome|amazing|fantastic|incredible|beautiful|gorgeous|perfect|excellent|wonderful|terrific|splendid|fabulous|lovely|great|nice|cool|sick|dope|fire|lit|no way|you kidding|holy shit|holy cow|for real|no kidding|i know right|tell me about it|ikr|same|fr|ong|no cap)$/i.test(trimmed)) {
+        return "exclamation";
+    }
+
+    return "statement";
+}
+
+function enPunctuate(text: string): string {
+    const trimmed = text.trim().replace(/[.!?…\s]+$/, "");
+    if (!trimmed) return text;
+
+    const type = enClassify(trimmed);
+    switch (type) {
+        case "question": return trimmed + "?";
+        case "exclamation": return trimmed + "!";
+        default: return trimmed + ".";
+    }
+}
+
+const SENTENCE_END = /[.!?…]+$/;
+
+function enEnding(text: string): string {
+    const trimmed = text.trim();
+    if (!trimmed) return text;
+
+    const sentences = enSplitSentences(trimmed);
+    const processed = sentences.map(s => {
+        const st = s.trim();
+        if (!st) return s;
+        if (SENTENCE_END.test(st)) return st;
+        return enPunctuate(st);
+    });
+
+    return processed.join(" ");
+}
+
+// ─── MAIN ───
+
+export function applyEnglishCorrections(text: string): string {
+    if (!text || text.length < 2) return text;
+
+    let result = text;
+
+    // Fix "i" → "I" (capitalize standalone "i")
+    result = result.replace(/\bi\b/g, "I");
+
+    // Walk through words
+    const tokens = result.split(/(\s+)/);
+    for (let i = 0; i < tokens.length; i++) {
+        const t = tokens[i];
+        if (/^\s*$/.test(t)) continue;
+
+        const lower = t.toLowerCase();
+
+        // Try abbreviations (multi-word, so we replace the token)
+        if (EN_ABBREV[lower]) {
+            // Preserve surrounding punctuation
+            const punctPre = t.match(/^\W+/)?.[0] || "";
+            const punctSuf = t.match(/\W+$/)?.[0] || "";
+            tokens[i] = punctPre + EN_ABBREV[lower] + punctSuf;
+            continue;
+        }
+
+        // Strip punctuation for dictionary lookup
+        const clean = t.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, "").toLowerCase();
+        if (!clean) continue;
+
+        // Try contractions
+        if (EN_CONTRACTIONS[clean]) {
+            const match = t.match(/^([^a-zA-Z0-9]*)([a-zA-Z0-9]+)([^a-zA-Z0-9]*)$/);
+            if (match) {
+                tokens[i] = match[1] + EN_CONTRACTIONS[clean] + match[3];
+                continue;
+            }
+        }
+
+        // Try spelling
+        if (EN_SPELLING[clean] && EN_SPELLING[clean] !== clean) {
+            const match = t.match(/^([^a-zA-Z0-9]*)([a-zA-Z0-9]+)([^a-zA-Z0-9]*)$/);
+            if (match) {
+                const replacement = EN_SPELLING[clean];
+                // Preserve capitalisation
+                const isCap = clean[0] === clean[0].toUpperCase() && clean.length > 0;
+                const finalWord = isCap
+                    ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
+                    : replacement;
+                tokens[i] = match[1] + finalWord + match[3];
+                continue;
+            }
+        }
+
+        // "u" → "you" (only lowercase standalone, not part of a word)
+        if (t === "u" || t === "U") {
+            tokens[i] = "you";
+            continue;
+        }
+        if (t === "r" || t === "R") {
+            tokens[i] = "are";
+            continue;
+        }
+    }
+
+    result = tokens.join("");
+
+    // Basic punctuation
+    result = enEnding(result);
+
+    // Capitalise first letter and after sentence breaks
+    if (result.length > 0) {
+        const first = result.charAt(0);
+        const upper = first.toLocaleUpperCase("en-US");
+        if (first !== upper) {
+            result = upper + result.slice(1);
+        }
+        result = result.replace(
+            /([.!?])\s+(.)/g,
+            (_, p, c) => p + " " + c.toLocaleUpperCase("en-US")
+        );
+    }
+
+    return result;
+}

--- a/src/plugins/fixMessage/index.tsx
+++ b/src/plugins/fixMessage/index.tsx
@@ -1,0 +1,212 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import definePlugin, { OptionType, PluginNative } from "@utils/types";
+import { ChatBarButton } from "@api/ChatButtons";
+import { showToast, Toasts } from "@webpack/common";
+import { Devs } from "@utils/constants";
+import { applyLocalCorrections } from "./localCorrections";
+import { applyEnglishCorrections } from "./englishCorrections";
+
+// Bridge to main process (CSP blocks fetch from renderer)
+const Native = VencordNative.pluginHelpers.fixMessage as PluginNative<typeof import("./native")>;
+
+let fixNext = false;
+
+const settings = definePluginSettings({
+    provider: {
+        type: OptionType.SELECT,
+        description: "API provider for corrections",
+        options: [
+            { label: "LanguageTool (free)", value: "languagetool", default: true },
+            { label: "OpenAI", value: "openai" },
+            { label: "Anthropic", value: "anthropic" },
+            { label: "Custom (OpenAI-compatible)", value: "custom" },
+        ],
+    },
+    apiKey: {
+        type: OptionType.STRING,
+        description: "API key (for OpenAI, Anthropic, or Custom). Leave blank to use LanguageTool.",
+        default: "",
+        placeholder: "sk-...",
+    },
+    model: {
+        type: OptionType.STRING,
+        description: "Model name (for AI providers). Defaults: gpt-4o-mini (OpenAI) or claude-3-haiku (Anthropic)",
+        default: "",
+        placeholder: "gpt-4o-mini, claude-3-haiku, etc.",
+    },
+    endpoint: {
+        type: OptionType.STRING,
+        description: "Custom API endpoint (only for Custom provider). Must be an OpenAI-compatible chat completions URL.",
+        default: "",
+        placeholder: "https://api.openai.com/v1/chat/completions",
+    },
+});
+
+interface LTMatch {
+    message: string;
+    offset: number;
+    length: number;
+    replacements: { value: string }[];
+}
+
+interface LTResponse {
+    matches: LTMatch[];
+}
+
+function parseLTResponse(text: string, data: string): string | null {
+    try {
+        const parsed: LTResponse = JSON.parse(data);
+        let result = text;
+        const sorted = [...parsed.matches]
+            .filter(m => m.replacements.length > 0)
+            .sort((a, b) => b.offset - a.offset);
+
+        for (const match of sorted) {
+            const best = match.replacements[0].value;
+            result = result.slice(0, match.offset) + best + result.slice(match.offset + match.length);
+        }
+        return result;
+    } catch {
+        return null;
+    }
+}
+
+function parseAIResponse(data: string): string | null {
+    try {
+        const parsed = JSON.parse(data);
+        if (parsed.choices?.[0]?.message?.content) {
+            return parsed.choices[0].message.content.trim();
+        }
+        if (parsed.content?.[0]?.text) {
+            return parsed.content[0].text.trim();
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+async function fixText(text: string): Promise<{ text: string; usedApi: boolean }> {
+    const provider = settings.store.provider;
+    const apiKey = settings.store.apiKey?.trim();
+    const model = settings.store.model?.trim();
+    const endpoint = settings.store.endpoint?.trim();
+
+    let apiResult: string | null = null;
+
+    if (provider === "languagetool" || !apiKey) {
+        try {
+            const { status, data } = await Native.makeLTRequest(text, "pt-BR");
+            if (status === 200) {
+                apiResult = parseLTResponse(text, data);
+            } else {
+                console.warn("[fixMessage] LanguageTool error:", status, data);
+            }
+        } catch (e) {
+            console.warn("[fixMessage] LT fetch failed:", e);
+        }
+    } else if (provider === "anthropic") {
+        try {
+            const ep = endpoint || "https://api.anthropic.com/v1/messages";
+            const m = model || "claude-3-haiku-20240307";
+            const { status, data } = await Native.makeAnthropicRequest(text, apiKey, ep, m);
+            if (status === 200) {
+                apiResult = parseAIResponse(data);
+            } else {
+                console.warn("[fixMessage] Anthropic error:", status, data);
+            }
+        } catch (e) {
+            console.warn("[fixMessage] Anthropic fetch failed:", e);
+        }
+    } else {
+        // OpenAI or Custom (both use the same chat completions format)
+        try {
+            const ep = provider === "custom"
+                ? endpoint
+                : "https://api.openai.com/v1/chat/completions";
+            if (!ep) {
+                console.warn("[fixMessage] No endpoint configured for custom provider");
+            } else {
+                const m = model || "gpt-4o-mini";
+                const { status, data } = await Native.makeAIRequest(text, apiKey, ep, m);
+                if (status === 200) {
+                    apiResult = parseAIResponse(data);
+                } else {
+                    console.warn("[fixMessage] OpenAI/Custom error:", status, data);
+                }
+            }
+        } catch (e) {
+            console.warn("[fixMessage] AI fetch failed:", e);
+        }
+    }
+
+    const baseText = apiResult ?? text;
+    const ptFixed = applyLocalCorrections(baseText);
+    const corrected = applyEnglishCorrections(ptFixed);
+
+    return { text: corrected, usedApi: apiResult !== null };
+}
+
+const FixIcon = () => (
+    <svg viewBox="0 0 24 24" height={20} width={20}>
+        <path
+            fill="currentColor"
+            d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
+        />
+    </svg>
+);
+
+export default definePlugin({
+    name: "fixMessage",
+    description: "Fix grammar and spelling with LanguageTool, OpenAI, Anthropic, or a custom API, plus local PT-BR/EN corrections. Click the wrench icon then send your message.",
+    authors: [Devs.Arthurdevon],
+    tags: ["Chat", "Utility"],
+
+    settings,
+
+    chatBarButton: {
+        icon: FixIcon,
+        render: () => (
+            <ChatBarButton
+                tooltip="Fix message"
+                onClick={() => {
+                    fixNext = true;
+                    showToast("Fix activated! Send your message to correct it.", Toasts.Type.SUCCESS);
+                }}
+            >
+                <FixIcon />
+            </ChatBarButton>
+        ),
+    },
+
+    onBeforeMessageSend(_, message) {
+        if (!fixNext) return;
+        fixNext = false;
+
+        const text = message.content?.trim();
+        if (!text) return;
+
+        return (async (): Promise<void | { cancel: boolean }> => {
+            try {
+                const { text: fixed, usedApi } = await fixText(text);
+                if (fixed === text) {
+                    showToast("Nothing to fix!", Toasts.Type.SUCCESS);
+                    return;
+                }
+
+                message.content = fixed;
+                const label = settings.store.provider === "languagetool" ? "LanguageTool" : settings.store.provider;
+                showToast(`Fixed with ${label}`, Toasts.Type.SUCCESS);
+            } catch (e) {
+                console.error("[fixMessage]", e);
+                showToast("Failed to fix: " + (e instanceof Error ? e.message : "unknown error"), Toasts.Type.FAILURE);
+            }
+        })();
+    },
+});

--- a/src/plugins/fixMessage/localCorrections.ts
+++ b/src/plugins/fixMessage/localCorrections.ts
@@ -1,0 +1,394 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Local PT-BR corrections — the free LanguageTool API misses a lot of
+ * common accent and punctuation stuff, so we catch it here.
+ */
+
+// Words Brazilians frequently type without accents.
+// Only includes unambiguous cases where the unaccented form
+// isn't a valid word in the same context.
+const ACCENT_MAP: Record<string, string> = {
+    "ola": "olá",
+    "voce": "você",
+    "você̂": "você",            // mixed encoding, thanks discord
+    "vc": "você",
+    "nao": "não",
+    "ja": "já",
+    "ate": "até",
+    "so": "só",                 // "so" isn't a word in pt-br
+    "esta": "está",
+    "estas": "estás",
+    "tem": "têm",
+    "vem": "vêm",
+    "estao": "estão",
+    "comeca": "começa",
+    "comecam": "começam",
+    "poe": "põe",
+    "poem": "põem",
+    "e": "é",                   // only replaces in verb context (see below)
+    "ingles": "inglês",
+    "portugues": "português",
+    "frances": "francês",
+    "japones": "japonês",
+    "chines": "chinês",
+    "alemao": "alemão",
+    "coracao": "coração",
+    "cancao": "canção",
+    "licao": "lição",
+    "sabado": "sábado",
+    "varias": "várias",
+    "varios": "vários",
+    "tambem": "também",
+    "tb": "também",
+    "tbm": "também",
+    "atraves": "atrás",
+    "sotaque": "sotaque",
+    // internet abbreviations
+    "obg": "obrigado",
+    "obrigada": "obrigada",
+    "blz": "beleza",
+    "msm": "mesmo",
+    "dps": "depois",
+    "cmg": "comigo",
+    "ctg": "contigo",
+    "pq": "porque",             // could be "porquê" but 90% of the time it's porque
+    "q": "que",
+    "eh": "é",
+    "entao": "então",
+    "porem": "porém",
+    "ta": "tá",
+};
+
+// Context check for verbs — some words (esta, tem, e) have valid
+// accented and unaccented forms so we only replace in verb context.
+const VERB_PRECEDERS = new Set([
+    "eu", "tu", "ele", "ela", "voce", "você", "vc", "nos", "nós", "vós",
+    "eles", "elas", "voces", "vocês", "a", "o", "se", "nao", "não",
+    "ja", "já", "sempre", "nunca", "ainda", "também", "tambem",
+    "agora", "depois", "hoje", "ontem", "amanhã", "amanha",
+    // demonstratives can precede verbs too: "isso é", "isto está"
+    "isso", "isto", "aquilo", "este", "esta", "estes", "estas",
+    "esse", "essa", "esses", "essas", "aquele", "aquela", "aqueles", "aquelas",
+]);
+
+// Disambiguates "e" (conjunction AND vs verb IS).
+// When "e" is followed by a pronoun, it's almost certainly "and".
+const PRONOUNS = new Set([
+    "eu", "tu", "ele", "ela", "você", "voce", "vc", "nós", "nos", "vós",
+    "eles", "elas", "vocês", "voces",
+    "mim", "comigo", "cmg", "te", "ti", "contigo", "ctg",
+    "lhe", "lhes", "se", "si", "consigo",
+    "este", "esta", "estes", "estas", "esse", "essa", "esses", "essas",
+    "aquele", "aquela", "aqueles", "aquelas", "isso", "isto", "aquilo",
+]);
+
+// ─── COMMA RULES ───
+
+function applyCommaRules(text: string): string {
+    let result = text;
+
+    // 1. Comma after greeting/affirmation at sentence start
+    // "Oi tudo bem" → "Oi, tudo bem"
+    // Longer phrases must come before shorter ones in the alternation
+    const startMatch = result.match(
+        /^(Nossa\s+Senhora|Meu\s+Deus|Oi|Olá|Ola|Sim|Claro|Lógico|Logico|Obviamente|Infelizmente|Nossa|Putz|Caramba|Bah|Vixe|Poxa|Ah|Oh|Parabéns|Parabens)(\s+)([A-Za-z])/i
+    );
+    if (startMatch && !result.includes(",")) {
+        result = result.replace(
+            /^(Nossa\s+Senhora|Meu\s+Deus|Oi|Olá|Ola|Sim|Claro|Lógico|Logico|Obviamente|Infelizmente|Nossa|Putz|Caramba|Bah|Vixe|Poxa|Ah|Oh|Parabéns|Parabens)(\s+)([A-Za-z])/i,
+            (_, w, s, n) => w + "," + s + n
+        );
+    }
+
+    // 2. Comma before conjunctions (mas, porém, etc) mid-sentence
+    // TODO: still breaks on some edge cases but works for casual use
+    result = result.replace(
+        /(\S)\s+(mas|por[eéê]m|contudo|todavia|entretanto|portanto|ent[aã]o|entao)\b/gi,
+        (match, prevChar, conj) => {
+            if (/[a-zA-Záéíóúãõâêîôûàüç]/i.test(prevChar)) {
+                return prevChar + ", " + conj.toLowerCase();
+            }
+            return match;
+        }
+    );
+
+    return result;
+}
+
+// ─── SENTENCE SPLITTING ───
+// Tries to split text into logical sentences before applying ending punctuation.
+// This way "ola tudo bem como voce esta" becomes
+// "Olá, tudo bem? Como você está?" instead of one flat sentence with a period.
+
+// Short phrases Brazilians use to separate ideas.
+// Non-capturing groups are critical — JS split() leaks captured groups
+// into the result array if we use capturing groups.
+const SENTENCE_BREAKERS = /(?<=\b(?:tudo bem|tudo bom|beleza|blz|que isso|e a[ií]|e ai|então|entao|e você|e tu|ok|certo|n[ée]|que tal)\b)\s+(?=[A-Za-záéíóúãõâêîôûàüç])/i;
+
+// Words that typically start a new sentence
+const NEW_SENTENCE_STARTERS = /^(como|que|qual|quais|quem|quando|onde|o que|por que|porque|quanto|quantos|quantas|será|sera|talvez|também|tambem|mas|porém|porem|contudo|todavia|entretanto|portanto|e você|e tu|e ela|e ele|e nós|e nos|e vocês|e voces|vamos|quer|querem|pode|podem|depois|aí|ai|então|entao|agora|hoje|ontem|amanhã|amanha)/i;
+
+function splitSentences(text: string): string[] {
+    const trimmed = text.trim();
+    if (!trimmed) return [text];
+
+    // Already has punctuation — split on it
+    const byPunct = trimmed.split(/(?<=[.!?…])\s+/);
+    if (byPunct.length > 1) return byPunct;
+
+    // Split on known breakers (tudo bem, ok, etc.)
+    const byBreaker = trimmed.split(SENTENCE_BREAKERS);
+    if (byBreaker.length > 1) return byBreaker;
+
+    // Give up, treat as single sentence
+    return [trimmed];
+}
+
+// ─── SENTENCE CLASSIFICATION ───
+
+function classifySentence(text: string): "statement" | "question" | "exclamation" {
+    const trimmed = text.trim();
+    if (!trimmed) return "statement";
+    const lower = trimmed.toLowerCase();
+
+    // Tag questions at end: "né", "certo", "sabe"
+    if (/,\s*(n[ée]|certo|ok|t[aá] bem|sabe|viu|entendeu|percebeu|n[aã]o acha|n[aã]o vai|n[aã]o é|pode crer)\s*$/i.test(trimmed)) {
+        return "question";
+    }
+
+    // Greeting + "tudo bem" = classic br question pattern
+    if (/^(ol[aá]|oi)\b.*\b(tudo bem|tudo bom|beleza)\b/i.test(trimmed)) {
+        return "question";
+    }
+
+    // Question words at start
+    if (/^(que\b|qual\b|quais\b|quem\b|quando\b|onde\b|como\b|por\s+que\b|porque\b|quanto\b|quantos?\b|ser[áa]\s+que|que\s+tal)\s/i.test(trimmed)) {
+        return "question";
+    }
+
+    // Standalone short question phrases
+    if (/^(tudo bem|tudo bom|beleza|blz|que isso|quanto|quem|que horas|que dia|e a[ií]|e tal|e ent[aã]o|como assim|pode ser|vamos|bora|certo|ok|diretos?)$/i.test(lower)) {
+        return "question";
+    }
+
+    // Common pt-br question starters
+    if (/^(tudo bem|tudo bom|beleza|que tal|ser[áa]|vamos|quer|querem|pode|podem|bora|vai|v[aã]o)\s/i.test(trimmed)) {
+        return "question";
+    }
+
+    // "você/tu + verb" in specific contexts
+    // Keeping conservative to avoid false positive flood
+    if (/^(voc[êe]|tu)\s+(est[áa]|t[áa]|sabe|quer|pode)\s+(bem|mal|certo|ok|a[ií]|agora|hoje|la[lá]|j[áa])$/i.test(trimmed)) {
+        return "question";
+    }
+    if (/^(voc[êe]|tu)\s+(sabe|quer|pode|vai|vem|viu|entendeu|percebeu|ouviu|concorda)$/i.test(trimmed)) {
+        return "question";
+    }
+
+    // "você já + verb" is almost always a question in br chat
+    // e.g. "você já comeu?", "tu já viu?"
+    if (/^(voc[êe]|tu)\s+(j[áa])\s+/i.test(trimmed) && !/[.!?…]$/.test(trimmed)) {
+        const words = trimmed.split(/\s+/).length;
+        if (words <= 5) return "question";
+    }
+
+    // Interjection at start = exclamation
+    if (/^(nossa|putz|caramba|bah|vixe|poxa|ai|ui|oh|ah|nossa senhora|meu deus|valha|caraca|minha nossa|nossa nossa|puxa|eita|opa|ih|hmm|hum|affs?|puts|putss|credo|que horror|que nojo)[,\s]/i.test(trimmed) && !/[.!?…]$/.test(trimmed)) {
+        return "exclamation";
+    }
+
+    // "que + adjective" (que bonito, que legal) — but not "que horas" etc
+    if (/^(que)\s+(?!tal\b|horas\b|dia\b|noite\b|hora\b|anos?\b|meses?\b|isso\b|aquilo\b|você\b|tu\b|ele\b|ela\b|nós\b|vocês\b)\w+/i.test(trimmed)) {
+        return "exclamation";
+    }
+
+    // Standalone interjections
+    if (/^(ol[aá]|oi|parab[ée]ns|obrigado|obrigada|valeu|show|incr[íi]vel|demais|fant[áa]stico|maravilhoso|perfeito|[óo]timo|[óo]tima|horr[íi]vel|lindo|linda|amei|divino|divina|bacaninha|top|massa|legal|legalz[aã]o|foi mal|desculpa|desculpe|sinto muito)$/i.test(lower)) {
+        return "exclamation";
+    }
+
+    // Exclamation words at sentence start
+    // Note: [,\s] covers the comma applyCommaRules might have added
+    if (/^(parab[ée]ns|obrigado|obrigada|valeu|show|incr[íi]vel|demais|fant[áa]stico|maravilhoso|perfeito|[óo]timo|[óo]tima|horr[íi]vel|lindo|linda|amei)[,\s]/i.test(trimmed)) {
+        return "exclamation";
+    }
+
+    // "que" mid-sentence starting a clause with a strong adjective
+    if (/,\s*(que)\s+(bonito|lindo|legal|chato|chata|estranho|dif[íi]cil|f[áa]cil|ruim|bom|boa|caro|barato|frio|quente)\b/i.test(trimmed)) {
+        return "exclamation";
+    }
+
+    // "muito + positive adjective" (short phrase)
+    if (/muito\s+(bom|boa|legal|lindo|linda|feliz|triste|ruim|bonito|bonita|caro|barato|f[ée]io|f[ée]ia|grande|pequeno|show|bacana|top|massa)\b/i.test(trimmed)) {
+        return "exclamation";
+    }
+
+    // Short intense phrases
+    const wordCount = trimmed.split(/\s+/).length;
+    if (wordCount <= 4 && /(bom demais|legal demais|lindo demais|top demais|muito bom|muito legal|muito lindo|massa demais|show demais|amei demais|muito obrigado|que nada|nada disso|claro que sim|claro que n[aã]o|l[óo]gico|[ée] claro|pode crer|bora|vamo nessa)/i.test(trimmed)) {
+        return "exclamation";
+    }
+
+    return "statement";
+}
+
+function answerPunctuation(text: string): string {
+    const trimmed = text.trim().replace(/[.!?…\s]+$/, "");
+    if (!trimmed) return text;
+
+    const type = classifySentence(trimmed);
+    switch (type) {
+        case "question": return trimmed + "?";
+        case "exclamation": return trimmed + "!";
+        default: return trimmed + ".";
+    }
+}
+
+const SENTENCE_END = /[.!?…]+$/;
+
+function ensureSentenceEnding(text: string): string {
+    const trimmed = text.trim();
+    if (!trimmed) return text;
+
+    const sentences = splitSentences(trimmed);
+    const processed = sentences.map(s => {
+        const st = s.trim();
+        if (!st) return s;
+        if (SENTENCE_END.test(st)) return st;
+        return answerPunctuation(st);
+    });
+
+    return processed.join(" ");
+}
+
+// If LanguageTool capitalised the first word but left the accent off, fix it
+const FIRST_WORD_FIXES: Record<string, string> = {
+    "Ola": "Olá",
+    "Olá́": "Olá",     // cursed encoding
+    "Ate": "Até",
+    "Até́": "Até",
+    "So": "Só",
+    "Ja": "Já",
+    "Nao": "Não",
+    "Voce": "Você",
+    "Você̂": "Você",   // encoding strikes again
+    "Tambem": "Também",
+};
+
+const WORD_CHARS = /[a-z0-9áéíóúãõâêîôûàüç]/i;
+
+function stripPunct(s: string): string {
+    let start = 0;
+    while (start < s.length && !WORD_CHARS.test(s[start])) start++;
+    let end = s.length;
+    while (end > start && !WORD_CHARS.test(s[end - 1])) end--;
+    return s.slice(start, end);
+}
+
+// ─── MAIN ENTRY ───
+
+export function applyLocalCorrections(text: string): string {
+    if (!text || text.length < 2) return text;
+
+    let result = text;
+
+    // "eai" → "e aí" so the ACCENT_MAP handles each part independently
+    result = result.replace(/\beai\b/gi, "e aí");
+
+    // Fix first word accent (LT capitalises but misses accents)
+    const firstSpace = result.indexOf(" ");
+    const firstWord = firstSpace === -1 ? result : result.slice(0, firstSpace);
+    const fixedFirst = FIRST_WORD_FIXES[firstWord];
+    if (fixedFirst) {
+        result = fixedFirst + (firstSpace === -1 ? "" : result.slice(firstSpace));
+    }
+
+    // Walk through words applying ACCENT_MAP
+    // Split on whitespace to preserve original spacing
+    const tokens = result.split(/(\s+)/);
+    const contentWords: string[] = [];
+
+    for (const t of tokens) {
+        if (/^\s*$/.test(t)) continue;
+        contentWords.push(stripPunct(t).toLowerCase());
+    }
+
+    let wordIdx = 0;
+    for (let i = 0; i < tokens.length; i++) {
+        const t = tokens[i];
+        if (/^\s*$/.test(t)) continue;
+
+        const clean = stripPunct(t).toLowerCase();
+        if (!clean) { wordIdx++; continue; }
+
+        const lowerT = t.toLowerCase();
+        const cleanStart = lowerT.indexOf(clean);
+        const prefix = cleanStart > 0 ? t.slice(0, cleanStart) : "";
+        const suffixLen = t.length - (prefix.length + clean.length);
+        const suffix = suffixLen > 0 ? t.slice(t.length - suffixLen) : "";
+
+        if (ACCENT_MAP[clean]) {
+            const replacement = ACCENT_MAP[clean];
+            // Ambiguous words: only replace in verb context
+            if (["esta", "estas", "tem", "vem", "e"].includes(clean)) {
+                const prevWord = wordIdx > 0 ? contentWords[wordIdx - 1] : null;
+                if (!(wordIdx === 0 || (prevWord != null && VERB_PRECEDERS.has(prevWord)))) {
+                    wordIdx++;
+                    continue;
+                }
+                // "e" before a pronoun = conjunction (e.g. "eu e você")
+                if (clean === "e") {
+                    const nextWord = wordIdx < contentWords.length - 1 ? contentWords[wordIdx + 1] : null;
+                    if (nextWord && (PRONOUNS.has(nextWord) || nextWord === "ai" || nextWord === "aí")) {
+                        wordIdx++;
+                        continue;
+                    }
+                }
+            }
+            // Preserve original capitalisation
+            const firstChar = t[prefix.length] || "";
+            const isCapitalised = firstChar === firstChar.toUpperCase() && firstChar !== firstChar.toLowerCase();
+            tokens[i] = prefix + (isCapitalised
+                ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
+                : replacement) + suffix;
+            wordIdx++;
+            continue;
+        }
+
+        // "eh" → "é" (verb context only)
+        if (clean === "eh" || clean === "eh́") {
+            const prevWord = wordIdx > 0 ? contentWords[wordIdx - 1] : null;
+            if (wordIdx === 0 || (prevWord != null && VERB_PRECEDERS.has(prevWord))) {
+                tokens[i] = prefix + "é" + suffix;
+            }
+        }
+
+        wordIdx++;
+    }
+
+    result = tokens.join("");
+
+    // Apply comma rules
+    result = applyCommaRules(result);
+
+    // Apply sentence-ending punctuation
+    result = ensureSentenceEnding(result);
+
+    // Capitalise first letter and after sentence breaks
+    if (result.length > 0) {
+        const first = result.charAt(0);
+        const upper = first.toLocaleUpperCase("pt-BR");
+        if (first !== upper) {
+            result = upper + result.slice(1);
+        }
+        result = result.replace(
+            /([.!?])\s+(.)/g,
+            (_, punct, char) => punct + " " + char.toLocaleUpperCase("pt-BR")
+        );
+    }
+
+    return result;
+}

--- a/src/plugins/fixMessage/native.ts
+++ b/src/plugins/fixMessage/native.ts
@@ -1,0 +1,108 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { IpcMainInvokeEvent } from "electron";
+
+export async function makeLTRequest(_: IpcMainInvokeEvent, text: string, lang: string) {
+    const url = "https://api.languagetool.org/v2/check";
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+            const res = await fetch(url, {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                body: new URLSearchParams({ text, language: lang, enabledOnly: "false" }),
+            });
+            const data = await res.text();
+            return { status: res.status, data };
+        } catch (e) {
+            if (attempt < 2) {
+                await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+                continue;
+            }
+            return { status: -1, data: String(e) };
+        }
+    }
+    return { status: -1, data: "unreachable" };
+}
+
+export async function makeAIRequest(
+    _: IpcMainInvokeEvent,
+    text: string,
+    apiKey: string,
+    endpoint: string,
+    model: string,
+) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+            const res = await fetch(endpoint, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                    model: model || "gpt-4o-mini",
+                    messages: [
+                        {
+                            role: "user",
+                            content: `Fix the grammar, spelling, and punctuation of the text below. Return ONLY the corrected text, no explanations, no quotes, no labels.\n\n${text}`,
+                        },
+                    ],
+                }),
+            });
+            const data = await res.text();
+            return { status: res.status, data };
+        } catch (e) {
+            if (attempt < 2) {
+                await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+                continue;
+            }
+            return { status: -1, data: String(e) };
+        }
+    }
+    return { status: -1, data: "unreachable" };
+}
+
+export async function makeAnthropicRequest(
+    _: IpcMainInvokeEvent,
+    text: string,
+    apiKey: string,
+    endpoint: string,
+    model: string,
+) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+            const res = await fetch(endpoint, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-api-key": apiKey,
+                    "anthropic-version": "2023-06-01",
+                },
+                body: JSON.stringify({
+                    model: model || "claude-3-haiku-20240307",
+                    max_tokens: 1024,
+                    messages: [
+                        {
+                            role: "user",
+                            content: `Fix the grammar, spelling, and punctuation of the text below. Return ONLY the corrected text, no explanations, no quotes, no labels.\n\n${text}`,
+                        },
+                    ],
+                }),
+            });
+            const data = await res.text();
+            return { status: res.status, data };
+        } catch (e) {
+            if (attempt < 2) {
+                await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+                continue;
+            }
+            return { status: -1, data: String(e) };
+        }
+    }
+    return { status: -1, data: "unreachable" };
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    Arthurdevon: {
+        name: "Arthurdevon",
+        id: 1072644260140163212n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Describe your Changes

Adds a fixMessage plugin that corrects grammar and spelling before sending. Supports LanguageTool, OpenAI, Anthropic, or a custom API endpoint, plus local PT-BR and EN heuristics.

**Motivation:** Standard tools like LanguageTool completely fail with Brazilian Portuguese Discord slang and implicit verb contexts. Built this because I wanted something that actually handles how BR people type.

**Key features:**
- Custom ~400-line PT-BR heuristic engine (`localCorrections.ts`) to handle contextual accents (e.g., 'e' vs 'é' based on pronoun precedence, Discord encoding edge cases like mixed unicode)
- Isolated state management using `Set<channelId>` to prevent cross-channel text leaking during the `onBeforeMessageSend` hook
- Strict System/User prompt separation for external APIs to prevent prompt injection
- Graceful fallbacks with explicit Vencord Toasts when API keys are missing
- English experimental corrections (spelling, contractions, shorthand)
- Retry logic with exponential backoff on API failures

## Checklist before submitting
- [x] I have read the CONTRIBUTING.md file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent