### PR TITLE
fix(messageLogger): ignore deleted last chat command message

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -390,6 +390,10 @@ export default definePlugin({
                     // fix up key (edit last message) attempting to edit a deleted message
                     match: /(?<=getLastEditableMessage\(\i\)\{.{0,200}\.find\((\i)=>)/,
                     replace: "!$1.deleted &&"
+                },
+                {
+                    match: /(?<=getLastChatCommandMessage\(\i\)\{.{0,200}\.find\((\i)=>)/,
+                    replace: "!$1.deleted &&"
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- skip deleted messages when resolving the last chat-command target
- prevent `+<EMOJI>` from attempting to react to a deleted cached message

## Root cause
`MessageLogger` keeps deleted messages in `MessageStore`, but only `getLastEditableMessage` filtered them out. `getLastChatCommandMessage` could still return a deleted cached message, so the `+<EMOJI>` shortcut targeted it.

## Testing
- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/eslint/bin/eslint.js src/plugins/messageLogger/index.tsx`

Closes #4063