### PR TITLE
PinDMS: fix duplicate context menu ids

### DIFF
--- a/src/plugins/pinDms/components/contextMenu.tsx
+++ b/src/plugins/pinDms/components/contextMenu.tsx
@@ -18,7 +18,7 @@ function createPinMenuItem(channelId: string) {
 
     return (
         <Menu.MenuItem
-            id="pin-dm"
+            id="vc-pin-dm"
             label="Pin DMs"
         >
 
@@ -48,7 +48,7 @@ function createPinMenuItem(channelId: string) {
             {pinned && (
                 <>
                     <Menu.MenuItem
-                        id="unpin-dm"
+                        id="vc-unpin-dm"
                         label="Unpin DM"
                         color="danger"
                         action={() => removeChannelFromCategory(channelId)}


### PR DESCRIPTION
so instead of integrating this plugin with discords pinning system I thought it would be a great idea to fix overlapping ids because it annoyed me
<img width="290" height="232" alt="image" src="https://github.com/user-attachments/assets/b6241f85-3305-4308-b419-df1a96640860" />

