### PR TITLE
MessageLogger: patch log bypass via nonce

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -44,8 +44,6 @@ interface MLMessage extends Message {
 
 const MessageClasses = findCssClassesLazy("edited", "communicationDisabled", "isSystemMessage");
 
-const IdRegex = /^\d{17,21}$/;
-
 const settings = definePluginSettings({
     deleteStyle: {
         type: OptionType.SELECT,
@@ -309,10 +307,14 @@ export default definePlugin({
         }
     },
 
+    /*
+     * Due to a Discord bug, it is possible to edit a past message by sending a new message whose nonce matches the old message's ID.
+     * This will make Discord replace the old message with the new one, which bypasses our edit logging since the message isn't ever
+     * actually edited. To patch this behaviour, we check for this trick and remove the nonce if detected.
+    */
     normalizeNonce(msg: Message) {
         try {
-
-            if (!msg?.nonce) return;
+            if (!msg.nonce) return;
 
             const prevMsg = MessageStore.getMessage(msg.channel_id, msg.nonce);
             if (!prevMsg || prevMsg.state !== "SENT") return;

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -44,6 +44,8 @@ interface MLMessage extends Message {
 
 const MessageClasses = findCssClassesLazy("edited", "communicationDisabled", "isSystemMessage");
 
+const IdRegex = /^\d{17,21}$/;
+
 const settings = definePluginSettings({
     deleteStyle: {
         type: OptionType.SELECT,
@@ -307,6 +309,22 @@ export default definePlugin({
         }
     },
 
+    normalizeNonce(msg: Message) {
+        try {
+
+            if (!msg?.nonce) return;
+
+            const prevMsg = MessageStore.getMessage(msg.channel_id, msg.nonce);
+            if (!prevMsg || prevMsg.state !== "SENT") return;
+
+            if (prevMsg.id !== msg.id) {
+                delete msg.nonce;
+            }
+        } catch (e) {
+            console.error("[MessageLogger] Error normalizing nonce");
+        }
+    },
+
     EditMarker({ message, className, children, ...props }: any) {
         return (
             <span
@@ -539,6 +557,14 @@ export default definePlugin({
                 },
             ],
             predicate: () => settings.store.collapseDeleted
+        },
+
+        {
+            find: "this.truncateTop",
+            replacement: {
+                match: /receiveMessage\((\i)\)\{/,
+                replace: "$& $self.normalizeNonce($1);"
+            }
         }
     ]
 });

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -30,7 +30,7 @@ import { classes } from "@utils/misc";
 import definePlugin, { OptionType } from "@utils/types";
 import { Message, MessageAttachment } from "@vencord/discord-types";
 import { findCssClassesLazy } from "@webpack";
-import { ChannelStore, FluxDispatcher, Menu, MessageStore, Parser, SelectedChannelStore, Timestamp, UserStore, useStateFromStores } from "@webpack/common";
+import { AuthenticationStore, ChannelStore, FluxDispatcher, Menu, MessageStore, Parser, SelectedChannelStore, Timestamp, UserStore, useStateFromStores } from "@webpack/common";
 
 import overlayStyle from "./deleteStyleOverlay.css?managed";
 import textStyle from "./deleteStyleText.css?managed";
@@ -338,14 +338,12 @@ export default definePlugin({
         }
     },
 
-    /*
-     * Due to a Discord bug, it is possible to edit a past message by sending a new message whose nonce matches the old message's ID.
-     * This will make Discord replace the old message with the new one, which bypasses our edit logging since the message isn't ever
-     * actually edited. To patch this behaviour, we check for this trick and remove the nonce if detected.
-    */
+    // It is possible to replace a message in place by creating a new message with the same nonce as an existing one.
+    // This is not considered an edit since it's a new message. Thus it bypasses our edit logging and can be used to "delete" a message by replacing it with an empty one.
+    // This fixes that bypass
     normalizeNonce(msg: Message) {
         try {
-            if (!msg.nonce) return;
+            if (!msg.nonce || msg.author.id === AuthenticationStore.getId()) return;
 
             const prevMsg = MessageStore.getMessage(msg.channel_id, msg.nonce);
             if (!prevMsg || prevMsg.state !== "SENT") return;


### PR DESCRIPTION
Fixes a bypass where sending a new message with an old message's ID as nonce would replace that message without an edit, which bypasses the plugin

Needs proper testing