### PR TITLE
SupportHelper: improve snippet functionality

### DIFF
--- a/src/plugins/_core/supportHelper.tsx
+++ b/src/plugins/_core/supportHelper.tsx
@@ -315,27 +315,27 @@ export default definePlugin({
                     </Button>
                 );
             }
+        }
 
-            if (props.message.author.id === VENBOT_USER_ID) {
-                const match = CodeBlockRe.exec(props.message.content || props.message.embeds[0]?.rawDescription || "");
-                if (match) {
-                    buttons.push(
-                        <Button
-                            key="vc-run-snippet"
-                            onClick={async () => {
-                                try {
-                                    await AsyncFunction(match[1])();
-                                    showToast("Success!", Toasts.Type.SUCCESS);
-                                } catch (e) {
-                                    new Logger(this.name).error("Error while running snippet:", e);
-                                    showToast("Failed to run snippet :(", Toasts.Type.FAILURE);
-                                }
-                            }}
-                        >
-                            Run Snippet
-                        </Button>
-                    );
-                }
+        if (props.message.author.id === VENBOT_USER_ID) {
+            const match = CodeBlockRe.exec(props.message.content || props.message.embeds[0]?.rawDescription || "");
+            if (match) {
+                buttons.push(
+                    <Button
+                        key="vc-run-snippet"
+                        onClick={async () => {
+                            try {
+                                await AsyncFunction(match[1])();
+                                showToast("Success!", Toasts.Type.SUCCESS);
+                            } catch (e) {
+                                new Logger(this.name).error("Error while running snippet:", e);
+                                showToast("Failed to run snippet :(", Toasts.Type.FAILURE);
+                            }
+                        }}
+                    >
+                        Run Snippet
+                    </Button>
+                );
             }
         }
 

--- a/src/plugins/_core/supportHelper.tsx
+++ b/src/plugins/_core/supportHelper.tsx
@@ -46,7 +46,7 @@ import SettingsPlugin from "./settings";
 const CodeBlockRe = /```js\n(.+?)```/s;
 
 const AdditionalAllowedChannelIds = [
-    "1024286218801926184", // Vencord > #bot-spam
+    "1024286218801926184", // Vencord > #bot-commands
 ];
 
 const TrustedRolesIds = [
@@ -317,7 +317,7 @@ export default definePlugin({
             }
         }
 
-        if (props.message.author.id === VENBOT_USER_ID) {
+        if (props.message.author.id === VENBOT_USER_ID && (props.channel.parent_id === KNOWN_ISSUES_CHANNEL_ID || props.channel.parent_id === SUPPORT_CATEGORY_ID)) {
             const match = CodeBlockRe.exec(props.message.content || props.message.embeds[0]?.rawDescription || "");
             if (match) {
                 buttons.push(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,7 +24,7 @@ export const CONTRIB_ROLE_ID = "1026534353167208489";
 export const REGULAR_ROLE_ID = "1026504932959977532";
 export const SUPPORT_CHANNEL_ID = "1026515880080842772";
 export const SUPPORT_CATEGORY_ID = "1108135649699180705";
-export const KNOWN_ISSUES_CHANNEL_ID = "1222936386626129920";
+export const KNOWN_ISSUES_CHANNEL_ID = "1257025907625951423";
 
 const platform = navigator.platform.toLowerCase();
 export const IS_WINDOWS = platform.startsWith("win");


### PR DESCRIPTION
Makes code snippets in `#known-issues` posts executable from right there (still via venbot), instead of having to make Venbot embed them in support channels, and pray people read it. Basically an improvement to self-service fixes.