### PR TITLE
MessageEventsApi: fix missing props on options object

### DIFF
--- a/src/api/MessageEvents.ts
+++ b/src/api/MessageEvents.ts
@@ -45,6 +45,8 @@ export interface MessageOptions {
     content: string;
     channel: Channel;
     type?: any;
+    hasStickers: boolean;
+    hasAttachments: boolean;
     openWarningPopout: (props: any) => any;
 }
 
@@ -54,7 +56,26 @@ export type MessageEditListener = (channelId: string, messageId: string, message
 const sendListeners = new Set<MessageSendListener>();
 const editListeners = new Set<MessageEditListener>();
 
-export async function _handlePreSend(channelId: string, messageObj: MessageObject, options: MessageOptions, replyOptions: MessageReplyOptions) {
+interface MessageOptions2 {
+    content: string;
+    channelId: string,
+    command: unknown | null;
+    isGif?: boolean;
+    scheduledTimestamp?: unknown;
+    stickers?: string[];
+    uploads?: CloudUpload[];
+    alsoForwardToChannelId?: unknown;
+}
+
+export async function _handlePreSend(
+    channelId: string,
+    messageObj: MessageObject,
+    options: MessageOptions,
+    replyOptions: MessageReplyOptions,
+    options2: MessageOptions2
+) {
+    options.stickers = options2.stickers;
+    options.uploads = options2.uploads;
     options.replyOptions = replyOptions;
     for (const listener of sendListeners) {
         try {

--- a/src/plugins/_api/messageEvents.ts
+++ b/src/plugins/_api/messageEvents.ts
@@ -38,9 +38,9 @@ export default definePlugin({
             find: ".handleSendMessage,onResize:",
             replacement: {
                 // https://regex101.com/r/7iswuk/1
-                match: /let (\i)=\i\.\i\.parse\((\i),.+?\.getSendMessageOptions\(\{.+?\}\)?;(?=.+?(\i)\.flags=)(?<=\)\(({.+?})\)\.then.+?)/,
-                replace: (m, parsedMessage, channel, replyOptions, extra) => m +
-                    `if(await Vencord.Api.MessageEvents._handlePreSend(${channel}.id,${parsedMessage},${extra},${replyOptions}))` +
+                match: /let (\i)=\i\.\i\.parse\((\i),.+?\.getSendMessageOptions\((\{.+?\})\),.{0,100}?\};(?=.+?(\i)\.flags=)(?<=\)\(({.+?})\)\.then.+?)/,
+                replace: (m, parsedMessage, channel, extra2, replyOptions, extra) => m +
+                    `if(await Vencord.Api.MessageEvents._handlePreSend(${channel}.id,${parsedMessage},${extra},${replyOptions},${extra2}))` +
                     "return{shouldClear:false,shouldRefocus:true};"
             }
         },


### PR DESCRIPTION
discord changed the object we grab so it no longer has the sickers and attachments properties. as a result we need to obtain these properties from other sources.

the current fix is poor, but working. alas, we can't use arguments[0] as this is an arrow function.