### PR TITLE
ShikiCodeblocks: Fix line numbers wrapping in modals

### DIFF
--- a/src/plugins/shikiCodeblocks.desktop/shiki.css
+++ b/src/plugins/shikiCodeblocks.desktop/shiki.css
@@ -92,6 +92,7 @@
     padding-left: 5px;
     padding-right: 8px;
     user-select: none;
+    white-space: nowrap;
 }
 
 .vc-shiki-root .vc-shiki-table-cell:last-child {


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
Before  |  After
:-:|:-:
<img width="928" height="1298" alt="image" src="https://github.com/user-attachments/assets/a014b9db-faf1-4b4f-b045-abeb4c3e270c" /> | <img width="935" height="1292" alt="image" src="https://github.com/user-attachments/assets/d1e662c3-56e8-4d2d-941a-df943cf27232" />

Fixes #4308 

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
