### PR TITLE
fix openPrivateChannel passes string instead of object to ChannelActionCreators

### DIFF
--- a/src/utils/discord.tsx
+++ b/src/utils/discord.tsx
@@ -90,7 +90,7 @@ export function getCurrentGuild(): Guild | undefined {
     return GuildStore.getGuild(getCurrentChannel()?.guild_id!);
 }
 
-export function openPrivateChannel(options: { recipientIds: string[]; navigateToChannel?: boolean; }) {
+export function openPrivateChannel(options: { recipientIds: string[]; joinCall?: boolean; joinCallVideo?: boolean; location?: string; onBeforeTransition?: () => void; navigateToChannel?: boolean; }) {
     ChannelActionCreators.openPrivateChannel(options);
 }
 

--- a/src/utils/discord.tsx
+++ b/src/utils/discord.tsx
@@ -90,8 +90,8 @@ export function getCurrentGuild(): Guild | undefined {
     return GuildStore.getGuild(getCurrentChannel()?.guild_id!);
 }
 
-export function openPrivateChannel(userId: string) {
-    ChannelActionCreators.openPrivateChannel(userId);
+export function openPrivateChannel(options: { recipientIds: string[]; navigateToChannel?: boolean; }) {
+    ChannelActionCreators.openPrivateChannel(options);
 }
 
 export const enum Theme {


### PR DESCRIPTION
openPrivateChannel was passing a bare userId string to ChannelActionCreators.openPrivateChannel, but that function expects an object { recipientIds: string[], navigateToChannel?: boolean }. The string got destructured silently and recipientIds landed as undefined, the dm was never opened and it was just a noop with no error.