### PR TITLE
Experiments: Allow linking experiments by negative index and label.

### DIFF
--- a/src/plugins/experiments/index.tsx
+++ b/src/plugins/experiments/index.tsx
@@ -127,8 +127,32 @@ export default definePlugin({
                 replace: "$&if($1==null)return;"
             }
         },
-
+        {
+            // Expands the experiment regex to allow negative numbers as well as text in the last segment of the URL.
+            find: '"^dev://experiment/',
+            replacement: {
+                match: /(\[0-9\]\+)/,
+                replace: "[a-zA-Z0-9-]+"
+            }
+        },
+        {
+            // Allow linking experiments by their label as well as their value.
+            find: ".EXPERIMENT_TREATMENT&&null",
+            replacement: [
+                {
+                    match: /(?<=find\(\i=>)((\i).value===\i)/,
+                    replace: "{return($1)||($self.matchExperiment(arguments[0].url,$2.label))}"
+                }
+            ]
+        },
     ],
+
+    matchExperiment(url: string, label: string): boolean {
+        const items = url.split("/");
+        const labelCleaned = label.replace(/[^a-zA-Z0-9]+/g, "").toLowerCase();
+        const urlEndCleaned = items[items.length - 1]?.replace(/[^a-zA-Z0-9]+/g, "").toLowerCase();
+        return !!labelCleaned && urlEndCleaned !== undefined && labelCleaned === urlEndCleaned;
+    },
 
     start: () => ExperimentStore.getUserExperimentBucket("2026-01-bug-reporter") > 0 && enableStyle(hideBugReport),
     stop: () => disableStyle(hideBugReport),

--- a/src/plugins/experiments/index.tsx
+++ b/src/plugins/experiments/index.tsx
@@ -135,25 +135,6 @@ export default definePlugin({
                 replace: "[a-zA-Z0-9-]+"
             }
         },
-        {
-            // Allow linking experiments by their label as well as their value.
-            find: ".EXPERIMENT_TREATMENT&&null",
-            replacement: [
-                {
-                    match: /(?<=find\(\i=>)((\i).value===\i)/,
-                    replace: "{return($1)||($self.matchExperiment(arguments[0].url,$2.label))}"
-                }
-            ]
-        },
-    ],
-
-    matchExperiment(url: string, label: string): boolean {
-        const items = url.split("/");
-        const labelCleaned = label.replace(/[^a-zA-Z0-9]+/g, "").toLowerCase();
-        const urlEndCleaned = items[items.length - 1]?.replace(/[^a-zA-Z0-9]+/g, "").toLowerCase();
-        return !!labelCleaned && urlEndCleaned !== undefined && labelCleaned === urlEndCleaned;
-    },
-
     start: () => ExperimentStore.getUserExperimentBucket("2026-01-bug-reporter") > 0 && enableStyle(hideBugReport),
     stop: () => disableStyle(hideBugReport),
 

--- a/src/plugins/experiments/index.tsx
+++ b/src/plugins/experiments/index.tsx
@@ -135,6 +135,8 @@ export default definePlugin({
                 replace: "[a-zA-Z0-9-]+"
             }
         },
+    ],
+
     start: () => ExperimentStore.getUserExperimentBucket("2026-01-bug-reporter") > 0 && enableStyle(hideBugReport),
     stop: () => disableStyle(hideBugReport),
 


### PR DESCRIPTION
Allow linking experiments by negative index, which mainly pertains to -1 for Not Eligible, and their labels, such as "noteligible" or "variant1".

<img width="631" height="1002" alt="image" src="https://github.com/user-attachments/assets/252c76f6-0450-4337-a02e-d94fde9d0acf" />