### PR TITLE
FakeNitro: fix sticker sending

### DIFF
--- a/src/api/MessageEvents.ts
+++ b/src/api/MessageEvents.ts
@@ -36,10 +36,10 @@ export interface MessageReplyOptions {
         parse: Array<string>;
         repliedUser: boolean;
     };
+    stickerIds?: string[];
 }
 
 export interface MessageOptions {
-    stickers?: string[];
     uploads?: CloudUpload[];
     replyOptions: MessageReplyOptions;
     content: string;

--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -182,7 +182,7 @@ function showCannotEmbedNotice() {
 
 export default definePlugin({
     name: "FakeNitro",
-    authors: [Devs.Arjix, Devs.D3SOX, Devs.Ven, Devs.fawn, Devs.captain, Devs.Nuckyz, Devs.AutumnVN, Devs.sadan],
+    authors: [Devs.Arjix, Devs.D3SOX, Devs.Ven, Devs.fawn, Devs.captain, Devs.Nuckyz, Devs.AutumnVN, Devs.sadan, Devs.niko],
     description: "Allows you to send fake emojis/stickers, use nitro themes, and stream in nitro quality",
     tags: ["Emotes", "Appearance", "Customisation", "Chat"],
     dependencies: ["MessageEventsAPI"],
@@ -831,7 +831,7 @@ export default definePlugin({
                 if (!s.enableStickerBypass)
                     break stickerBypass;
 
-                const sticker = StickersStore.getStickerById(extra.stickers?.[0]!);
+                const sticker = StickersStore.getStickerById(extra.replyOptions.stickerIds?.[0]!);
                 if (!sticker)
                     break stickerBypass;
 
@@ -877,7 +877,7 @@ export default definePlugin({
                     const linkText = s.hyperLinkText.replaceAll("{{NAME}}", sticker.name);
 
                     messageObj.content += `${getWordBoundary(messageObj.content, messageObj.content.length - 1)}${s.useHyperLinks ? `[${linkText}](${url})` : url}`;
-                    extra.stickers!.length = 0;
+                    extra.replyOptions.stickerIds!.length = 0;
                 }
             }
 


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
Switched FakeNitro's sticker sending to use the right field and added it to the typing (also removed the old one, since I assume this is a permanent change)

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
