### PR TITLE
feat: add tenor gif search plugin

### DIFF
--- a/src/main/csp/index.ts
+++ b/src/main/csp/index.ts
@@ -12,6 +12,7 @@ type PolicyMap = Record<string, string[]>;
 export const ConnectSrc = ["connect-src"];
 export const ImageSrc = [...ConnectSrc, "img-src"];
 export const CssSrc = ["style-src", "font-src"];
+export const ImageAndMediaSrc = [...ImageSrc, "media-src"];
 export const ImageAndCssSrc = [...ImageSrc, ...CssSrc];
 export const ImageScriptsAndCssSrc = [...ImageAndCssSrc, "script-src", "worker-src"];
 
@@ -40,7 +41,6 @@ export const CspPolicies: PolicyMap = {
     "i.imgur.com": ImageSrc, // Imgur, used by some themes
     "i.ibb.co": ImageSrc, // ImgBB, used by some themes
     "i.pinimg.com": ImageSrc, // Pinterest, used by some themes
-    "*.tenor.com": ImageSrc, // Tenor, used by some themes
     "files.catbox.moe": ImageAndCssSrc, // Catbox, used by some themes
 
     "cdn.discordapp.com": ImageAndCssSrc, // Discord CDN, used by Vencord and some themes to load media
@@ -63,6 +63,10 @@ export const CspPolicies: PolicyMap = {
     "dearrow-thumb.ajay.app": ImageSrc, // Dearrow Thumbnail CDN
     "usrbg.is-hardly.online": ImageSrc, // USRBG API
     "icons.duckduckgo.com": ImageSrc, // DuckDuckGo Favicon API (Reverse Image Search)
+
+    // Tenor, used by TenorSearch plugin and some themes
+    "*.tenor.com": ImageAndMediaSrc,
+    "*.tenor.co": ImageAndMediaSrc,
 };
 
 const findHeader = (headers: PolicyMap, headerName: Lowercase<string>) => {

--- a/src/main/csp/index.ts
+++ b/src/main/csp/index.ts
@@ -12,6 +12,7 @@ type PolicyMap = Record<string, string[]>;
 export const ConnectSrc = ["connect-src"];
 export const ImageSrc = [...ConnectSrc, "img-src"];
 export const CssSrc = ["style-src", "font-src"];
+export const ImageAndMediaSrc = [...ImageSrc, "media-src"];
 export const ImageAndCssSrc = [...ImageSrc, ...CssSrc];
 export const ImageScriptsAndCssSrc = [...ImageAndCssSrc, "script-src", "worker-src"];
 
@@ -63,6 +64,11 @@ export const CspPolicies: PolicyMap = {
     "dearrow-thumb.ajay.app": ImageSrc, // Dearrow Thumbnail CDN
     "usrbg.is-hardly.online": ImageSrc, // USRBG API
     "icons.duckduckgo.com": ImageSrc, // DuckDuckGo Favicon API (Reverse Image Search)
+
+    "api.tenor.com": ConnectSrc, // Tenor API
+    "media.tenor.co": ImageAndMediaSrc, // Tenor media CDN
+    "media.tenor.com": ImageAndMediaSrc, // Tenor media CDN
+    "c.tenor.com": ImageAndMediaSrc, // Tenor legacy media CDN
 };
 
 const findHeader = (headers: PolicyMap, headerName: Lowercase<string>) => {

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -70,19 +70,19 @@ function mapGifs(items: TenorResult[]) {
     return items.map(toDiscordGif).filter((g): g is DiscordGif => g != null);
 }
 
-async function fetchSearch(query: string) {
-    const res = await fetch(tenorUrl("search", { q: query, limit: String(RESULT_LIMIT) }));
+async function fetchTenorResults(path: string, extra: Record<string, string> = {}) {
+    const res = await fetch(tenorUrl(path, extra));
     if (!res.ok) return [];
-    const body = await res.json();
-    const items: TenorResult[] = Array.isArray(body) ? body : (body.results ?? body.items ?? []);
-    return mapGifs(items);
+    const { results = [] } = await res.json();
+    return results as TenorResult[];
+}
+
+async function fetchSearch(query: string) {
+    return mapGifs(await fetchTenorResults("search", { q: query, limit: String(RESULT_LIMIT) }));
 }
 
 async function fetchTrending() {
-    const res = await fetch(tenorUrl("trending", { limit: String(RESULT_LIMIT) }));
-    if (!res.ok) return [];
-    const body = await res.json();
-    return mapGifs(body.results ?? []);
+    return mapGifs(await fetchTenorResults("trending", { limit: String(RESULT_LIMIT) }));
 }
 
 async function fetchCategories(): Promise<TrendingCategories | null> {

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -16,8 +16,9 @@ const SEARCH_DEBOUNCE_MS = 250;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let cachedCategories: TrendingCategories | null = null;
 
-interface TenorMedia { url?: string; dims?: [number, number]; preview?: string; }
-interface TenorResult { id: string; title?: string; itemurl?: string; media?: Array<Record<string, TenorMedia>>; }
+interface TenorMedia { url: string; preview: string; dims: [number, number]; }
+interface TenorResult { id: string; media: Array<Record<string, TenorMedia>>; itemurl: string; }
+
 interface TenorCategoryTag { searchterm: string; image: string; }
 
 interface DiscordGif {
@@ -26,9 +27,9 @@ interface DiscordGif {
     url: string;
     src: string;
     gif_src: string;
-    width?: number;
-    height?: number;
-    preview?: string;
+    width: number;
+    height: number;
+    preview: string;
 }
 
 interface TrendingCategories {
@@ -51,19 +52,19 @@ function tenorUrl(path: string, extra: Record<string, string> = {}) {
 }
 
 function toDiscordGif(item: TenorResult): DiscordGif | null {
-    const media = item.media?.[0];
-    if (!media) return null;
+    const media = item.media[0];
+    const { gif, webm } = media;
 
-    const { webm, gif } = media;
-    const src = webm?.url ?? gif?.url;
-    const gifSrc = gif?.url ?? src;
-    if (!src || !gifSrc) return null;
-
-    const width = webm?.dims?.[0];
-    const height = webm?.dims?.[1];
-    const preview = webm?.preview;
-
-    return { id: item.id ?? src, title: item.title ?? "", url: item.itemurl ?? gifSrc, src, gif_src: gifSrc, width, height, preview };
+    return {
+        id: item.id,
+        title: "", // discord always returns a blank string
+        url: item.itemurl,
+        src: webm.url,
+        gif_src: gif.url,
+        width: webm.dims[0],
+        height: webm.dims[1],
+        preview: webm.preview
+    };
 }
 
 function mapGifs(items: TenorResult[]) {

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -154,14 +154,6 @@ export default definePlugin({
         });
     },
 
-    stop() {
-        cachedCategories = null;
-        if (debounceTimer) {
-            clearTimeout(debounceTimer);
-            debounceTimer = null;
-        }
-    },
-
     handleTrendingFetch() {
         if (cachedCategories) {
             FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...cachedCategories });

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -126,6 +126,10 @@ export default definePlugin({
                 {
                     match: /(handleSelectItem=\((\i),(\i)\)=>\{)/,
                     replace: "$1if($self.handleSelectItem(this,$2,$3))return;"
+                },
+                {
+                    match: /placeholder:(\i),"aria-label":\i/,
+                    replace: 'placeholder:$1.replace(/Giphy|Klipy/gi,"Tenor"),"aria-label":$1.replace(/Giphy|Klipy/gi,"Tenor")'
                 }
             ]
         },

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -130,13 +130,6 @@ export default definePlugin({
             ]
         },
         {
-            find: "gif_picker",
-            replacement: {
-                match: /\i\.getConfig\(\{location:"gif_picker"\}\)\.provider/,
-                replace: '"tenor"'
-            }
-        },
-        {
             find: '"GIF_PICKER_TRENDING_FETCH_SUCCESS",trendingCategories:',
             replacement: {
                 match: /\i\.\i\.get\(\{url:\i\.\i\.GIFS_TRENDING,/,

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -46,12 +46,11 @@ interface GifPickerInstance {
 }
 
 function tenorUrl(path: string, extra: Record<string, string> = {}) {
-    const url = new URL(`https://api.tenor.com/v1/${path}`);
-    url.searchParams.set("key", TENOR_KEY);
-    url.searchParams.set("locale", (LocaleStore.locale).replace("-", "_").toLowerCase());
-    for (const [k, v] of Object.entries(extra))
-        url.searchParams.set(k, v);
-    return url.toString();
+	return `https://api.tenor.com/v1/${path}?` + new URLSearchParams({
+    	key: TENOR_KEY,
+    	locale: LocaleStore.locale.replace("-", "_").toLowerCase(),
+    	...extra
+    });
 }
 
 function toDiscordGif(item: TenorResult): DiscordGif | null {

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -10,12 +10,11 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { FluxDispatcher, LocaleStore } from "@webpack/common";
 
+// API key is taken from the GBoard app on iOS
 const TENOR_KEY = "3Z0688EVWYKH";
 const RESULT_LIMIT = 100;
 const SEARCH_DEBOUNCE_MS = 250;
 
-let activeAbort: AbortController | null = null;
-let categoryAbort: AbortController | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let cachedCategories: TrendingCategories | null = null;
 
@@ -42,14 +41,14 @@ interface TrendingCategories {
 interface GifPickerInstance {
     state: { resultType: string | null; };
     setState(state: { resultType: string | null; }, callback?: () => void): void;
-    props: { searchBarRef?: RefObject<HTMLInputElement> };
+    props: { searchBarRef?: RefObject<HTMLInputElement>; };
 }
 
 function tenorUrl(path: string, extra: Record<string, string> = {}) {
-	return `https://api.tenor.com/v1/${path}?` + new URLSearchParams({
-    	key: TENOR_KEY,
-    	locale: LocaleStore.locale.replace("-", "_").toLowerCase(),
-    	...extra
+    return `https://api.tenor.com/v1/${path}?` + new URLSearchParams({
+        key: TENOR_KEY,
+        locale: LocaleStore.locale.replace("-", "_").toLowerCase(),
+        ...extra
     });
 }
 
@@ -73,24 +72,24 @@ function mapGifs(items: TenorResult[]) {
     return items.map(toDiscordGif).filter((g): g is DiscordGif => g != null);
 }
 
-async function fetchSearch(query: string, signal: AbortSignal) {
-    const res = await fetch(tenorUrl("search", { q: query, limit: String(RESULT_LIMIT) }), { signal });
+async function fetchSearch(query: string) {
+    const res = await fetch(tenorUrl("search", { q: query, limit: String(RESULT_LIMIT) }));
     if (!res.ok) return [];
     const body = await res.json();
     const items: TenorResult[] = Array.isArray(body) ? body : (body.results ?? body.items ?? []);
     return mapGifs(items);
 }
 
-async function fetchTrending(signal: AbortSignal) {
-    const res = await fetch(tenorUrl("trending", { limit: String(RESULT_LIMIT) }), { signal });
+async function fetchTrending() {
+    const res = await fetch(tenorUrl("trending", { limit: String(RESULT_LIMIT) }));
     if (!res.ok) return [];
     const body = await res.json();
     return mapGifs(body.results ?? []);
 }
 
-async function fetchCategories(signal: AbortSignal): Promise<TrendingCategories | null> {
+async function fetchCategories(): Promise<TrendingCategories | null> {
     try {
-        const res = await fetch(tenorUrl("categories", { type: "featured" }), { signal });
+        const res = await fetch(tenorUrl("categories", { type: "featured" }));
         if (!res.ok) return null;
         const { tags } = await res.json() as { tags?: TenorCategoryTag[]; };
         if (!tags?.length) return null;
@@ -104,18 +103,12 @@ async function fetchCategories(signal: AbortSignal): Promise<TrendingCategories 
 }
 
 function doFetch(query: string) {
-    activeAbort?.abort();
-    const abort = new AbortController();
-    activeAbort = abort;
-
-    fetchSearch(query, abort.signal).then(items => {
-        if (abort.signal.aborted) return;
+    fetchSearch(query).then(items => {
         FluxDispatcher.dispatch(items.length
             ? { type: "GIF_PICKER_QUERY_SUCCESS", query, items }
             : { type: "GIF_PICKER_QUERY_FAILURE", query }
         );
-    }).catch(err => {
-        if (err.name === "AbortError") return;
+    }).catch(() => {
         FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE", query });
     });
 }
@@ -124,21 +117,16 @@ export default definePlugin({
     name: "TenorGifSearch",
     description: "Restore Tenor GIF search",
     authors: [Devs.Lunascape],
-    settingsAboutComponent: () => (
-        <Paragraph className={Margins.bottom16}>
-            This plugin restores Tenor GIF searching after Tenor killed the public API, this uses the Mobile API from GBoard.
-        </Paragraph>
-    ),
     patches: [
         {
             find: "renderHeaderContent()",
             replacement: [
                 {
-                    match: /(search\((\i),\s*(\i),\s*(\i)\)\s*\{)/,
+                    match: /(search\((\i),(\i),(\i)\)\{)/,
                     replace: "$1if($self.handleSearch(this,$2,$3,$4))return;"
                 },
                 {
-                    match: /(handleSelectItem\s*=\s*\((\i),\s*(\i)\)\s*=>\s*\{)/,
+                    match: /(handleSelectItem=\((\i),(\i)\)=>\{)/,
                     replace: "$1if($self.handleSelectItem(this,$2,$3))return;"
                 }
             ]
@@ -160,20 +148,14 @@ export default definePlugin({
     ],
 
     start() {
-        const abort = new AbortController();
-        categoryAbort = abort;
-        fetchCategories(abort.signal).then(data => {
-            if (!data || abort.signal.aborted) return;
+        fetchCategories().then(data => {
+            if (!data) return;
             cachedCategories = data;
         });
     },
 
     stop() {
         cachedCategories = null;
-        activeAbort?.abort();
-        activeAbort = null;
-        categoryAbort?.abort();
-        categoryAbort = null;
         if (debounceTimer) {
             clearTimeout(debounceTimer);
             debounceTimer = null;
@@ -185,11 +167,8 @@ export default definePlugin({
             FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...cachedCategories });
             return;
         }
-        categoryAbort?.abort();
-        const abort = new AbortController();
-        categoryAbort = abort;
-        fetchCategories(abort.signal).then(data => {
-            if (!data || abort.signal.aborted) return;
+        fetchCategories().then(data => {
+            if (!data) return;
             cachedCategories = data;
             FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...data });
         });
@@ -202,8 +181,6 @@ export default definePlugin({
         }
 
         if (query === "") {
-            activeAbort?.abort();
-            activeAbort = null;
             return false;
         }
 
@@ -233,17 +210,12 @@ export default definePlugin({
         }
         if (type === "Trending") {
             instance.setState({ resultType: type });
-            activeAbort?.abort();
-            const abort = new AbortController();
-            activeAbort = abort;
-            fetchTrending(abort.signal).then(items => {
-                if (abort.signal.aborted) return;
+            fetchTrending().then(items => {
                 FluxDispatcher.dispatch(items.length
                     ? { type: "GIF_PICKER_QUERY_SUCCESS", items }
                     : { type: "GIF_PICKER_QUERY_FAILURE" }
                 );
-            }).catch(err => {
-                if (err.name === "AbortError") return;
+            }).catch(() => {
                 FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE" });
             });
             return true;

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -1,0 +1,254 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Margins } from "@components/margins";
+import { Paragraph } from "@components/Paragraph";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { FluxDispatcher, LocaleStore } from "@webpack/common";
+
+const TENOR_KEY = "3Z0688EVWYKH";
+const RESULT_LIMIT = 100;
+const SEARCH_DEBOUNCE_MS = 250;
+
+let activeAbort: AbortController | null = null;
+let categoryAbort: AbortController | null = null;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let cachedCategories: TrendingCategories | null = null;
+
+interface TenorMedia { url?: string; dims?: [number, number]; preview?: string; }
+interface TenorResult { id: string; title?: string; itemurl?: string; media?: Array<Record<string, TenorMedia>>; }
+interface TenorCategoryTag { searchterm: string; image: string; }
+
+interface DiscordGif {
+    id: string;
+    title: string;
+    url: string;
+    src: string;
+    gif_src: string;
+    width?: number;
+    height?: number;
+    preview?: string;
+}
+
+interface TrendingCategories {
+    trendingCategories: { name: string; src: string; }[];
+    trendingGIFPreview: { src: string; };
+}
+
+interface GifPickerInstance {
+    state: { resultType: string | null; };
+    setState(state: { resultType: string | null; }, callback?: () => void): void;
+    props: { searchBarRef?: { current?: { focus(): void; } | null; }; };
+}
+
+function tenorUrl(path: string, extra: Record<string, string> = {}) {
+    const url = new URL(`https://api.tenor.com/v1/${path}`);
+    url.searchParams.set("key", TENOR_KEY);
+    url.searchParams.set("locale", (LocaleStore.locale).replace("-", "_").toLowerCase());
+    for (const [k, v] of Object.entries(extra))
+        url.searchParams.set(k, v);
+    return url.toString();
+}
+
+function toDiscordGif(item: TenorResult): DiscordGif | null {
+    const media = item.media?.[0];
+    if (!media) return null;
+
+    const { webm, gif } = media;
+    const src = webm?.url ?? gif?.url;
+    const gifSrc = gif?.url ?? src;
+    if (!src || !gifSrc) return null;
+
+    const width = webm?.dims?.[0];
+    const height = webm?.dims?.[1];
+    const preview = webm?.preview;
+
+    return { id: item.id ?? src, title: item.title ?? "", url: item.itemurl ?? gifSrc, src, gif_src: gifSrc, width, height, preview };
+}
+
+function mapGifs(items: TenorResult[]) {
+    return items.map(toDiscordGif).filter((g): g is DiscordGif => g != null);
+}
+
+async function fetchSearch(query: string, signal: AbortSignal) {
+    const res = await fetch(tenorUrl("search", { q: query, limit: String(RESULT_LIMIT) }), { signal });
+    if (!res.ok) return [];
+    const body = await res.json();
+    const items: TenorResult[] = Array.isArray(body) ? body : (body.results ?? body.items ?? []);
+    return mapGifs(items);
+}
+
+async function fetchTrending(signal: AbortSignal) {
+    const res = await fetch(tenorUrl("trending", { limit: String(RESULT_LIMIT) }), { signal });
+    if (!res.ok) return [];
+    const body = await res.json();
+    return mapGifs(body.results ?? []);
+}
+
+async function fetchCategories(signal: AbortSignal): Promise<TrendingCategories | null> {
+    try {
+        const res = await fetch(tenorUrl("categories", { type: "featured" }), { signal });
+        if (!res.ok) return null;
+        const { tags } = await res.json() as { tags?: TenorCategoryTag[]; };
+        if (!tags?.length) return null;
+        return {
+            trendingCategories: tags.map(t => ({ name: t.searchterm, src: t.image })),
+            trendingGIFPreview: { src: tags[0].image }
+        };
+    } catch {
+        return null;
+    }
+}
+
+function doFetch(query: string) {
+    activeAbort?.abort();
+    const abort = new AbortController();
+    activeAbort = abort;
+
+    fetchSearch(query, abort.signal).then(items => {
+        if (abort.signal.aborted) return;
+        FluxDispatcher.dispatch(items.length
+            ? { type: "GIF_PICKER_QUERY_SUCCESS", query, items }
+            : { type: "GIF_PICKER_QUERY_FAILURE", query }
+        );
+    }).catch(err => {
+        if (err.name === "AbortError") return;
+        FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE", query });
+    });
+}
+
+export default definePlugin({
+    name: "TenorGifSearch",
+    description: "Restore Tenor GIF search",
+    authors: [Devs.Lunascape],
+    settingsAboutComponent: () => (
+        <Paragraph className={Margins.bottom16}>
+            This plugin restores Tenor GIF searching after Tenor killed the public API, this uses the Mobile API from GBoard.
+        </Paragraph>
+    ),
+    patches: [
+        {
+            find: "renderHeaderContent()",
+            replacement: [
+                {
+                    match: /(search\((\i),\s*(\i),\s*(\i)\)\s*\{)/,
+                    replace: "$1if($self.handleSearch(this,$2,$3,$4))return;"
+                },
+                {
+                    match: /(handleSelectItem\s*=\s*\((\i),\s*(\i)\)\s*=>\s*\{)/,
+                    replace: "$1if($self.handleSelectItem(this,$2,$3))return;"
+                }
+            ]
+        },
+        {
+            find: "gif_picker",
+            replacement: {
+                match: /\i\.getConfig\(\{location:"gif_picker"\}\)\.provider/,
+                replace: '"tenor"'
+            }
+        },
+        {
+            find: '"GIF_PICKER_TRENDING_FETCH_SUCCESS",trendingCategories:',
+            replacement: {
+                match: /\i\.\i\.get\(\{url:\i\.\i\.GIFS_TRENDING,/,
+                replace: "return $self.handleTrendingFetch();$&"
+            }
+        }
+    ],
+
+    start() {
+        const abort = new AbortController();
+        categoryAbort = abort;
+        fetchCategories(abort.signal).then(data => {
+            if (!data || abort.signal.aborted) return;
+            cachedCategories = data;
+        });
+    },
+
+    stop() {
+        cachedCategories = null;
+        activeAbort?.abort();
+        activeAbort = null;
+        categoryAbort?.abort();
+        categoryAbort = null;
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+        }
+    },
+
+    handleTrendingFetch() {
+        if (cachedCategories) {
+            FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...cachedCategories });
+            return;
+        }
+        categoryAbort?.abort();
+        const abort = new AbortController();
+        categoryAbort = abort;
+        fetchCategories(abort.signal).then(data => {
+            if (!data || abort.signal.aborted) return;
+            cachedCategories = data;
+            FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...data });
+        });
+    },
+
+    handleSearch(instance: GifPickerInstance, query: string, _type: string, immediate: boolean) {
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+        }
+
+        if (query === "") {
+            activeAbort?.abort();
+            activeAbort = null;
+            return false;
+        }
+
+        if (instance.state.resultType !== "Search") {
+            instance.setState({ resultType: "Search" });
+        }
+
+        FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY", query });
+
+        if (immediate) {
+            doFetch(query);
+        } else {
+            debounceTimer = setTimeout(() => doFetch(query), SEARCH_DEBOUNCE_MS);
+        }
+
+        return true;
+    },
+
+    handleSelectItem(instance: GifPickerInstance, type: string, name: string) {
+        if (type === "Category") {
+            FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY", query: name });
+            doFetch(name);
+            instance.setState({ resultType: type }, () => {
+                instance.props.searchBarRef?.current?.focus();
+            });
+            return true;
+        }
+        if (type === "Trending") {
+            instance.setState({ resultType: type });
+            activeAbort?.abort();
+            const abort = new AbortController();
+            activeAbort = abort;
+            fetchTrending(abort.signal).then(items => {
+                if (abort.signal.aborted) return;
+                FluxDispatcher.dispatch(items.length
+                    ? { type: "GIF_PICKER_QUERY_SUCCESS", items }
+                    : { type: "GIF_PICKER_QUERY_FAILURE" }
+                );
+            }).catch(err => {
+                if (err.name === "AbortError") return;
+                FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE" });
+            });
+            return true;
+        }
+        return false;
+    }
+});

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -113,6 +113,10 @@ export default definePlugin({
                 {
                     match: /let \i=Date\.now\(\);\i\([^)]+\),\i\.\i\.get\(\{url:\i\.\i\.GIFS_TRENDING_GIFS,/,
                     replace: "return $self.handleTrendingGifsFetch();$&"
+                },
+                {
+                    match: /\i\.\i\.post\(\{url:\i\.\i\.GIFS_SELECT,body:\{id:(\i),q:(\i),provider:\i\}/,
+                    replace: "return $self.handleGifSelect($1,$2);$&"
                 }
             ]
         }
@@ -158,6 +162,10 @@ export default definePlugin({
             cachedCategories = data;
             FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...data });
         });
+    },
+
+    handleGifSelect(id: string, query: string) {
+        fetch(tenorUrl("registershare", { id, q: query }));
     },
 
     handleTrendingGifsFetch() {

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { Margins } from "@components/margins";
-import { Paragraph } from "@components/Paragraph";
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { FluxDispatcher, LocaleStore } from "@webpack/common";

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -10,15 +10,11 @@ import { FluxDispatcher, LocaleStore } from "@webpack/common";
 
 // API key is taken from the GBoard app on iOS
 const TENOR_KEY = "3Z0688EVWYKH";
-const RESULT_LIMIT = 100;
-const SEARCH_DEBOUNCE_MS = 250;
 
-let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let cachedCategories: TrendingCategories | null = null;
 
 interface TenorMedia { url: string; preview: string; dims: [number, number]; }
 interface TenorResult { id: string; media: Array<Record<string, TenorMedia>>; itemurl: string; }
-
 interface TenorCategoryTag { searchterm: string; image: string; }
 
 interface DiscordGif {
@@ -35,12 +31,6 @@ interface DiscordGif {
 interface TrendingCategories {
     trendingCategories: { name: string; src: string; }[];
     trendingGIFPreview: { src: string; };
-}
-
-interface GifPickerInstance {
-    state: { resultType: string | null; };
-    setState(state: { resultType: string | null; }, callback?: () => void): void;
-    props: { searchBarRef?: RefObject<HTMLInputElement>; };
 }
 
 function tenorUrl(path: string, extra: Record<string, string> = {}) {
@@ -71,20 +61,117 @@ function mapGifs(items: TenorResult[]) {
     return items.map(toDiscordGif).filter((g): g is DiscordGif => g != null);
 }
 
-async function fetchTenorResults(path: string, extra: Record<string, string> = {}) {
-    const res = await fetch(tenorUrl(path, extra));
-    if (!res.ok) return [];
-    const { results = [] } = await res.json();
-    return results as TenorResult[];
+// this is ugly sorry
+async function fetchTenorResults(path: string, limit: number, extra: Record<string, string> = {}) {
+    const pageSize = Math.min(limit, 50);
+    const items: TenorResult[] = [];
+    let pos = "";
+
+    while (items.length < limit) {
+        const params: Record<string, string> = { ...extra, limit: String(Math.min(limit - items.length, pageSize)) };
+        if (pos) params.pos = pos;
+        const res = await fetch(tenorUrl(path, params));
+        if (!res.ok) break;
+        const body = await res.json();
+        const page: TenorResult[] = body.results ?? [];
+        if (!page.length) break;
+        items.push(...page);
+        if (!body.next) break;
+        pos = body.next;
+    }
+
+    return items;
 }
 
-async function fetchSearch(query: string) {
-    return mapGifs(await fetchTenorResults("search", { q: query, limit: String(RESULT_LIMIT) }));
-}
+export default definePlugin({
+    name: "TenorGifSearch",
+    description: "Restore Tenor GIF search",
+    authors: [Devs.Lunascape],
+    patches: [
+        {
+            find: "renderHeaderContent()",
+            replacement: {
+                match: /placeholder:(\i),"aria-label":\i/,
+                replace: 'placeholder:$1.replace(/Giphy|Klipy/gi,"Tenor"),"aria-label":$1.replace(/Giphy|Klipy/gi,"Tenor")'
+            }
+        },
+        {
+            find: '"GIF_PICKER_TRENDING_FETCH_SUCCESS",trendingCategories:',
+            replacement: [
+                {
+                    match: /let \i=Date\.now\(\);\i\([^)]+\),\i\.\i\.get\(\{url:\i\.\i\.GIFS_SEARCH,query:\{q:(\i),/,
+                    replace: "return $self.handleSearchFetch($1);$&"
+                },
+                {
+                    match: /""!==(\i)&&null!=\1&&\i\.\i\.get\(\{url:\i\.\i\.GIFS_SUGGEST,/,
+                    replace: "return $self.handleSuggestionsFetch($1);$&"
+                },
+                {
+                    match: /\i\.\i\.get\(\{url:\i\.\i\.GIFS_TRENDING,/,
+                    replace: "return $self.handleTrendingFetch();$&"
+                },
+                {
+                    match: /let \i=Date\.now\(\);\i\([^)]+\),\i\.\i\.get\(\{url:\i\.\i\.GIFS_TRENDING_GIFS,/,
+                    replace: "return $self.handleTrendingGifsFetch();$&"
+                }
+            ]
+        }
+    ],
 
-async function fetchTrending() {
-    return mapGifs(await fetchTenorResults("trending", { limit: String(RESULT_LIMIT) }));
-}
+    start() {
+        fetchCategories().then(data => {
+            if (!data) return;
+            cachedCategories = data;
+        });
+    },
+
+    handleSearchFetch(query: string) {
+        // discord has a 100 result limit for normal search
+        fetchTenorResults("search", 100, { q: query }).then(results => {
+            const items = mapGifs(results);
+            FluxDispatcher.dispatch(items.length
+                ? { type: "GIF_PICKER_QUERY_SUCCESS", query, items }
+                : { type: "GIF_PICKER_QUERY_FAILURE", query }
+            );
+        }).catch(() => {
+            FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE", query });
+        });
+    },
+
+    handleSuggestionsFetch(query: string) {
+        if (query === "" || query == null) return;
+        fetch(tenorUrl("search_suggestions", { q: query, limit: "5" }))
+            .then(res => res.ok ? res.json() : null)
+            .then(body => {
+                if (!body?.results?.length) return;
+                FluxDispatcher.dispatch({ type: "GIF_PICKER_SUGGESTIONS_SUCCESS", query, items: body.results });
+            });
+    },
+
+    handleTrendingFetch() {
+        if (cachedCategories) {
+            FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...cachedCategories });
+            return;
+        }
+        fetchCategories().then(data => {
+            if (!data) return;
+            cachedCategories = data;
+            FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...data });
+        });
+    },
+
+    handleTrendingGifsFetch() {
+        fetchTenorResults("trending", 50).then(results => {
+            const items = mapGifs(results);
+            FluxDispatcher.dispatch(items.length
+                ? { type: "GIF_PICKER_QUERY_SUCCESS", items }
+                : { type: "GIF_PICKER_QUERY_FAILURE" }
+            );
+        }).catch(() => {
+            FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE" });
+        });
+    }
+});
 
 async function fetchCategories(): Promise<TrendingCategories | null> {
     try {
@@ -100,114 +187,3 @@ async function fetchCategories(): Promise<TrendingCategories | null> {
         return null;
     }
 }
-
-function doFetch(query: string) {
-    fetchSearch(query).then(items => {
-        FluxDispatcher.dispatch(items.length
-            ? { type: "GIF_PICKER_QUERY_SUCCESS", query, items }
-            : { type: "GIF_PICKER_QUERY_FAILURE", query }
-        );
-    }).catch(() => {
-        FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE", query });
-    });
-}
-
-export default definePlugin({
-    name: "TenorGifSearch",
-    description: "Restore Tenor GIF search",
-    authors: [Devs.Lunascape],
-    patches: [
-        {
-            find: "renderHeaderContent()",
-            replacement: [
-                {
-                    match: /(search\((\i),(\i),(\i)\)\{)/,
-                    replace: "$1if($self.handleSearch(this,$2,$3,$4))return;"
-                },
-                {
-                    match: /(handleSelectItem=\((\i),(\i)\)=>\{)/,
-                    replace: "$1if($self.handleSelectItem(this,$2,$3))return;"
-                },
-                {
-                    match: /placeholder:(\i),"aria-label":\i/,
-                    replace: 'placeholder:$1.replace(/Giphy|Klipy/gi,"Tenor"),"aria-label":$1.replace(/Giphy|Klipy/gi,"Tenor")'
-                }
-            ]
-        },
-        {
-            find: '"GIF_PICKER_TRENDING_FETCH_SUCCESS",trendingCategories:',
-            replacement: {
-                match: /\i\.\i\.get\(\{url:\i\.\i\.GIFS_TRENDING,/,
-                replace: "return $self.handleTrendingFetch();$&"
-            }
-        }
-    ],
-
-    start() {
-        fetchCategories().then(data => {
-            if (!data) return;
-            cachedCategories = data;
-        });
-    },
-
-    handleTrendingFetch() {
-        if (cachedCategories) {
-            FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...cachedCategories });
-            return;
-        }
-        fetchCategories().then(data => {
-            if (!data) return;
-            cachedCategories = data;
-            FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...data });
-        });
-    },
-
-    handleSearch(instance: GifPickerInstance, query: string, _type: string, immediate: boolean) {
-        if (debounceTimer) {
-            clearTimeout(debounceTimer);
-            debounceTimer = null;
-        }
-
-        if (query === "") {
-            return false;
-        }
-
-        if (instance.state.resultType !== "Search") {
-            instance.setState({ resultType: "Search" });
-        }
-
-        FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY", query });
-
-        if (immediate) {
-            doFetch(query);
-        } else {
-            debounceTimer = setTimeout(() => doFetch(query), SEARCH_DEBOUNCE_MS);
-        }
-
-        return true;
-    },
-
-    handleSelectItem(instance: GifPickerInstance, type: string, name: string) {
-        if (type === "Category") {
-            FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY", query: name });
-            doFetch(name);
-            instance.setState({ resultType: type }, () => {
-                instance.props.searchBarRef?.current?.focus();
-            });
-            return true;
-        }
-        if (type === "Trending") {
-            instance.setState({ resultType: type });
-            fetchTrending().then(items => {
-                FluxDispatcher.dispatch(items.length
-                    ? { type: "GIF_PICKER_QUERY_SUCCESS", items }
-                    : { type: "GIF_PICKER_QUERY_FAILURE" }
-                );
-            }).catch(() => {
-                FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE" });
-            });
-            return true;
-        }
-        return false;
-    }
-});

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -42,7 +42,7 @@ interface TrendingCategories {
 interface GifPickerInstance {
     state: { resultType: string | null; };
     setState(state: { resultType: string | null; }, callback?: () => void): void;
-    props: { searchBarRef?: { current?: { focus(): void; } | null; }; };
+    props: { searchBarRef?: RefObject<HTMLInputElement> };
 }
 
 function tenorUrl(path: string, extra: Record<string, string> = {}) {

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -62,24 +62,34 @@ function mapGifs(items: TenorResult[]) {
 }
 
 // this is ugly sorry
+// function contributed by taep96 because my original one broke the search result window
 async function fetchTenorResults(path: string, limit: number, extra: Record<string, string> = {}) {
     const pageSize = Math.min(limit, 50);
     const items: TenorResult[] = [];
+    const seen = new Set<string>();
     let pos = "";
-
     while (items.length < limit) {
-        const params: Record<string, string> = { ...extra, limit: String(Math.min(limit - items.length, pageSize)) };
+        const params: Record<string, string> = {
+            ...extra,
+            limit: String(Math.min(limit - items.length, pageSize))
+        };
         if (pos) params.pos = pos;
         const res = await fetch(tenorUrl(path, params));
         if (!res.ok) break;
         const body = await res.json();
         const page: TenorResult[] = body.results ?? [];
         if (!page.length) break;
-        items.push(...page);
-        if (!body.next) break;
+        const previousLength = items.length;
+        for (const item of page) {
+            if (seen.has(item.id)) continue;
+            seen.add(item.id);
+            items.push(item);
+            if (items.length >= limit) break;
+        }
+        if (items.length === previousLength) break;
+        if (!body.next || body.next === pos) break;
         pos = body.next;
     }
-
     return items;
 }
 

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Devs } from "@utils/constants";
+import { isNonNullish } from "@utils/guards";
 import definePlugin from "@utils/types";
 import { FluxDispatcher, LocaleStore } from "@webpack/common";
 
@@ -13,9 +14,20 @@ const TENOR_KEY = "3Z0688EVWYKH";
 
 let cachedCategories: TrendingCategories | null = null;
 
-interface TenorMedia { url: string; preview: string; dims: [number, number]; }
-interface TenorResult { id: string; media: Array<Record<string, TenorMedia>>; itemurl: string; }
-interface TenorCategoryTag { searchterm: string; image: string; }
+interface TenorMedia {
+    url: string;
+    preview: string;
+    dims: [number, number];
+}
+interface TenorResult {
+    id: string;
+    media: Array<Record<string, TenorMedia>>;
+    itemurl: string;
+}
+interface TenorCategoryTag {
+    searchterm: string;
+    image: string;
+}
 
 interface DiscordGif {
     id: string;
@@ -29,74 +41,96 @@ interface DiscordGif {
 }
 
 interface TrendingCategories {
-    trendingCategories: { name: string; src: string; }[];
+    trendingCategories: Record<"name" | "src", string>[];
     trendingGIFPreview: { src: string; };
 }
 
-function tenorUrl(path: string, extra: Record<string, string> = {}) {
-    return `https://api.tenor.com/v1/${path}?` + new URLSearchParams({
-        key: TENOR_KEY,
-        locale: LocaleStore.locale.replace("-", "_").toLowerCase(),
-        ...extra
-    });
-}
-
 function toDiscordGif(item: TenorResult): DiscordGif | null {
-    const media = item.media[0];
-    const { gif, webm } = media;
+    const { gif, webm } = item.media[0];
 
     return {
         id: item.id,
         title: "", // discord always returns a blank string
         url: item.itemurl,
-        src: webm.url,
         gif_src: gif.url,
+        src: webm.url,
         width: webm.dims[0],
         height: webm.dims[1],
         preview: webm.preview
     };
 }
 
-function mapGifs(items: TenorResult[]) {
-    return items.map(toDiscordGif).filter((g): g is DiscordGif => g != null);
+function mapToDiscordGifs(items: TenorResult[]) {
+    return items.map(toDiscordGif).filter(isNonNullish);
 }
 
-// this is ugly sorry
-// function contributed by taep96 because my original one broke the search result window
+async function tenorFetch<TResult>(path: string, params: Record<string, string>) {
+    const url = `https://api.tenor.com/v1${path}?` + new URLSearchParams({
+        key: TENOR_KEY,
+        locale: LocaleStore.locale.replace("-", "_").toLowerCase(),
+        ...params
+    });
+
+    const res = await fetch(url);
+    if (!res.ok)
+        throw new Error(`GET ${path}: Tenor API request failed with status ${res.status}`);
+
+    return res.json() as Promise<TResult>;
+}
+
+// function contributed by taep96
 async function fetchTenorResults(path: string, limit: number, extra: Record<string, string> = {}) {
     const pageSize = Math.min(limit, 50);
     const items: TenorResult[] = [];
     const seen = new Set<string>();
     let pos = "";
+
     while (items.length < limit) {
         const params: Record<string, string> = {
             ...extra,
             limit: String(Math.min(limit - items.length, pageSize))
         };
         if (pos) params.pos = pos;
-        const res = await fetch(tenorUrl(path, params));
-        if (!res.ok) break;
-        const body = await res.json();
-        const page: TenorResult[] = body.results ?? [];
+
+        const { next, results: page } = await tenorFetch<{ next?: string; results: TenorResult[]; }>(path, params);
         if (!page.length) break;
+
         const previousLength = items.length;
         for (const item of page) {
             if (seen.has(item.id)) continue;
             seen.add(item.id);
+
             items.push(item);
             if (items.length >= limit) break;
         }
         if (items.length === previousLength) break;
-        if (!body.next || body.next === pos) break;
-        pos = body.next;
+
+        if (!next || next === pos) break;
+        pos = next;
     }
+
     return items;
+}
+
+async function fetchCategories(): Promise<TrendingCategories | null> {
+    return tenorFetch<{ tags?: TenorCategoryTag[]; }>("/categories", { type: "featured" })
+        .then(({ tags }) => {
+            if (!tags?.length) return null;
+
+            return {
+                trendingCategories: tags.map(t => ({ name: t.searchterm, src: t.image })),
+                trendingGIFPreview: { src: tags[0].image }
+            };
+        })
+        .catch(() => null);
+
 }
 
 export default definePlugin({
     name: "TenorGifSearch",
     description: "Restore Tenor GIF search",
     authors: [Devs.Lunascape],
+
     patches: [
         {
             find: "renderHeaderContent()",
@@ -139,89 +173,77 @@ export default definePlugin({
         }
     ],
 
-    start() {
-        fetchCategories().then(data => {
-            if (!data) return;
-            cachedCategories = data;
-        });
+    async start() {
+        cachedCategories = await fetchCategories() ?? cachedCategories;
     },
 
     handleSearchFetch(query: string) {
         // discord has a 100 result limit for normal search
-        fetchTenorResults("search", 100, { q: query }).then(results => {
-            const items = mapGifs(results);
-            FluxDispatcher.dispatch(items.length
-                ? { type: "GIF_PICKER_QUERY_SUCCESS", query, items }
-                : { type: "GIF_PICKER_QUERY_FAILURE", query }
-            );
-        }).catch(() => {
-            FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE", query });
-        });
-    },
-
-    handleSuggestionsFetch(query: string) {
-        if (query === "" || query == null) return;
-        fetch(tenorUrl("search_suggestions", { q: query, limit: "5" }))
-            .then(res => res.ok ? res.json() : null)
-            .then(body => {
-                if (!body?.results?.length) return;
-                FluxDispatcher.dispatch({ type: "GIF_PICKER_SUGGESTIONS_SUCCESS", query, items: body.results });
+        fetchTenorResults("/search", 100, { q: query })
+            .then(results => {
+                const items = mapToDiscordGifs(results);
+                FluxDispatcher.dispatch(
+                    items.length
+                        ? { type: "GIF_PICKER_QUERY_SUCCESS", query, items }
+                        : { type: "GIF_PICKER_QUERY_FAILURE", query }
+                );
+            })
+            .catch(() => {
+                FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE", query });
             });
     },
 
-    handleTrendingFetch() {
-        if (cachedCategories) {
-            FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...cachedCategories });
-            return;
+    async handleSuggestionsFetch(query: string) {
+        if (!query) return;
+
+        const { results } = await tenorFetch<{ results?: string[]; }>("/search_suggestions", { q: query, limit: "5" });
+
+        FluxDispatcher.dispatch({ type: "GIF_PICKER_SUGGESTIONS_SUCCESS", query, items: results });
+    },
+
+    async handleTrendingFetch() {
+        if (!cachedCategories) {
+            cachedCategories = await fetchCategories();
+
+            if (!cachedCategories) return;
         }
-        fetchCategories().then(data => {
-            if (!data) return;
-            cachedCategories = data;
-            FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...data });
-        });
+
+        FluxDispatcher.dispatch({ type: "GIF_PICKER_TRENDING_FETCH_SUCCESS", ...cachedCategories });
     },
 
     handleGifSelect(id: string, query: string) {
-        fetch(tenorUrl("registershare", { id, q: query }));
+        tenorFetch("/registershare", { id, q: query });
     },
 
     handleTrendingGifsFetch() {
-        fetchTenorResults("trending", 50).then(results => {
-            const items = mapGifs(results);
-            FluxDispatcher.dispatch(items.length
-                ? { type: "GIF_PICKER_QUERY_SUCCESS", items }
-                : { type: "GIF_PICKER_QUERY_FAILURE" }
-            );
-        }).catch(() => {
-            FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE" });
-        });
+        fetchTenorResults("/trending", 50)
+            .then(results => {
+                const items = mapToDiscordGifs(results);
+                FluxDispatcher.dispatch(
+                    items.length
+                        ? { type: "GIF_PICKER_QUERY_SUCCESS", items }
+                        : { type: "GIF_PICKER_QUERY_FAILURE" }
+                );
+            })
+            .catch(() => {
+                FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE" });
+            });
     },
 
     tenorIntegrationSearch(integration: string, query: string) {
         FluxDispatcher.dispatch({ type: "INTEGRATION_QUERY", integration, query });
-        fetchTenorResults("search", 20, { q: query }).then(results => {
-            const items = mapGifs(results);
-            FluxDispatcher.dispatch(items.length
-                ? { type: "INTEGRATION_QUERY_SUCCESS", integration, query, results: items }
-                : { type: "INTEGRATION_QUERY_FAILURE", integration, query }
-            );
-        }).catch(() => {
-            FluxDispatcher.dispatch({ type: "INTEGRATION_QUERY_FAILURE", integration, query, results: [] });
-        });
+
+        fetchTenorResults("/search", 20, { q: query })
+            .then(results => {
+                const items = mapToDiscordGifs(results);
+                FluxDispatcher.dispatch(
+                    items.length
+                        ? { type: "INTEGRATION_QUERY_SUCCESS", integration, query, results: items }
+                        : { type: "INTEGRATION_QUERY_FAILURE", integration, query }
+                );
+            })
+            .catch(() => {
+                FluxDispatcher.dispatch({ type: "INTEGRATION_QUERY_FAILURE", integration, query, results: [] });
+            });
     }
 });
-
-async function fetchCategories(): Promise<TrendingCategories | null> {
-    try {
-        const res = await fetch(tenorUrl("categories", { type: "featured" }));
-        if (!res.ok) return null;
-        const { tags } = await res.json() as { tags?: TenorCategoryTag[]; };
-        if (!tags?.length) return null;
-        return {
-            trendingCategories: tags.map(t => ({ name: t.searchterm, src: t.image })),
-            trendingGIFPreview: { src: tags[0].image }
-        };
-    } catch {
-        return null;
-    }
-}

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -129,6 +129,13 @@ export default definePlugin({
                     replace: "return $self.handleGifSelect($1,$2);$&"
                 }
             ]
+        },
+        {
+            find: '"IntegrationQueryStore"',
+            replacement: {
+                match: /search\((\i),(\i)\)\{null==\i\.getResults\(\1,\2\)&&/,
+                replace: "search($1,$2){return $self.tenorIntegrationSearch($1,$2);null==void 0&&"
+            }
         }
     ],
 
@@ -187,6 +194,19 @@ export default definePlugin({
             );
         }).catch(() => {
             FluxDispatcher.dispatch({ type: "GIF_PICKER_QUERY_FAILURE" });
+        });
+    },
+
+    tenorIntegrationSearch(integration: string, query: string) {
+        FluxDispatcher.dispatch({ type: "INTEGRATION_QUERY", integration, query });
+        fetchTenorResults("search", 20, { q: query }).then(results => {
+            const items = mapGifs(results);
+            FluxDispatcher.dispatch(items.length
+                ? { type: "INTEGRATION_QUERY_SUCCESS", integration, query, results: items }
+                : { type: "INTEGRATION_QUERY_FAILURE", integration, query }
+            );
+        }).catch(() => {
+            FluxDispatcher.dispatch({ type: "INTEGRATION_QUERY_FAILURE", integration, query, results: [] });
         });
     }
 });

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -135,8 +135,8 @@ export default definePlugin({
         {
             find: "renderHeaderContent()",
             replacement: {
-                match: /placeholder:(\i),"aria-label":\i/,
-                replace: 'placeholder:$1.replace(/Giphy|Klipy/gi,"Tenor"),"aria-label":$1.replace(/Giphy|Klipy/gi,"Tenor")'
+                match: /placeholder:(\i),"aria-label":(\i)/,
+                replace: 'placeholder:$1?.replace(/Giphy|Klipy/gi,"Tenor"),"aria-label":$2?.replace(/Giphy|Klipy/gi,"Tenor")'
             }
         },
         {
@@ -167,8 +167,8 @@ export default definePlugin({
         {
             find: '"IntegrationQueryStore"',
             replacement: {
-                match: /search\((\i),(\i)\)\{null==\i\.getResults\(\1,\2\)&&/,
-                replace: "search($1,$2){return $self.tenorIntegrationSearch($1,$2);null==void 0&&"
+                match: /(?<=search\((\i),(\i)\)\{)null==\i\.getResults\(\1,\2\)&&/,
+                replace: "return $self.tenorIntegrationSearch($1,$2);null==void 0&&"
             }
         }
     ],

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -646,6 +646,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "NightmareSan",
         id: 304239816466235392n
     },
+    Lunascape: {
+        name: "Lunascape",
+        id: 383365021415243776n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
Added a plugin that replaces the discord gif search api with one directly from tenor, which should continue working after the API shutdown as it is the same API Gboard on iOS uses, [which Google says will continue working](https://support.google.com/tenor/answer/10455265#zippy=%2Chow-will-this-affect-users).

I know that the other gif providers are kinda lacking so I thought this plugin would be helpful.
(also im sorry if this sucks lol its my first plugin)
## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
