### PR TITLE
PermissionsViewer, CharacterCounter: fix bugs

### DIFF
--- a/src/plugins/characterCounter/index.tsx
+++ b/src/plugins/characterCounter/index.tsx
@@ -62,7 +62,24 @@ export default definePlugin({
 
         useEffect(() => {
             const listener = () => {
-                setSelectedCount(document.getSelection()?.toString()?.length ?? 0);
+                const selection = document.getSelection();
+                if (!selection || selection.isCollapsed) {
+                    setSelectedCount(0);
+                    return;
+                }
+
+                const editorRoot = editorRef?.current?.ref?.current;
+                if (editorRoot) {
+                    for (const node of [selection.anchorNode, selection.focusNode]) {
+                        const el = node?.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+                        if (!el || !editorRoot.contains(el)) {
+                            setSelectedCount(0);
+                            return;
+                        }
+                    }
+                }
+
+                setSelectedCount(selection.toString().length);
             };
 
             document.addEventListener("selectionchange", listener);

--- a/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/RolesAndUsersPermissions.tsx
@@ -52,12 +52,13 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
         (old, current) => old.length === current.length
     );
 
-    useEffect(() => {
-        permissions.sort((a, b) => a.type - b.type);
-    }, [permissions]);
+    const sortedPermissions = useMemo(
+        () => [...permissions].sort((a, b) => a.type - b.type),
+        [permissions]
+    );
 
     useEffect(() => {
-        const usersToRequest = permissions
+        const usersToRequest = sortedPermissions
             .filter(p => p.type === PermissionOverwriteType.MEMBER && !GuildMemberStore.isMember(guild.id, p.id!))
             .map(({ id }) => id);
 
@@ -69,7 +70,7 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
     }, []);
 
     const [selectedItemIndex, selectItem] = useState(0);
-    const selectedItem = permissions[selectedItemIndex];
+    const selectedItem = sortedPermissions[selectedItemIndex];
 
     const roles = GuildRoleStore.getRolesSnapshot(guild.id);
 
@@ -88,7 +89,7 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
             {selectedItem && (
                 <div className={cl("modal-container")}>
                     <ScrollerThin className={cl("modal-list")} orientation="auto">
-                        {permissions.map((permission, index) => {
+                        {sortedPermissions.map((permission, index) => {
                             const user: User | undefined = UserStore.getUser(permission.id ?? "");
                             const role: Role | undefined = roles[permission.id ?? ""];
                             const roleIconSrc = role != null ? getRoleIconSrc(role) : undefined;
@@ -167,7 +168,7 @@ function RolesAndUsersPermissionsComponent({ permissions, guild, modalProps, hea
                                 if (permissions != null)
                                     return (permissions & bit) === bit
                                         ? "allowed"
-                                        : "denied";
+                                        : "default";
 
                                 if (overwriteAllow && (overwriteAllow & bit) === bit)
                                     return "allowed";

--- a/src/plugins/permissionsViewer/components/UserPermissions.tsx
+++ b/src/plugins/permissionsViewer/components/UserPermissions.tsx
@@ -111,10 +111,10 @@ function UserPermissionsComponent({ guild, guildMember, closePopout }: { guild: 
             });
         }
 
-        sortUserRoles(userRoles);
+        const sortedUserRoles = sortUserRoles(userRoles);
 
         for (const bit of Object.values(PermissionsBits)) {
-            for (const { permissions, colorString, position, name } of userRoles) {
+            for (const { permissions, colorString, position, name } of sortedUserRoles) {
                 if ((permissions & bit) === bit) {
                     userPermissions.push({
                         permission: guildPermissionSpecMap[String(bit)].title,
@@ -131,7 +131,7 @@ function UserPermissionsComponent({ guild, guildMember, closePopout }: { guild: 
         userPermissions.sort((a, b) => b.rolePosition - a.rolePosition);
 
         return [rolePermissions, userPermissions];
-    }, [permissionsSortOrder]);
+    }, [permissionsSortOrder, guild.id, guildMember.userId]);
 
     return <div>
         <div className={cl("user-header-container")}>

--- a/src/plugins/permissionsViewer/utils.ts
+++ b/src/plugins/permissionsViewer/utils.ts
@@ -39,9 +39,9 @@ export function getSortedRolesForMember({ id: guildId }: Guild, member: GuildMem
 export function sortUserRoles(roles: Role[]) {
     switch (settings.store.permissionsSortOrder) {
         case PermissionsSortOrder.HighestRole:
-            return roles.sort((a, b) => b.position - a.position);
+            return [...roles].sort((a, b) => b.position - a.position);
         case PermissionsSortOrder.LowestRole:
-            return roles.sort((a, b) => a.position - b.position);
+            return [...roles].sort((a, b) => a.position - b.position);
         default:
             return roles;
     }
@@ -50,7 +50,7 @@ export function sortUserRoles(roles: Role[]) {
 export function sortPermissionOverwrites<T extends { id: string; type: number; }>(overwrites: T[], guildId: string) {
     const roles = GuildRoleStore.getRolesSnapshot(guildId);
 
-    return overwrites.sort((a, b) => {
+    return [...overwrites].sort((a, b) => {
         if (a.type !== PermissionOverwriteType.ROLE || b.type !== PermissionOverwriteType.ROLE) return 0;
 
         const roleA = roles[a.id];


### PR DESCRIPTION
## Describe your Changes

PermissionsViewer was showing every unset role permission bit as denied. Those should just be hidden.

Also copy arrays before sorting so we don't mutate props, and actually use the return value of sortUserRoles.

CharacterCounter was counting selected text from anywhere on the page. Only count selection inside the chat editor.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent