### PR TITLE
plugins: add NoAutoStreamerMode

### DIFF
--- a/src/plugins/noAutoStreamerMode/index.ts
+++ b/src/plugins/noAutoStreamerMode/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2024 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "NoAutoStreamerMode",
+    description: "Disables automatic streamer mode toggling",
+    authors: [Devs.june],
+    patches: [
+        {
+            find: "get autoToggle()",
+            replacement: {
+                match: /return _.autoToggle/,
+                replace: "return false"
+            }
+        }
+    ]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -638,6 +638,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    june: {
+        name: "june",
+        id: 1400922134355644458n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
automatic streamer mode toggling is very very annoying, especially since (at least for me on linux) every time it detects OBS running, it quite literally forces streamer mode and re-enables it every few seconds

this plugin simply patches `autoToggle()` to always return false

before i settled on this solution, i tried modifying `RUNNING_STREAMER_TOOLS_CHANGE` and `STREAMER_MODE_UPDATE` directly, but that quickly turned into a headache, so this is probably the best way

---

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
