### PR TITLE
plugin: add tenorcord

### DIFF
--- a/src/plugins/tenorcord/README.md
+++ b/src/plugins/tenorcord/README.md
@@ -1,6 +1,6 @@
 # TenorCord
 
-A Vencord plugin that adds (back) Tenor GIF support to Discord.
+A Vencord plugin that adds (back) Tenor GIF support to Discord. as tenor api was sunset in **30 jun 2026**.
 
 ## Configuration
 

--- a/src/plugins/tenorcord/README.md
+++ b/src/plugins/tenorcord/README.md
@@ -1,0 +1,21 @@
+# TenorCord
+
+A Vencord plugin that adds (back) Tenor GIF support to Discord.
+
+## Configuration
+
+| Setting | Default                                                 | Description         |
+| ------- | ------------------------------------------------------- | ------------------- |
+| API URL | `https://tenor-api.happyendermandev.workers.dev/api/v9` | Tenor API proxy URL |
+
+### Self hosting
+
+If you want to host your own API proxy:
+
+1. Clone the [tenor-worker](https://codeberg.org/wavedevgit/tenor-worker) repository
+2. Deploy to Cloudflare Workers
+3. Update the API URL in plugin settings
+
+## How it works
+
+Discord's GIF picker uses klipy now. This plugin redirects those requests to your own proxy server, which fetches GIFs from Tenor.

--- a/src/plugins/tenorcord/index.ts
+++ b/src/plugins/tenorcord/index.ts
@@ -35,6 +35,16 @@ export default definePlugin({
         return base.concat(route);
     },
     patches: [
+        // patch intl strings
+        {
+            find: ".T1Frnm",
+            replacement: [
+                {
+                    match: /(\i)\.intl\.string\([\s\S]+\)/,
+                    replace: "$1.intl.string($1.t.TnYqke)"
+                }
+            ]
+        },
         // patch api endpoints
         {
             find: ".GIFS_SEARCH",

--- a/src/plugins/tenorcord/index.ts
+++ b/src/plugins/tenorcord/index.ts
@@ -1,0 +1,84 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    apiUrl: {
+        description:
+            "Tenor api proxy URL.",
+        type: OptionType.STRING,
+        // this only has endpoints for gifs
+        // please dont abuse
+        // src is at: http://codeberg.org/wavedevgit/tenor-worker 
+        default: "https://tenor-api.happyendermandev.workers.dev/api/v9",
+    },
+
+});
+
+export default definePlugin({
+    name: "TenorCord",
+    description:
+        "Add support for tenor.",
+    authors: [EquicordDevs.HappyEnderman],
+    tags: ["Chat", "Emotes", "Customisation"],
+
+    settings,
+
+    getApiUrl(route: string) {
+        const base = this.settings.store.apiUrl.endsWith("/") ? this.settings.store.apiUrl.slice(0, -1) : this.settings.store.apiUrl;
+        return base.concat(route);
+    },
+    patches: [
+        // patch api endpoints
+        {
+            find: ".GIFS_SEARCH",
+            replacement: {
+                match: /url:\s*\i\.\s*\i\.GIFS_SEARCH\s*,/,
+                replace: "url:$self.getApiUrl('/gifs/search'),",
+            },
+        },
+        {
+            find: ".GIFS_TRENDING",
+            replacement: {
+                match: /url:\s*\i\.\s*\i\.GIFS_TRENDING\s*,/,
+                replace: "url:$self.getApiUrl('/gifs/trending'),",
+            },
+        },
+        {
+            find: ".GIFS_TRENDING_GIFS",
+            replacement: {
+                match: /url:\s*\i\.\s*\i\.GIFS_TRENDING_GIFS\s*,/,
+                replace: "url:$self.getApiUrl('/gifs/trending-gifs'),",
+            },
+        },
+        {
+            find: ".GIFS_SUGGEST",
+            replacement: {
+                match: /url:\s*\i\.\s*\i\.GIFS_SUGGEST\s*,/,
+                replace: "url:$self.getApiUrl('/gifs/suggest'),",
+            },
+        },
+        {
+            find: ".GIFS_TRENDING_SEARCH",
+            replacement: {
+                match: /url:\s*\i\.\s*\i\.GIFS_TRENDING_SEARCH\s*,/,
+                replace: "url:$self.getApiUrl('/gifs/trending-search'),",
+            },
+        },
+        {
+            find: ".GIFS_SELECT",
+            replacement: {
+                match: /url:\s*\i\.\s*\i\.GIFS_SELECT\s*,/,
+                replace: "url:$self.getApiUrl('/gifs/select'),",
+            },
+        },
+
+    ],
+
+});


### PR DESCRIPTION
## Describe your Changes

I added a new plugin called tenorcord that restores Tenor support by using a Cloudflare Worker as a proxy for the Tenor API, which is scraped from tenor.com. This is necessary because the public Tenor API was sunset on June 30, 2026.

This allows for using the tenor gifs in discord. I could remove the default API url if you want me to. 

The CF Worker is open source at https://codeberg.org/wavedevgit/tenor-worker/src/branch/main.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
