### PR TITLE
plugin: MoreAccounts

### DIFF
--- a/src/plugins/moreAccounts/README.md
+++ b/src/plugins/moreAccounts/README.md
@@ -1,0 +1,16 @@
+# MoreAccounts
+
+removes the 5 account limit on the account switcher
+
+discord lets you sign in to 5 accounts, then it just starts evicting older ones every time you connect. the token stays in storage so the account isn't really logged out, it just disappears from the dropdown. you have to log in again to bring it back.
+
+this patches both. the trim is removed and the "add an account" button stops erroring at 5.
+
+## settings
+- **Max Accounts**: number, default 50. won't go below 5
+- **Auto-restore** runs once when you connect, re-adds accounts that got evicted before you had this. on by default
+- a **Restore hidden accounts** button below if you want to run it manually
+
+restore reads the stored tokens, hits `/users/@me` for each one to get the username and check if it's still valid, then puts them back. expired tokens show the normal red "please log in again". nothing ever gets removed.
+
+made this because i had 7 accounts and discord kept dropping 2 of them on restart. tested on canary, windows.

--- a/src/plugins/moreAccounts/README.md
+++ b/src/plugins/moreAccounts/README.md
@@ -1,16 +1,8 @@
 # MoreAccounts
 
-removes the 5 account limit on the account switcher
-
-discord lets you sign in to 5 accounts, then it just starts evicting older ones every time you connect. the token stays in storage so the account isn't really logged out, it just disappears from the dropdown. you have to log in again to bring it back.
-
-this patches both. the trim is removed and the "add an account" button stops erroring at 5.
+removes the 5 account cap in the account switcher
 
 ## settings
-- **Max Accounts**: number, default 50. won't go below 5
-- **Auto-restore** runs once when you connect, re-adds accounts that got evicted before you had this. on by default
-- a **Restore hidden accounts** button below if you want to run it manually
-
-restore reads the stored tokens, hits `/users/@me` for each one to get the username and check if it's still valid, then puts them back. expired tokens show the normal red "please log in again". nothing ever gets removed.
-
-made this because i had 7 accounts and discord kept dropping 2 of them on restart. tested on canary, windows.
+- Max Accounts: number, default 50
+- Auto-restore: re-add accounts discord dropped past the cap
+- Restore button: same thing on demand

--- a/src/plugins/moreAccounts/accounts.ts
+++ b/src/plugins/moreAccounts/accounts.ts
@@ -1,0 +1,133 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Logger } from "@utils/Logger";
+import { find, findByPropsLazy, findStoreLazy } from "@webpack";
+import { FluxDispatcher, RestAPI, UserStore } from "@webpack/common";
+
+const logger = new Logger("MoreAccounts");
+
+const Tokens = findByPropsLazy("getToken", "setToken", "encryptAndStoreTokens");
+const MultiAccountStore = findStoreLazy("MultiAccountStore");
+
+function isKv(o: any) {
+    return o != null && typeof o.get === "function" && typeof o.set === "function" && typeof o.remove === "function";
+}
+
+function hasTokens(o: any) {
+    try {
+        const t = o.get("tokens");
+        return t != null && typeof t === "object" && Object.keys(t).some(k => /^\d+$/.test(k));
+    } catch {
+        return false;
+    }
+}
+
+let cache: any = null;
+function storage() {
+    if (isKv(cache)) return cache;
+    const mod: any = find((m: any) => {
+        if (!m || typeof m !== "object") return false;
+        try {
+            return Object.values(m).some((v: any) => isKv(v) && hasTokens(v));
+        } catch {
+            return false;
+        }
+    });
+    cache = mod ? Object.values(mod).find((v: any) => isKv(v) && hasTokens(v)) ?? null : null;
+    return cache;
+}
+
+export function storageReady() {
+    return isKv(storage());
+}
+
+function storedIds(): string[] {
+    try {
+        return Object.keys(storage()?.get?.("tokens") ?? {}).filter(k => /^\d+$/.test(k));
+    } catch {
+        return [];
+    }
+}
+
+export function countHidden() {
+    const store: any = MultiAccountStore;
+    const inSwitcher = new Set((store.getUsers?.() ?? []).map((u: any) => u.id));
+    return storedIds().filter(id => !inSwitcher.has(id)).length;
+}
+
+async function check(token: string) {
+    try {
+        const res: any = await (RestAPI as any).get({ url: "/users/@me", headers: { authorization: token } });
+        return { valid: true, user: res.body };
+    } catch {
+        return { valid: false };
+    }
+}
+
+export interface RestoreResult {
+    added: number;
+    valid: number;
+    expired: number;
+    skippedNoToken: number;
+    skippedLimit: number;
+}
+
+export async function restoreHiddenAccounts(maxAccounts: number): Promise<RestoreResult> {
+    const r: RestoreResult = { added: 0, valid: 0, expired: 0, skippedNoToken: 0, skippedLimit: 0 };
+
+    const store: any = MultiAccountStore;
+    const users: any[] = store?.getUsers?.();
+    if (!users || !storage() || !Tokens) return r;
+
+    const max = Number.isFinite(maxAccounts) && maxAccounts >= 5 ? Math.floor(maxAccounts) : 50;
+    const present = new Set(users.map(u => u.id));
+    const hidden = storedIds().filter(id => !present.has(id));
+
+    const toRestore = hidden.slice(0, Math.max(0, max - users.length));
+    r.skippedLimit = hidden.length - toRestore.length;
+
+    const done: { id: string; valid: boolean; }[] = [];
+
+    for (const id of toRestore) {
+        try {
+            const tok = (Tokens as any).getToken(id);
+            if (!tok) {
+                r.skippedNoToken++;
+                continue;
+            }
+
+            const out: any = await check(tok);
+            const profile = out.user ?? (UserStore as any).getUser?.(id);
+
+            users.push({
+                id,
+                username: profile?.username ?? `Account ${id}`,
+                avatar: profile?.avatar ?? null,
+                discriminator: profile?.discriminator ?? "0",
+                tokenStatus: out.valid ? 2 : 0,
+                pushSyncToken: null
+            });
+
+            done.push({ id, valid: out.valid });
+            r.added++;
+            if (out.valid) r.valid++;
+            else r.expired++;
+        } catch (e) {
+            logger.error(`failed to restore ${id}`, e);
+            r.skippedNoToken++;
+        }
+    }
+
+    for (const { id, valid } of done) {
+        FluxDispatcher.dispatch({
+            type: valid ? "MULTI_ACCOUNT_VALIDATE_TOKEN_SUCCESS" : "MULTI_ACCOUNT_VALIDATE_TOKEN_FAILURE",
+            userId: id
+        });
+    }
+
+    return r;
+}

--- a/src/plugins/moreAccounts/index.tsx
+++ b/src/plugins/moreAccounts/index.tsx
@@ -79,8 +79,8 @@ export default definePlugin({
     name: "MoreAccounts",
     description: "removes the 5 account cap on the switcher",
     authors: [Devs.hxe3],
+    tags: ["Customisation"],
     settings,
-
 
     get max() {
         const n = Math.floor(Number(settings.store.maxAccounts));

--- a/src/plugins/moreAccounts/index.tsx
+++ b/src/plugins/moreAccounts/index.tsx
@@ -1,0 +1,114 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Flex } from "@components/Flex";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { Button, Forms, React, useState } from "@webpack/common";
+
+import { countHidden, restoreHiddenAccounts, storageReady } from "./accounts";
+
+let didAutoRestore = false;
+
+function RestoreSection() {
+    const [busy, setBusy] = useState(false);
+    const [hidden, setHidden] = useState(() => countHidden());
+    const [message, setMessage] = useState<string | null>(null);
+    const ready = storageReady();
+
+    async function run() {
+        setBusy(true);
+        setMessage(null);
+        try {
+            const r = await restoreHiddenAccounts(settings.store.maxAccounts);
+            const parts = [`Restored ${r.added} account(s)`];
+            if (r.added) parts.push(`${r.valid} valid, ${r.expired} expired`);
+            if (r.skippedLimit) parts.push(`${r.skippedLimit} skipped, raise Max Accounts`);
+            setMessage(parts.join(", "));
+            setHidden(countHidden());
+        } catch {
+            setMessage("Restore failed, check the console.");
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    return (
+        <section>
+            <Forms.FormTitle>Hidden accounts</Forms.FormTitle>
+            <Forms.FormText style={{ marginBottom: 8 }}>
+                {!ready
+                    ? "couldn't reach Discord's account storage"
+                    : hidden > 0
+                        ? `${hidden} account(s) have a saved token that the switcher dropped. restore re-adds them. expired ones show "please log in again".`
+                        : "nothing hidden, every saved account is already in the switcher"}
+            </Forms.FormText>
+            <Flex>
+                <Button onClick={run} disabled={busy || !ready || hidden === 0}>
+                    {busy ? "Restoring..." : hidden > 0 ? `Restore ${hidden} hidden account${hidden === 1 ? "" : "s"}` : "Nothing to restore"}
+                </Button>
+            </Flex>
+            {message && <Forms.FormText style={{ marginTop: 8 }}>{message}</Forms.FormText>}
+        </section>
+    );
+}
+
+const settings = definePluginSettings({
+    maxAccounts: {
+        type: OptionType.NUMBER,
+        description: "Max accounts in the switcher. Setting this below your current count logs the extras out",
+        default: 50
+    },
+    autoRestore: {
+        type: OptionType.BOOLEAN,
+        description: "Re-add hidden accounts to the switcher automatically when you connect",
+        default: true
+    },
+    restore: {
+        type: OptionType.COMPONENT,
+        description: "Restore hidden accounts",
+        component: RestoreSection
+    }
+});
+
+export default definePlugin({
+    name: "MoreAccounts",
+    description: "removes the 5 account cap on the switcher",
+    authors: [Devs.hxe3],
+    settings,
+
+
+    get max() {
+        const n = Math.floor(Number(settings.store.maxAccounts));
+        return Number.isFinite(n) && n >= 5 ? n : 50;
+    },
+
+    flux: {
+        CONNECTION_OPEN() {
+            if (didAutoRestore || !settings.store.autoRestore) return;
+            didAutoRestore = true;
+            setTimeout(() => restoreHiddenAccounts(settings.store.maxAccounts).catch(() => void 0), 1500);
+        }
+    },
+
+    patches: [
+        {
+            find: 'persistKey="MultiAccountStore"',
+            replacement: {
+                match: /(\(\i=\i\)\.length>)5(&&\i\.splice\()5(\))/,
+                replace: "$1$self.max$2$self.max$3"
+            }
+        },
+        {
+            find: "maxNumAccounts:",
+            replacement: {
+                match: /(\.length>=)5(\?\i\(!0\))/,
+                replace: "$1$self.max$2"
+            }
+        }
+    ]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -51,6 +51,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "V",
         id: 343383572805058560n
     },
+    hxe3: {
+        name: "hxe3",
+        id: 1383056240174960700n
+    },
     Apexo: {
         name: "Apexo",
         id: 228548952687902720n


### PR DESCRIPTION
## Describe your Changes

removes the 5 account cap in the account switcher.

discord drops accounts past 5 every connect but keeps the token saved, so they vanish from the dropdown until you log in again. this patches both the trim and the "add an account" block.

also restores accounts that were already evicted: reads their saved tokens, validates against `/users/@me`, adds them back. expired ones get the red "please log in again". nothing is removed.

tested on canary, windows, 7 accounts.