### PR TITLE
Allow toggling API-dependent plugins without restart

### DIFF
--- a/src/api/PluginManager.ts
+++ b/src/api/PluginManager.ts
@@ -112,7 +112,13 @@ function isReporterTestable(p: Plugin, part: ReporterTestable) {
         : (p.reporterTestable & part) === part;
 }
 
+/** API plugins only install webpack hooks; consumers register at runtime. */
+function isApiPlugin(p: Plugin) {
+    return p.name.endsWith("API");
+}
+
 export function pluginRequiresRestart(p: Plugin) {
+    if (isApiPlugin(p)) return false;
     return p.requiresRestart !== false && (p.requiresRestart || !!p.patches?.length);
 }
 
@@ -257,7 +263,7 @@ export const startPlugin = traceFunction("startPlugin", function startPlugin(p: 
     if (chatBarButton) addChatBarButton(name, chatBarButton.render, chatBarButton.icon);
     if (renderMemberListDecorator) addMemberListDecorator(name, renderMemberListDecorator);
     if (renderMessageDecoration) addMessageDecoration(name, renderMessageDecoration);
-    if (renderMessageAccessory) addMessageAccessory(name, renderMessageAccessory);
+    if (renderMessageAccessory) addMessageAccessory(name, renderMessageAccessory, p.messageAccessoryPosition);
     if (messagePopoverButton) addMessagePopoverButton(name, messagePopoverButton.render, messagePopoverButton.icon);
 
     return true;
@@ -387,7 +393,7 @@ export const initPluginManager = onlyOnce(function init() {
             }
         }
 
-        if (p.patches && isPluginEnabled(p.name)) {
+        if (p.patches && (isPluginEnabled(p.name) || isApiPlugin(p))) {
             if (!IS_REPORTER || isReporterTestable(p, ReporterTestable.Patches)) {
                 for (const patch of p.patches) {
                     addPatch(patch, p.name);

--- a/src/components/settings/tabs/plugins/index.tsx
+++ b/src/components/settings/tabs/plugins/index.tsx
@@ -52,12 +52,12 @@ function ReloadRequiredCard({ required }: { required: boolean; }) {
             {required
                 ? (
                     <>
-                        <HeadingTertiary>Restart required!</HeadingTertiary>
+                        <HeadingTertiary>Reload required</HeadingTertiary>
                         <Paragraph className={cl("dep-text")}>
-                            Restart now to apply new plugins and their settings
+                            Reload Discord to apply this plugin. This refreshes the app window — you do not need to quit Discord entirely.
                         </Paragraph>
                         <Button onClick={() => location.reload()} className={cl("restart-button")}>
-                            Restart
+                            Reload Discord
                         </Button>
                     </>
                 )

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -215,6 +215,8 @@ export interface PluginDef {
     onBeforeMessageEdit?: MessageEditListener;
 
     renderMessageAccessory?: MessageAccessoryFactory;
+    /** Index passed to MessageAccessories.addMessageAccessory (e.g. 4 = just above embeds). */
+    messageAccessoryPosition?: number;
     renderMessageDecoration?: MessageDecorationFactory;
 
     renderMemberListDecorator?: MemberListDecoratorFactory;


### PR DESCRIPTION
## Summary
- Always apply webpack patches for `*API` plugins at init. The hooks delegate to runtime registries and are effectively no-ops until a consumer plugin registers buttons/accessories/listeners.
- Treat API plugins as not requiring restart when auto-enabled as dependencies, so feature plugins can be toggled on mid-session without a reload.
- Add optional `messageAccessoryPosition` on `PluginDef` (passed through to `addMessageAccessory`) so accessories can be placed above embeds without manual `start()`/`stop()` registration.
- Clarify plugin settings copy: reload refreshes the Discord window; a full app quit is not required.

## Motivation
Plugins that depend on `ChatInputButtonAPI`, `MessageAccessoriesAPI`, `MessageEventsAPI`, etc. currently prompt for restart on first enable because those dependencies use webpack patches. In practice the patches are safe to install unconditionally, and only the consumer plugin needs hot `start()`/`stop()`.

## Test plan
- [ ] Fresh Discord session with all API plugins disabled in settings
- [ ] Enable a plugin that uses `chatBarButton` + `renderMessageAccessory` (e.g. Translate) — should work without reload banner
- [ ] Toggle the same plugin off/on — button and accessory disappear/reappear
- [ ] Enable a plugin with its own webpack patches — reload banner still appears
- [ ] Verify API plugins remain hidden/marked as dependencies when auto-enabled