### PR TITLE
BetterRoleContext: support role headers in member list

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -82,6 +82,31 @@ export function CopyIcon(props: IconProps) {
 }
 
 /**
+ * Discord's ID icon, as seen in Developer Mode "Copy ID" context menu items
+ */
+export function CopyIdIcon(props: IconProps) {
+    return (
+        <Icon
+            {...props}
+            className={classes(props.className, "vc-copy-id-icon")}
+            viewBox="0 0 24 24"
+        >
+            <path
+                fill="currentColor"
+                d="M15.3 14.48c-.46.45-1.08.67-1.86.67h-1.39V9.2h1.39c.78 0 1.4.22 1.86.67.46.45.68 1.22.68 2.31 0 1.1-.22 1.86-.68 2.31Z"
+            />
+            <path
+                fill="currentColor"
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M5 2a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V5a3 3 0 0 0-3-3H5Zm1 15h2.04V7.34H6V17Zm4-9.66V17h3.44c1.46 0 2.6-.42 3.38-1.25.8-.83 1.2-2.02 1.2-3.58s-.4-2.75-1.2-3.58c-.79-.83-1.92-1.25-3.38-1.25H10Z"
+            />
+        </Icon>
+    );
+}
+
+
+/**
  * Discord's open external icon, as seen in the user profile connections
  */
 export function OpenExternalIcon(props: IconProps) {

--- a/src/plugins/betterRoleContext/README.md
+++ b/src/plugins/betterRoleContext/README.md
@@ -1,6 +1,6 @@
 # BetterRoleContext
 
-Adds options to copy role color, edit role and view role icon when right clicking roles in the user profile
+Adds options to copy role color, edit role and view role icon when right clicking roles in the user profile or in the member list
 
 ![](https://github.com/Vendicated/Vencord/assets/45497981/354220a4-09f3-4c5f-a28e-4b19ca775190)
 

--- a/src/plugins/betterRoleContext/index.tsx
+++ b/src/plugins/betterRoleContext/index.tsx
@@ -171,22 +171,15 @@ export function buildExtraRoleContextMenuItems(role: Role, guild: Guild, popoutR
     return { before, after };
 }
 
-export function openRoleContextMenu(event: React.MouseEvent<HTMLElement>, guildId: string, roleId: string) {
-    event.preventDefault();
-    event.stopPropagation();
-
+export function openRoleContextMenu(event: React.MouseEvent<HTMLElement>, { guildId, id: roleId }: { guildId: string; id: string; }) {
     const guild = getCurrentGuild();
-
     if (!guild || guild.id !== guildId) return;
 
-    const role = GuildRoleStore.getRole(guild.id, roleId);
+    const role = GuildRoleStore.getRole(guildId, roleId);
     if (!role) return;
 
-    const popoutRef = {
-        current: event.currentTarget
-    } as React.RefObject<HTMLElement>;
-
     ContextMenuApi.openContextMenu(event, () => {
+        const popoutRef = useRef(null);
         const { before, after } = buildExtraRoleContextMenuItems(role, guild, popoutRef);
 
         return (
@@ -225,11 +218,13 @@ export default definePlugin({
                 replace: "$self.RoleMembers=$1;$&"
             }
         },
+        // Conflicts with RoleColorEverywhere which changes the code at the end of our match. (and also uses same find & similar match)
+        // However, "BetterRoleContext" applies first (alphabetic order), so it's not an issue
         {
             find: 'tutorialId:"whos-online',
             replacement: {
-                match: /let\{id:(\i),title:(\i),count:(\i),guildId:(\i),className:(\i)\}=(\i),(.+?)("aria-hidden":!0,)children:/,
-                replace: "let{id:$1,title:$2,count:$3,guildId:$4,className:$5}=$6,$7$8onContextMenu:e=>$self.openRoleContextMenu(e,$4,$1),children:"
+                match: /(?<=#{intl::CHANNEL_MEMBERS_A11Y_LABEL}.{0,200}?"aria-hidden":!0,)children:.{0,200}?(?:—|\\u2014) ",\i\]\}\)\]/,
+                replace: "onContextMenu:e=>$self.openRoleContextMenu(e,arguments[0]),$&"
             }
         }
     ],

--- a/src/plugins/betterRoleContext/index.tsx
+++ b/src/plugins/betterRoleContext/index.tsx
@@ -6,16 +6,16 @@
 
 import { definePluginSettings } from "@api/Settings";
 import { getUserSettingLazy } from "@api/UserSettings";
-import { ImageIcon } from "@components/Icons";
+import { CopyIdIcon, ImageIcon } from "@components/Icons";
 import { copyToClipboard } from "@utils/clipboard";
 import { Devs } from "@utils/constants";
-import { getCurrentChannel, getCurrentGuild, openImageModal } from "@utils/discord";
+import { getCurrentChannel, getCurrentGuild, getIntlMessage, openImageModal } from "@utils/discord";
 import { isTruthy } from "@utils/guards";
 import { classes } from "@utils/misc";
 import definePlugin, { OptionType } from "@utils/types";
 import { Guild, PopoutProps, Role } from "@vencord/discord-types";
 import { findByCodeLazy, findByPropsLazy, findCssClassesLazy } from "@webpack";
-import { GuildRoleStore, Menu, PermissionStore, Popout, useRef } from "@webpack/common";
+import { ContextMenuApi, GuildRoleStore, Menu, PermissionStore, Popout, useRef } from "@webpack/common";
 import { ComponentType } from "react";
 
 const GuildSettingsActions = findByPropsLazy("open", "selectRole", "updateGuild");
@@ -171,22 +171,68 @@ export function buildExtraRoleContextMenuItems(role: Role, guild: Guild, popoutR
     return { before, after };
 }
 
+export function openRoleContextMenu(event: React.MouseEvent<HTMLElement>, guildId: string, roleId: string) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const guild = getCurrentGuild();
+
+    if (!guild || guild.id !== guildId) return;
+
+    const role = GuildRoleStore.getRole(guild.id, roleId);
+    if (!role) return;
+
+    const popoutRef = {
+        current: event.currentTarget
+    } as React.RefObject<HTMLElement>;
+
+    ContextMenuApi.openContextMenu(event, () => {
+        const { before, after } = buildExtraRoleContextMenuItems(role, guild, popoutRef);
+
+        return (
+            <Menu.Menu
+                navId="vc-better-role-context-member-list"
+                onClose={ContextMenuApi.closeContextMenu}
+                aria-label="Role Actions"
+            >
+                {before}
+                {after}
+                <Menu.MenuItem
+                    key="vc-better-role-context-copy-role-id"
+                    id="vc-better-role-context-copy-role-id"
+                    label={getIntlMessage("COPY_ID_ROLE")}
+                    icon={CopyIdIcon}
+                    action={() => copyToClipboard(role.id)}
+                />
+            </Menu.Menu>
+        );
+    });
+}
+
 export default definePlugin({
     name: "BetterRoleContext",
-    description: "Adds options to copy role color / edit role / view role icon when right clicking roles in the user profile",
+    description: "Adds options to copy role color / edit role / view role icon when right clicking roles in the user profile or in the member list",
     tags: ["Roles", "Appearance"],
-    authors: [Devs.Ven, Devs.goodbee],
+    authors: [Devs.Ven, Devs.goodbee, Devs.nightmaresan],
     dependencies: ["UserSettingsAPI"],
-
     settings,
-
-    patches: [{
-        find: ".ROLE_MENTION)",
-        replacement: {
-            match: /function (\i)(?=.+?renderPopout:.{0,20}\1,\{guildId:\i,channelId:\i)/,
-            replace: "$self.RoleMembers=$1;$&"
+    openRoleContextMenu,
+    patches: [
+        {
+            find: ".ROLE_MENTION)",
+            replacement: {
+                match: /function (\i)(?=.+?renderPopout:.{0,20}\1,\{guildId:\i,channelId:\i)/,
+                replace: "$self.RoleMembers=$1;$&"
+            }
+        },
+        {
+            find: 'tutorialId:"whos-online',
+            replacement: {
+                match: /let\{id:(\i),title:(\i),count:(\i),guildId:(\i),className:(\i)\}=(\i),(.+?)("aria-hidden":!0,)children:/,
+                replace: "let{id:$1,title:$2,count:$3,guildId:$4,className:$5}=$6,$7$8onContextMenu:e=>$self.openRoleContextMenu(e,$4,$1),children:"
+            }
         }
-    }],
+    ],
 
     start() {
         // DeveloperMode needs to be enabled for the context menu to be shown

--- a/src/plugins/betterRoleContext/index.tsx
+++ b/src/plugins/betterRoleContext/index.tsx
@@ -219,7 +219,7 @@ export default definePlugin({
             }
         },
         // Conflicts with RoleColorEverywhere which changes the code at the end of our match. (and also uses same find & similar match)
-        // However, "BetterRoleContext" applies first (alphabetic order), so it's not an issue
+        // However, BetterRoleContext applies first (alphabetic order), so it's not an issue
         {
             find: 'tutorialId:"whos-online',
             replacement: {

--- a/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
@@ -18,7 +18,7 @@
 
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Flex } from "@components/Flex";
-import { InfoIcon, OwnerCrownIcon } from "@components/Icons";
+import { CopyIdIcon, InfoIcon, OwnerCrownIcon } from "@components/Icons";
 import { buildExtraRoleContextMenuItems } from "@plugins/betterRoleContext";
 import { cl, getGuildPermissionSpecMap, loadGetGuildPermissionSpecMap } from "@plugins/permissionsViewer/utils";
 import { copyToClipboard } from "@utils/clipboard";
@@ -198,15 +198,6 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
     );
 }
 
-function IDIcon() {
-    return (
-        <svg width="18" height="18" viewBox="0 0 24 24">
-            <path fill="currentColor" d="M15.3 14.48c-.46.45-1.08.67-1.86.67h-1.39V9.2h1.39c.78 0 1.4.22 1.86.67.46.45.68 1.22.68 2.31 0 1.1-.22 1.86-.68 2.31Z" />
-            <path fill="currentColor" fillRule="evenodd" clipRule="evenodd" d="M5 2a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V5a3 3 0 0 0-3-3H5Zm1 15h2.04V7.34H6V17Zm4-9.66V17h3.44c1.46 0 2.6-.42 3.38-1.25.8-.83 1.2-2.02 1.2-3.58s-.4-2.75-1.2-3.58c-.79-.83-1.92-1.25-3.38-1.25H10Z" />
-        </svg>
-    );
-}
-
 function ViewAsRoleIcon() {
     return (
         <svg width="18" height="18" viewBox="0 0 24 24">
@@ -231,7 +222,7 @@ function RoleContextMenu({ guild, roleId, onClose }: { guild: Guild; roleId: str
             <Menu.MenuItem
                 id={cl("copy-role-id")}
                 label={getIntlMessage("COPY_ID_ROLE")}
-                icon={IDIcon}
+                icon={CopyIdIcon}
                 action={() => copyToClipboard(roleId)}
             />
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    nightmaresan: {
+        name: "NightmareSan",
+        id: 304239816466235392n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Describe your Changes

Since I use this plugin myself, I thought it would be pretty neat to support context actions for roles within the member list. This allows users to interact with roles directly without having to go through roles in user profiles, so I figured I would make it available for everyone.

I also centralized the icon used for Developer Mode's "Copy ID" action.

This is my first PR to Vencord and I tried to follow all guidelines, so please let me know if I missed anything :)

## Checklist before submitting

* [x] I have read the [CONTRIBUTING.md](https://github.com/Vendicated/Vencord/pull/CONTRIBUTING.md) file and made sure this pull request complies with it
* [x] This pull request was written by me, and not an AI agent