### PR TITLE
FullUserInChatbox: stop popout editor events leaking into the chatbox

### DIFF
--- a/src/plugins/fullUserInChatbox/index.tsx
+++ b/src/plugins/fullUserInChatbox/index.tsx
@@ -9,7 +9,7 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { findComponentByCodeLazy } from "@webpack";
 import { UserStore, useStateFromStores } from "@webpack/common";
-import { ReactNode } from "react";
+import { ReactNode, SyntheticEvent } from "react";
 
 const UserMentionComponent = findComponentByCodeLazy(".USER_MENTION)");
 
@@ -34,8 +34,27 @@ export default definePlugin({
                 match: /(hidePersonalInformation\).+?)(if\(null!=\i\){.+?return \i)(?=})/,
                 replace: "$1return $self.UserMentionComponent({...arguments[0],originalComponent:()=>{$2}});"
             }
+        },
+        {
+            find: 'getElementById("slate-toolbar"',
+            replacement: {
+                match: /handle(?:Focus|Blur|Paste)Capture\((\i)\)\{/g,
+                replace: "$&if($self.isEventOutsideEditor($1))return;"
+            }
+        },
+        {
+            find: ".current?.handleOuterClick()",
+            replacement: {
+                match: /\(\)=>\{(null!=\i\|\|\i\|\|\i\.current\?\.handleOuterClick\(\))\}/,
+                replace: "e=>{if($self.isEventOutsideEditor(e))return;$1}"
+            }
         }
     ],
+
+    isEventOutsideEditor(event?: SyntheticEvent) {
+        return event != null && event.currentTarget instanceof Node && event.target instanceof Node
+            && !event.currentTarget.contains(event.target);
+    },
 
     UserMentionComponent: ErrorBoundary.wrap((props: UserMentionComponentProps) => {
         const user = useStateFromStores([UserStore], () => UserStore.getUser(props.id));

--- a/src/plugins/fullUserInChatbox/index.tsx
+++ b/src/plugins/fullUserInChatbox/index.tsx
@@ -24,7 +24,7 @@ export default definePlugin({
     name: "FullUserInChatbox",
     description: "Makes the user mention in the chatbox have more functionalities, like left/right clicking",
     tags: ["Shortcuts", "Utility"],
-    authors: [Devs.sadan],
+    authors: [Devs.sadan, Devs.MrCRACK],
 
     patches: [
         {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -646,6 +646,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "NightmareSan",
         id: 304239816466235392n
     },
+    MrCRACK: {
+        name: "MrCRACK",
+        id: 795716077400752128n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Describe your Changes
noticed this one had been sitting for a while so I gave it a shot. the popout's message box was leaking focus/blur/paste and click events into the chatbox, this makes the outer editor ignore anything that didn't actually happen inside it. Fixes #4337

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent