### PR TITLE
fix(UserVoiceShow): Icon position in profile popout

### DIFF
--- a/src/plugins/userVoiceShow/index.tsx
+++ b/src/plugins/userVoiceShow/index.tsx
@@ -51,7 +51,7 @@ export default definePlugin({
     name: "UserVoiceShow",
     description: "Shows an indicator when a user is in a Voice Channel",
     tags: ["Voice", "Appearance", "Friends"],
-    authors: [Devs.Nuckyz, Devs.LordElias],
+    authors: [Devs.Nuckyz, Devs.LordElias, Devs.nightmaresan],
     dependencies: ["MemberListDecoratorsAPI", "MessageDecorationsAPI"],
     settings,
 
@@ -60,8 +60,8 @@ export default definePlugin({
         {
             find: "#{intl::USER_PROFILE_PRONOUNS}",
             replacement: {
-                match: /(?<=children:\[\i," ",\i)(?=\])/,
-                replace: ",$self.VoiceChannelIndicator({userId:arguments[0]?.user?.id,isProfile:true})"
+                match: /(?<=children:\[)(?=\i," ",\i\])/,
+                replace: "$self.VoiceChannelIndicator({userId:arguments[0]?.user?.id,isProfile:true}),"
             },
             predicate: () => settings.store.showInUserProfileModal
         },

--- a/src/plugins/userVoiceShow/style.css
+++ b/src/plugins/userVoiceShow/style.css
@@ -14,8 +14,21 @@
 }
 
 .vc-uvs-profile-speaker {
-    width: var(--custom-nickname-icon-size);
     height: var(--custom-nickname-icon-size);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.05em;
+    margin-right: 0.2em;
+    vertical-align: middle;
+    transform: translateY(-0.125em); /* Icon isnt fully in the middle */
+}
+
+.vc-uvs-profile-speaker::before {
+    content: "[";
+}
+
+.vc-uvs-profile-speaker::after {
+    content: "]";
 }
 
 .vc-uvs-tooltip-container {
@@ -24,8 +37,6 @@
 
 .vc-uvs-tooltip-content {
     display: flex;
-    flex-direction: column;
-    gap: 6px;
 }
 
 .vc-uvs-name {


### PR DESCRIPTION
## Describe your Changes
The icon is currently off-center within profile popouts:
<img width="174" height="69" alt="image" src="https://github.com/user-attachments/assets/1060bc52-362a-40ea-9080-42b637c6185f" />

Changed the CSS to inline-flex and moved the position in front of the name, so it stays consistent across all users. Because the name div breaks into separate lines if the name becomes too long:
<img width="309" height="66" alt="image" src="https://github.com/user-attachments/assets/3f4a3597-1376-46ac-bd50-8f48c524e24b" />
<img width="289" height="65" alt="image" src="https://github.com/user-attachments/assets/6cb73aa2-f8e7-4aa7-b26c-66c1388f2466" />

To me personally the bracket variant looks cleaner but both works

## Checklist before submitting
- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [X] This pull request was written by me, and not an AI agent
