### PR TITLE
feat(plugin): add FrequentFriends plugin

### DIFF
--- a/src/plugins/FrequentFriends/LICENSE
+++ b/src/plugins/FrequentFriends/LICENSE
@@ -1,0 +1,13 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  For the complete license text, see: https://www.gnu.org/licenses/gpl-3.0.txt

--- a/src/plugins/FrequentFriends/README.md
+++ b/src/plugins/FrequentFriends/README.md
@@ -4,7 +4,9 @@ Brings back Discord's removed "Frequently Contacted" list directly to your DM si
 
 ## Preview
 
-<!-- Add your screenshots here -->
+<img width="593" height="669" alt="frequentfriendsscreenshot" src="https://github.com/user-attachments/assets/0011b1ad-a364-4fc8-a685-ecc264829800" /> <img width="590" height="674" alt="frequentscreenshot" src="https://github.com/user-attachments/assets/20d94c57-4f24-4d0b-a2d7-7eae8e30ce18" />
+
+
 
 ## Features
 

--- a/src/plugins/FrequentFriends/README.md
+++ b/src/plugins/FrequentFriends/README.md
@@ -1,0 +1,33 @@
+# FrequentFriends
+
+Brings back Discord's removed "Frequently Contacted" list directly to your DM sidebar. Ranks friends by actual DM and voice activity using an exponential decay model, so recent interactions always matter more than old ones.
+
+## Preview
+
+<!-- Add your screenshots here -->
+
+## Features
+
+- **Smart Ranking:** Scores friends based on DM message frequency and voice co-presence time, with exponential decay so recent activity weighs more
+- **Fire & Snowflake Badges:** Most frequent friend gets a 🔥 badge, least frequent gets a ❄️ badge
+- **Presence-Aware:** Respects online/offline status with an option to include offline friends
+- **Affinity Sync:** Optionally seeds initial scores from Discord's internal affinity store for a better cold-start experience
+- **Per-Account Data:** Frequency data is stored separately per Discord account
+- **Reset & Undo:** Wipe all data with a one-click reset, with a backup you can restore immediately
+
+## Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| Custom Label | `Frequent Friends` | Title shown above the avatar row (max 30 chars) |
+| Max Friends | `5` | How many avatars to show (3–10) |
+| Show Offline | `off` | Include offline and invisible friends |
+| Ignore Affinities | `off` | Skip Discord's affinity data, use only your own tracked interactions |
+| Reset All Data | — | Wipes all tracked scores (saves a backup first) |
+| Undo Reset | — | Restores your data from the latest backup |
+
+## Data Storage
+
+Frequency data is stored per-account in Vencord's DataStore under the key `FrequentFriends_<userId>`.
+
+The `FrequencyData` object uses abbreviated field names (`ds`, `vs`, `dl`, `vl`, `af`) to reduce storage size. **Do not rename these fields** without a migration step — existing entries will silently lose their scores.

--- a/src/plugins/FrequentFriends/constants.ts
+++ b/src/plugins/FrequentFriends/constants.ts
@@ -1,0 +1,16 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export const STORE_KEY_PREFIX = "FrequentFriends_";
+export const HALF_LIFE_MS = 7 * 86400000;
+export const DM_POINTS = 1.0;
+export const VC_POINTS = 0.5;
+export const DM_WEIGHT = 1.0;
+export const VC_WEIGHT = 2.0;
+export const AFFINITY_WEIGHT = 0.1;
+export const DM_COOLDOWN_MS = 10000;
+export const MIN_SCORE_THRESHOLD = 0.05;
+export const KEEP_TOP_ENTRIES = 200;

--- a/src/plugins/FrequentFriends/index.tsx
+++ b/src/plugins/FrequentFriends/index.tsx
@@ -1,0 +1,187 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import definePlugin from "@utils/types";
+import { React } from "@webpack/common";
+import {
+    ChannelStore,
+    FluxDispatcher,
+    UserStore,
+    VoiceStateStore
+} from "@webpack/common";
+import {
+    currentVoiceChannelId,
+    frequencyCache,
+    lastBackup,
+    loadData,
+    recordInteraction,
+    setCurrentVoiceChannelId,
+    setFrequencyCache,
+    setLastBackup,
+    startVoiceScoring,
+    stopVoiceScoring,
+    subscribeToBackupChanges,
+    subscribeToScoreChanges,
+    syncWithAffinities
+} from "./scoring";
+import settings, { pluginCallbacks } from "./settings";
+import { getForceUpdateWidget, isPluginEnabled, setIsEnabled } from "./state";
+import { FrequentFriendsWidget } from "./ui";
+import "./style.css";
+
+// Wire up settings callbacks to scoring module (avoids circular dependency)
+pluginCallbacks.getFrequencyCache = () => frequencyCache;
+pluginCallbacks.setFrequencyCache = cache => setFrequencyCache(cache);
+pluginCallbacks.getLastBackup = () => lastBackup;
+pluginCallbacks.setLastBackup = backup => setLastBackup(backup);
+pluginCallbacks.syncWithAffinities = () => syncWithAffinities();
+pluginCallbacks.subscribeToBackupChanges = fn => subscribeToBackupChanges(fn);
+pluginCallbacks.subscribeToScoreChanges = fn => subscribeToScoreChanges(fn);
+
+interface FluxMessageEvent {
+    message?: {
+        author?: { id?: string; };
+        channel_id?: string;
+    };
+}
+
+interface FluxVoiceStateEvent {
+    voiceStates?: Array<{
+        userId: string;
+        channelId?: string | null;
+    }>;
+}
+
+function onMessage(e: FluxMessageEvent) {
+    const msg = e?.message;
+    const currentUser = UserStore.getCurrentUser();
+    if (!msg?.author?.id || !currentUser) return;
+    const channel = ChannelStore.getChannel(msg.channel_id!);
+    if (!channel || channel.type !== 1) return;
+    const targetId = msg.author.id === currentUser.id ? channel.recipients?.[0] : msg.author.id;
+    if (targetId) recordInteraction(targetId, "dm");
+}
+
+function onVoiceStateUpdate(e: FluxVoiceStateEvent) {
+    const currentUser = UserStore.getCurrentUser();
+    if (!currentUser) return;
+    if (!Array.isArray(e?.voiceStates)) return;
+    for (const vs of e.voiceStates) {
+        if (vs.userId !== currentUser.id) continue;
+        const newChannelId = vs.channelId ?? null;
+        if (newChannelId === currentVoiceChannelId) return;
+        setCurrentVoiceChannelId(newChannelId);
+        newChannelId ? startVoiceScoring() : stopVoiceScoring();
+        return;
+    }
+}
+
+// syncTimeout is kept at module scope so stop() can cancel it and prevent
+// a stale account's affinity data from being written into the new account's store.
+let syncTimeout: ReturnType<typeof setTimeout> | null = null;
+
+async function onCurrentUserUpdate() {
+    if (syncTimeout) {
+        clearTimeout(syncTimeout);
+        syncTimeout = null;
+    }
+    if (!isPluginEnabled()) return;
+    stopVoiceScoring();
+    setCurrentVoiceChannelId(null);
+    await loadData();
+    // Discord stores take some time to flush old data and load new data on account switch.
+    // Delaying the affinity sync prevents cross-account data pollution.
+    syncTimeout = setTimeout(() => {
+        syncTimeout = null;
+        if (isPluginEnabled()) syncWithAffinities();
+    }, 5000);
+}
+
+export default definePlugin({
+    name: "FrequentFriends",
+    description: "Shows friends you interact with most frequently in your DM sidebar.",
+    authors: [{ name: "0nerf", id: 515200391395409920n }],
+    settings,
+
+    patches: [
+        {
+            find: '"dm-quick-launcher"===',
+            replacement: [
+                {
+                    // Guard against double-wrapping on plugin restart:
+                    // if the function is already our wrapper (_ffWrapped flag),
+                    // return it as-is instead of wrapping again.
+                    match: /(renderSection:)([^,}]+)/,
+                    replace: "$1 (this._ffRenderSection ??= $self.hookRenderSection(this, $2))"
+                }
+            ]
+        }
+    ],
+
+    hookRenderSection(instance: any, originalRenderSection: Function) {
+        // Bail out early if this instance was already patched — prevents double-wrap
+        // when the plugin is stopped and restarted without a full client reload.
+        if (typeof originalRenderSection === "function" && (originalRenderSection as any)._ffWrapped) {
+            return originalRenderSection;
+        }
+
+        const wrapped = function (this: any, e: any) {
+            const originalResult = originalRenderSection.call(instance, e);
+            if (e.section === 1 && isPluginEnabled()) {
+                return (
+                    <React.Fragment key="ff-section-1">
+                        <ErrorBoundary noop>
+                            <FrequentFriendsWidget />
+                        </ErrorBoundary>
+                        {originalResult}
+                    </React.Fragment>
+                );
+            }
+            return originalResult;
+        };
+
+        // Mark so we can detect re-wrapping on restart
+        Object.defineProperty(wrapped, "_ffWrapped", { value: true, writable: false });
+        return wrapped;
+    },
+
+    async start() {
+        setIsEnabled(true);
+        getForceUpdateWidget()?.();
+        await loadData();
+        await syncWithAffinities();
+        FluxDispatcher.subscribe("MESSAGE_CREATE", onMessage);
+        FluxDispatcher.subscribe("VOICE_STATE_UPDATES", onVoiceStateUpdate);
+        FluxDispatcher.subscribe("CURRENT_USER_UPDATE", onCurrentUserUpdate);
+        this._initVoiceState();
+    },
+
+    _initVoiceState() {
+        const currentUser = UserStore.getCurrentUser();
+        if (!currentUser) return;
+        const myState = (VoiceStateStore as any).getVoiceStateForUser?.(currentUser.id);
+        if (myState?.channelId) {
+            setCurrentVoiceChannelId(myState.channelId);
+            startVoiceScoring();
+        }
+    },
+
+    stop() {
+        setIsEnabled(false);
+        getForceUpdateWidget()?.();
+        stopVoiceScoring();
+        setCurrentVoiceChannelId(null);
+        // Cancel any pending affinity sync to prevent writing stale account data
+        if (syncTimeout) {
+            clearTimeout(syncTimeout);
+            syncTimeout = null;
+        }
+        FluxDispatcher.unsubscribe("MESSAGE_CREATE", onMessage);
+        FluxDispatcher.unsubscribe("VOICE_STATE_UPDATES", onVoiceStateUpdate);
+        FluxDispatcher.unsubscribe("CURRENT_USER_UPDATE", onCurrentUserUpdate);
+    }
+});

--- a/src/plugins/FrequentFriends/scoring.ts
+++ b/src/plugins/FrequentFriends/scoring.ts
@@ -1,0 +1,212 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { DataStore } from "@api/index";
+import { findByPropsLazy } from "@webpack";
+import {
+    RelationshipStore,
+    UserStore,
+    VoiceStateStore
+} from "@webpack/common";
+import {
+    AFFINITY_WEIGHT,
+    DM_COOLDOWN_MS,
+    DM_POINTS,
+    DM_WEIGHT,
+    HALF_LIFE_MS,
+    KEEP_TOP_ENTRIES,
+    MIN_SCORE_THRESHOLD,
+    STORE_KEY_PREFIX,
+    VC_POINTS,
+    VC_WEIGHT
+} from "./constants";
+import settings from "./settings";
+import type { FrequencyData } from "./types";
+
+const UserAffinitiesStore = findByPropsLazy("getUserAffinities");
+
+export let frequencyCache: Record<string, FrequencyData> = Object.create(null);
+export let lastBackup: Record<string, FrequencyData> | null = null;
+let voiceScoreInterval: ReturnType<typeof setInterval> | null = null;
+// Global lock to prevent a race between _initVoiceState and onVoiceStateUpdate
+// both calling startVoiceScoring() before the first interval is fully registered.
+let voiceScoringActive = false;
+export let currentVoiceChannelId: string | null = null;
+let saveDebounce: ReturnType<typeof setTimeout> | null = null;
+let currentStoreKey: string = STORE_KEY_PREFIX + "default";
+
+const scoreListeners = new Set<() => void>();
+export function subscribeToScoreChanges(fn: () => void): () => void {
+    scoreListeners.add(fn);
+    return () => scoreListeners.delete(fn);
+}
+function notifyScoreListeners() { for (const fn of scoreListeners) fn(); }
+
+const backupListeners = new Set<() => void>();
+export function subscribeToBackupChanges(fn: () => void): () => void {
+    backupListeners.add(fn);
+    return () => backupListeners.delete(fn);
+}
+function notifyBackupListeners() { for (const fn of backupListeners) fn(); }
+
+export function setFrequencyCache(cache: Record<string, FrequencyData>) {
+    frequencyCache = cache;
+    notifyScoreListeners();
+}
+export function setLastBackup(backup: Record<string, FrequencyData> | null) {
+    lastBackup = backup;
+    notifyBackupListeners();
+}
+export function setCurrentVoiceChannelId(id: string | null) { currentVoiceChannelId = id; }
+
+function isSafeUserId(userId: unknown): userId is string {
+    if (!userId || typeof userId !== "string") return false;
+    if (userId === "__proto__" || userId === "constructor" || userId === "prototype") return false;
+    return true;
+}
+
+export function expDecay(elapsedMs: number): number {
+    if (elapsedMs <= 0) return 1;
+    return Math.pow(0.5, elapsedMs / HALF_LIFE_MS);
+}
+
+export async function loadData() {
+    const currentUser = UserStore.getCurrentUser();
+    currentStoreKey = currentUser
+        ? STORE_KEY_PREFIX + currentUser.id
+        : STORE_KEY_PREFIX + "default";
+    try {
+        const source = await DataStore.get(currentStoreKey).catch(() => ({}));
+        frequencyCache = (source && typeof source === "object") ? source : Object.create(null);
+    } catch {
+        frequencyCache = Object.create(null);
+    }
+    notifyScoreListeners();
+}
+
+export function queueSave() {
+    if (saveDebounce) clearTimeout(saveDebounce);
+    saveDebounce = setTimeout(() => {
+        saveDebounce = null;
+        DataStore.set(currentStoreKey, frequencyCache).catch(e => console.warn(e));
+    }, 400);
+}
+
+export function getCurrentStoreKey(): string { return currentStoreKey; }
+
+function pruneCache() {
+    const entries = Object.entries(frequencyCache);
+    if (entries.length <= KEEP_TOP_ENTRIES) return;
+    const sorted = entries
+        .map(([id, data]) => ({ id, score: getCompositeScore(data) }))
+        .sort((a, b) => b.score - a.score);
+    for (const { id, score } of sorted.slice(KEEP_TOP_ENTRIES)) {
+        if (score < MIN_SCORE_THRESHOLD) delete frequencyCache[id];
+    }
+}
+
+function getSafeAffinities(): any[] {
+    if (settings.store.ignoreAffinities) return [];
+    try {
+        if (!UserAffinitiesStore || typeof UserAffinitiesStore.getUserAffinities !== "function") return [];
+        const data = UserAffinitiesStore.getUserAffinities();
+        return Array.isArray(data) ? data : [];
+    } catch {
+        return [];
+    }
+}
+
+export async function syncWithAffinities() {
+    if (settings.store.ignoreAffinities) return;
+    const affinities = getSafeAffinities();
+    if (affinities.length === 0) return;
+    const now = Date.now();
+    let changed = false;
+    for (const affinity of affinities) {
+        const userId = affinity.otherUserId ?? affinity.user_id;
+        if (!isSafeUserId(userId)) continue;
+        if (!RelationshipStore.isFriend(userId)) continue;
+        const dmP: number = affinity.dmProbability ?? 0;
+        const vcP: number = affinity.vcProbability ?? 0;
+        if (!frequencyCache[userId]) {
+            frequencyCache[userId] = {
+                ds: dmP * 20,
+                vs: vcP * 20,
+                dl: dmP > 0 ? now : 0,
+                vl: vcP > 0 ? now : 0,
+                af: (dmP + vcP) * 50
+            };
+            changed = true;
+        }
+    }
+    if (changed) {
+        queueSave();
+        notifyScoreListeners();
+    }
+}
+
+export function getCompositeScore(data: FrequencyData): number {
+    const now = Date.now();
+    const dmDecayed = data.dl > 0 ? data.ds * expDecay(now - data.dl) : 0;
+    const vcDecayed = data.vl > 0 ? data.vs * expDecay(now - data.vl) : 0;
+    const affinityPart = settings.store.ignoreAffinities ? 0 : data.af * AFFINITY_WEIGHT;
+    return dmDecayed * DM_WEIGHT + vcDecayed * VC_WEIGHT + affinityPart;
+}
+
+export function recordInteraction(userId: string, type: "dm" | "voice", weight: number = 1) {
+    if (!isSafeUserId(userId)) return;
+    if (!RelationshipStore.isFriend(userId)) return;
+    const now = Date.now();
+    if (!frequencyCache[userId]) frequencyCache[userId] = { ds: 0, vs: 0, dl: 0, vl: 0, af: 0 };
+    const entry = frequencyCache[userId];
+    if (type === "dm") {
+        const elapsed = entry.dl > 0 ? now - entry.dl : 0;
+        const cooldown = elapsed >= DM_COOLDOWN_MS ? 1 : elapsed / DM_COOLDOWN_MS;
+        entry.ds = entry.ds * expDecay(elapsed) + DM_POINTS * weight * cooldown;
+        entry.dl = now;
+    } else {
+        const elapsed = entry.vl > 0 ? now - entry.vl : 0;
+        entry.vs = entry.vs * expDecay(elapsed) + VC_POINTS * weight;
+        entry.vl = now;
+    }
+    pruneCache();
+    queueSave();
+    notifyScoreListeners();
+}
+
+export function getRankedFriendIds(): string[] {
+    return Object.entries(frequencyCache)
+        .filter(([id]) => RelationshipStore.isFriend(id))
+        .map(([id, data]) => ({ id, score: getCompositeScore(data) }))
+        .sort((a, b) => b.score - a.score)
+        .map(e => e.id);
+}
+
+export function startVoiceScoring() {
+    // Prevent double-interval: if a race between _initVoiceState and
+    // onVoiceStateUpdate causes two startVoiceScoring() calls before the
+    // first setInterval is registered, the lock blocks the second one.
+    if (voiceScoringActive) {
+        stopVoiceScoring();
+    }
+    voiceScoringActive = true;
+    voiceScoreInterval = setInterval(() => {
+        const currentUser = UserStore.getCurrentUser();
+        if (!currentUser || !currentVoiceChannelId) { stopVoiceScoring(); return; }
+        const allVoiceStates = VoiceStateStore.getVoiceStatesForChannel(currentVoiceChannelId);
+        if (!allVoiceStates) return;
+        for (const peerId of Object.keys(allVoiceStates)) {
+            if (peerId !== currentUser.id && RelationshipStore.isFriend(peerId)) {
+                recordInteraction(peerId, "voice");
+            }
+        }
+    }, 60000);
+}
+
+export function stopVoiceScoring() {
+    voiceScoringActive = false;
+    if (voiceScoreInterval) { clearInterval(voiceScoreInterval); voiceScoreInterval = null; }
+}

--- a/src/plugins/FrequentFriends/settings.tsx
+++ b/src/plugins/FrequentFriends/settings.tsx
@@ -1,0 +1,107 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { DataStore } from "@api/index";
+import { OptionType } from "@utils/types";
+import { Button, UserStore, useEffect, useState } from "@webpack/common";
+import { STORE_KEY_PREFIX } from "./constants";
+import type { FrequencyData } from "./types";
+
+export const pluginCallbacks = {
+    syncWithAffinities: async () => {},
+    getFrequencyCache: (): Record<string, FrequencyData> => ({}),
+    setFrequencyCache: (_cache: Record<string, FrequencyData>) => {},
+    getLastBackup: (): Record<string, FrequencyData> | null => null,
+    setLastBackup: (_backup: Record<string, FrequencyData> | null) => {},
+    subscribeToBackupChanges: (_fn: () => void): (() => void) => () => {},
+    subscribeToScoreChanges: (_fn: () => void): (() => void) => () => {},
+};
+
+function getCurrentStoreKey(): string {
+    const user = UserStore.getCurrentUser();
+    return STORE_KEY_PREFIX + (user ? user.id : "default");
+}
+
+function ResetButton() {
+    return (
+        <Button
+            color={Button.Colors.RED}
+            size={Button.Sizes.SMALL}
+            onClick={async () => {
+                pluginCallbacks.setLastBackup(JSON.parse(JSON.stringify(pluginCallbacks.getFrequencyCache())));
+                pluginCallbacks.setFrequencyCache({});
+                await DataStore.set(getCurrentStoreKey(), {}).catch(e => console.warn(e));
+                await pluginCallbacks.syncWithAffinities();
+            }}
+        >
+            Reset All Data
+        </Button>
+    );
+}
+
+function UndoButton() {
+    const [hasBackup, setHasBackup] = useState(() => !!pluginCallbacks.getLastBackup());
+
+    useEffect(() => pluginCallbacks.subscribeToBackupChanges(() => {
+        setHasBackup(!!pluginCallbacks.getLastBackup());
+    }), []);
+
+    return (
+        <Button
+            color={Button.Colors.BRAND}
+            size={Button.Sizes.SMALL}
+            disabled={!hasBackup}
+            onClick={async () => {
+                const backup = pluginCallbacks.getLastBackup();
+                if (!backup) return;
+                pluginCallbacks.setFrequencyCache(JSON.parse(JSON.stringify(backup)));
+                pluginCallbacks.setLastBackup(null);
+                await DataStore.set(getCurrentStoreKey(), pluginCallbacks.getFrequencyCache()).catch(e => console.warn(e));
+            }}
+        >
+            Undo Reset
+        </Button>
+    );
+}
+
+const settings = definePluginSettings({
+    customLabel: {
+        type: OptionType.STRING,
+        description: "Custom title for the list",
+        default: "Frequent Friends",
+        maxLength: 30
+    },
+    maxFriends: {
+        type: OptionType.SLIDER,
+        description: "Maximum number of frequent friends to show",
+        default: 5,
+        markers: [3, 4, 5, 6, 7, 8, 9, 10],
+        stickToMarkers: true
+    },
+    showOffline: {
+        type: OptionType.BOOLEAN,
+        description: "Show offline friends",
+        default: false
+    },
+    ignoreAffinities: {
+        type: OptionType.BOOLEAN,
+        description: "Pure manual mode",
+        default: false
+    },
+    resetData: {
+        type: OptionType.COMPONENT,
+        description: "Wipe all frequency and affinity data from the plugin",
+        component: ResetButton
+    },
+    undoReset: {
+        type: OptionType.COMPONENT,
+        description: "Restore data if you reset by mistake",
+        component: UndoButton
+    }
+});
+
+export default settings;

--- a/src/plugins/FrequentFriends/state.ts
+++ b/src/plugins/FrequentFriends/state.ts
@@ -1,0 +1,15 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// Shared runtime state to avoid circular imports between index.tsx and ui.tsx
+
+let _isEnabled = false;
+export function isPluginEnabled() { return _isEnabled; }
+export function setIsEnabled(v: boolean) { _isEnabled = v; }
+
+let _forceUpdate: (() => void) | null = null;
+export function getForceUpdateWidget() { return _forceUpdate; }
+export function setForceUpdateWidget(fn: (() => void) | null) { _forceUpdate = fn; }

--- a/src/plugins/FrequentFriends/style.css
+++ b/src/plugins/FrequentFriends/style.css
@@ -1,0 +1,106 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#frequentFriends-root {
+    padding: 0 8px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+#frequentFriends-root .ff-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--channels-default);
+    padding: 8px 4px 4px 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    line-height: 1;
+}
+
+#frequentFriends-root .ff-label-text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+
+#frequentFriends-root .ff-info-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    cursor: default;
+    /* Prevent the info icon from being clipped by the parent's overflow:hidden */
+    flex-shrink: 0;
+}
+
+#frequentFriends-root .ff-info-icon {
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    background: var(--background-modifier-accent, #6d7078);
+    color: var(--header-primary, #f2f3f5);
+    font-size: 11px;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#frequentFriends-root .ff-avatars {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 4px 4px 0 8px;
+    padding-bottom: 8px;
+}
+
+#frequentFriends-root .ff-avatar-wrap {
+    position: relative;
+    cursor: pointer;
+    border-radius: 999px;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+}
+
+#frequentFriends-root .ff-avatar-inner-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 32px;
+    height: 32px;
+}
+
+#frequentFriends-root .ff-avatar-inner {
+    width: 32px !important;
+    height: 32px !important;
+    display: block;
+}
+
+#frequentFriends-root .ff-badge {
+    position: absolute;
+    top: -5px;
+    width: 16px;
+    height: 16px;
+    border-radius: 999px;
+    background: var(--background-secondary-alt, #2b2d31);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 3;
+}
+
+#frequentFriends-root .ff-badge-fire { left: -5px; }
+#frequentFriends-root .ff-badge-snow { right: -5px; }
+
+#frequentFriends-root .ff-empty {
+    padding: 0 8px 4px;
+    font-size: 11px;
+    color: var(--text-muted);
+}

--- a/src/plugins/FrequentFriends/types.ts
+++ b/src/plugins/FrequentFriends/types.ts
@@ -1,0 +1,26 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export type PresenceStatus = "online" | "idle" | "dnd" | "offline" | "invisible";
+
+/**
+ * Persistent frequency data stored per user in DataStore.
+ * Field names are intentionally abbreviated to reduce storage footprint.
+ * Do NOT rename these fields without a migration step — existing entries
+ * in users' DataStore will silently lose their data.
+ */
+export interface FrequencyData {
+    /** dm score — exponentially-decayed sum of DM interaction points */
+    ds: number;
+    /** voice score — exponentially-decayed sum of voice co-presence points */
+    vs: number;
+    /** dm last — timestamp (ms) of the last recorded DM interaction */
+    dl: number;
+    /** voice last — timestamp (ms) of the last recorded voice interaction */
+    vl: number;
+    /** affinity seed — initial score contribution seeded from Discord's affinity store */
+    af: number;
+}

--- a/src/plugins/FrequentFriends/ui.tsx
+++ b/src/plugins/FrequentFriends/ui.tsx
@@ -1,0 +1,213 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findByPropsLazy } from "@webpack";
+import {
+    Avatar,
+    PresenceStore,
+    RelationshipStore,
+    Tooltip,
+    UserStore,
+    useEffect,
+    useMemo,
+    useState,
+    useStateFromStores
+} from "@webpack/common";
+import { getRankedFriendIds, subscribeToScoreChanges } from "./scoring";
+import settings from "./settings";
+import { isPluginEnabled, setForceUpdateWidget } from "./state";
+import type { PresenceStatus } from "./types";
+import { JSX } from "react";
+
+const ChannelNavActions = findByPropsLazy("selectPrivateChannel");
+const PrivateChannelActions = findByPropsLazy("openPrivateChannel", "ensurePrivateChannel");
+
+function normalizeStatus(raw: string): PresenceStatus {
+    switch (raw) {
+        case "online": case "idle": case "dnd": case "invisible": return raw;
+        default: return "offline";
+    }
+}
+
+function useStatus(userId: string): PresenceStatus {
+    return useStateFromStores(
+        [PresenceStore],
+        () => normalizeStatus((PresenceStore as any)?.getStatus?.(userId) ?? "offline")
+    );
+}
+
+function UserAvatar({ userId, isFirst, isLast }: {
+    userId: string;
+    isFirst: boolean;
+    isLast: boolean;
+}) {
+    const user = UserStore.getUser(userId);
+    const status = useStatus(userId);
+    const [isHovered, setIsHovered] = useState(false);
+
+    if (!user) return null;
+
+    const name = user.globalName ?? user.username ?? "Unknown";
+
+    // Memoize the decoration URL so repeated renders (hover, presence changes)
+    // don't allocate a new string on every call — noticeable with many avatars.
+    const avatarDecorationUrl = useMemo(() => {
+        const asset = user.avatarDecorationData?.asset;
+        if (!asset) return undefined;
+        const ext = isHovered ? "png" : "webp";
+        const pt = isHovered ? "true" : "false";
+        return `https://cdn.discordapp.com/avatar-decoration-presets/${asset}.${ext}?size=48&passthrough=${pt}`;
+    }, [user.avatarDecorationData?.asset, isHovered]);
+
+    let badge: JSX.Element | null = null;
+    if (isFirst) {
+        badge = (
+            <Tooltip text="Most Frequent" position="top">
+                {(props: any) => (
+                    <div {...props} className="ff-badge ff-badge-fire">
+                        <svg width="10" height="12" viewBox="0 0 10 14">
+                            <path d="M5 0C3 3 0 6 0 9.5C0 12 2.2 14 5 14S10 12 10 9.5C10 7 8 4.5 7 3C8 5 8 7 7 9C6 6 5.5 3 5 0Z" fill="white" />
+                            <path d="M5 7C4 8.5 3 10 3 11.5C3 12.9 3.9 13.5 5 13.5S7 12.9 7 11.5C7 10 6 8.5 5 7Z" fill="var(--background-secondary-alt,#2b2d31)" />
+                        </svg>
+                    </div>
+                )}
+            </Tooltip>
+        );
+    } else if (isLast) {
+        badge = (
+            <Tooltip text="Cooling off" position="top">
+                {(props: any) => (
+                    <div {...props} className="ff-badge ff-badge-snow">
+                        <svg width="12" height="12" viewBox="-11 -11 22 22" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                            {[0, 72, 144, 216, 288].map(r => (
+                                <g key={r} transform={r ? `rotate(${r})` : undefined}>
+                                    <line x1="0" y1="0" x2="0" y2="-9" />
+                                    <line x1="0" y1="-4.5" x2="-2.5" y2="-7" />
+                                    <line x1="0" y1="-4.5" x2="2.5" y2="-7" />
+                                </g>
+                            ))}
+                        </svg>
+                    </div>
+                )}
+            </Tooltip>
+        );
+    }
+
+    return (
+        <div
+            className="ff-avatar-wrap"
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            onClick={() => PrivateChannelActions?.ensurePrivateChannel?.(userId)?.then?.((cid: string) => ChannelNavActions?.selectPrivateChannel?.(cid))}
+        >
+            <Tooltip text={name} position="top">
+                {(props: any) => (
+                    <div {...props} className="ff-avatar-inner-wrapper">
+                        <Avatar
+                            className="ff-avatar-inner"
+                            src={user.getAvatarURL(undefined, 128, true)}
+                            size="SIZE_32"
+                            status={status}
+                            isMobile={false}
+                            isTyping={false}
+                            aria-label={name}
+                            {...({ avatarDecoration: avatarDecorationUrl } as any)}
+                        />
+                    </div>
+                )}
+            </Tooltip>
+
+            {badge}
+        </div>
+    );
+}
+
+function InfoTooltip() {
+    return (
+        <Tooltip text="Friends you talk to the most in chat and voice channels" position="top">
+            {(props: any) => (
+                <div {...props} className="ff-info-wrapper">
+                    <span className="ff-info-icon">i</span>
+                </div>
+            )}
+        </Tooltip>
+    );
+}
+
+export function FrequentFriendsWidget() {
+    const [tick, setTick] = useState(0);
+    const { showOffline, maxFriends, customLabel } = settings.use(["showOffline", "maxFriends", "customLabel", "ignoreAffinities"]);
+
+    // SLIDER may return a float on some Vencord builds even with stickToMarkers.
+    // Round defensively so slice/comparison logic always gets a whole number.
+    const maxFriendsInt = Math.round(maxFriends);
+
+    useEffect(() => {
+        const unsub = subscribeToScoreChanges(() => setTick(t => t + 1));
+        setForceUpdateWidget(() => setTick(t => t + 1));
+        return () => {
+            unsub();
+            setForceUpdateWidget(() => {});
+        };
+    }, []);
+
+    if (!isPluginEnabled()) return null;
+
+    const allRankedIds = useMemo(() => getRankedFriendIds(), [tick]);
+    const ids: string[] = [];
+    const addedIds = new Set<string>();
+
+    for (const id of allRankedIds) {
+        if (!showOffline) {
+            const status = normalizeStatus((PresenceStore as any)?.getStatus?.(id) ?? "offline");
+            if (status === "offline" || status === "invisible") continue;
+        }
+        ids.push(id);
+        addedIds.add(id);
+        if (ids.length >= maxFriendsInt) break;
+    }
+
+    if (ids.length < maxFriendsInt) {
+        const friendIds = RelationshipStore.getFriendIDs();
+        for (const id of friendIds) {
+            if (addedIds.has(id)) continue;
+            if (!showOffline) {
+                const status = normalizeStatus((PresenceStore as any)?.getStatus?.(id) ?? "offline");
+                if (status === "offline" || status === "invisible") continue;
+            }
+            ids.push(id);
+            addedIds.add(id);
+            if (ids.length >= maxFriendsInt) break;
+        }
+    }
+
+    // Label length is capped by settings.maxLength: 30.
+    // Truncation is handled via CSS text-overflow:ellipsis (see style.css).
+    const label = customLabel || "Frequent Friends";
+
+    return (
+        <div id="frequentFriends-root">
+            <div className="ff-label">
+                <span className="ff-label-text">{label}</span>
+                <InfoTooltip />
+            </div>
+            {ids.length === 0 ? (
+                <div className="ff-empty">No frequent friends yet.</div>
+            ) : (
+                <div className="ff-avatars">
+                    {ids.map((id, i) => (
+                        <UserAvatar
+                            key={id}
+                            userId={id}
+                            isFirst={i === 0 && ids.length > 1}
+                            isLast={i === ids.length - 1 && ids.length > 1}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
Brings back Discord's removed Frequent Friends feature. Tracks friends by DM and voice activity, recent interactions weigh more than old ones.
Most active friend shows first with a fire badge ("Most Frequent"), least active shows last with a snow badge ("Cooling off"), same as the original feature.
Extra settings:
-List size (3-10 friends)
-Custom label
-Show/hide offline friends
-Disable Discord affinity data
-Reset + undo
Works on Vencord and Equicord
## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
<img width="593" height="669" alt="frequentfriendsscreenshot" src="https://github.com/user-attachments/assets/b4d97330-5a4c-43a4-9868-b0e216b7dedd" />

<img width="590" height="674" alt="frequentscreenshot" src="https://github.com/user-attachments/assets/9a81154f-d1fe-4bbd-8ee9-c0eea0d4dfc3" />
