### PR TITLE
feat: add DMNotifications plugin

### DIFF
--- a/src/plugins/dmNotifications/NotificationManager.tsx
+++ b/src/plugins/dmNotifications/NotificationManager.tsx
@@ -1,0 +1,66 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { createRoot } from "@webpack/common";
+import type { Root } from "react-dom/client";
+
+import { settings } from "./settings";
+import { useToasts } from "./store";
+import Toast from "./Toast";
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+function Container() {
+    const toasts = useToasts();
+    const {
+        position, duration, showReplyBar, closeOnReply,
+        backgroundColor, usernameColor, textColor, accentColor
+    } = settings.use([
+        "position", "duration", "showReplyBar", "closeOnReply",
+        "backgroundColor", "usernameColor", "textColor", "accentColor"
+    ]);
+
+    return (
+        <div
+            className={`vc-dmn-container vc-dmn-pos-${position}`}
+            style={{
+                ["--vc-dmn-bg" as any]: backgroundColor,
+                ["--vc-dmn-user" as any]: usernameColor,
+                ["--vc-dmn-text" as any]: textColor,
+                ["--vc-dmn-accent" as any]: accentColor
+            }}
+        >
+            {toasts.map(t => (
+                <Toast
+                    key={t.id}
+                    id={t.id}
+                    message={t.message}
+                    channel={t.channel}
+                    duration={duration}
+                    showReplyBar={showReplyBar}
+                    closeOnReply={closeOnReply}
+                />
+            ))}
+        </div>
+    );
+}
+
+export function mountNotifications() {
+    if (root) return;
+    container = document.createElement("div");
+    container.id = "vc-dmn-root";
+    document.body.append(container);
+    root = createRoot(container);
+    root.render(<Container />);
+}
+
+export function unmountNotifications() {
+    root?.unmount();
+    container?.remove();
+    root = undefined;
+    container = undefined;
+}

--- a/src/plugins/dmNotifications/ReplyBar.tsx
+++ b/src/plugins/dmNotifications/ReplyBar.tsx
@@ -1,0 +1,205 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { sendMessage } from "@utils/discord";
+import type { Channel, Message } from "@vencord/discord-types";
+import { DraftType, React, showToast, Toasts, UploadHandler, useMemo, useRef, useState } from "@webpack/common";
+
+import { EmojiSuggestion, emojiToText, getEmojiCategories, recordRecentEmoji, searchEmoji } from "./emoji";
+
+interface Props {
+    channel: Channel;
+    replyTo: Message;
+    onSent(): void;
+}
+
+export default function ReplyBar({ channel, replyTo, onSent }: Props) {
+    const [value, setValue] = useState("");
+    const [suggestions, setSuggestions] = useState<EmojiSuggestion[]>([]);
+    const [sending, setSending] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+    const [pickerQuery, setPickerQuery] = useState("");
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    const isGuildMessage = !!channel.guild_id;
+    const categories = useMemo(() => getEmojiCategories(pickerQuery), [pickerQuery, pickerOpen]);
+
+    function updateSuggestions(text: string, caret: number) {
+        const upToCaret = text.slice(0, caret);
+        const match = /(?:^|\s):([a-zA-Z0-9_+-]{2,})$/.exec(upToCaret);
+        if (!match) {
+            setSuggestions([]);
+            return;
+        }
+        setSuggestions(searchEmoji(match[1]));
+    }
+
+    function insertAtCaret(text: string) {
+        const el = textareaRef.current;
+        const caret = el?.selectionStart ?? value.length;
+        const newValue = value.slice(0, caret) + text + value.slice(caret);
+        setValue(newValue);
+        requestAnimationFrame(() => {
+            el?.focus();
+            el?.setSelectionRange(caret + text.length, caret + text.length);
+        });
+    }
+
+    function applySuggestion(e: EmojiSuggestion) {
+        const el = textareaRef.current;
+        const caret = el?.selectionStart ?? value.length;
+        const upToCaret = value.slice(0, caret);
+        const match = /(?:^|\s):([a-zA-Z0-9_+-]{2,})$/.exec(upToCaret);
+        if (!match) return;
+
+        const start = caret - match[1].length - 1;
+        const inserted = emojiToText(e);
+        const newValue = value.slice(0, start) + inserted + " " + value.slice(caret);
+        setValue(newValue);
+        setSuggestions([]);
+        recordRecentEmoji(e);
+        requestAnimationFrame(() => el?.focus());
+    }
+
+    function pickFromPopover(e: EmojiSuggestion) {
+        insertAtCaret(emojiToText(e) + " ");
+        recordRecentEmoji(e);
+        setPickerOpen(false);
+        setPickerQuery("");
+    }
+
+    async function handleSend() {
+        const content = value.trim();
+        if (!content || sending) return;
+
+        setSending(true);
+        try {
+            await sendMessage(channel.id, { content }, false, isGuildMessage ? {
+                messageReference: {
+                    channel_id: replyTo.channel_id,
+                    message_id: replyTo.id,
+                    guild_id: (replyTo as any).guild_id
+                } as any,
+                allowedMentions: { parse: ["users", "roles", "everyone"], replied_user: true }
+            } : {});
+            setValue("");
+            onSent();
+        } catch {
+            showToast("Failed to send reply", Toasts.Type.FAILURE);
+        } finally {
+            setSending(false);
+        }
+    }
+
+    function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+        const files = Array.from(e.clipboardData?.files ?? []);
+        if (!files.length) return;
+        e.preventDefault();
+        UploadHandler.promptToUpload(files, channel, DraftType.ChannelMessage);
+    }
+
+    return (
+        <div className="vc-dmn-replybar" onClick={e => e.stopPropagation()}>
+            {suggestions.length > 0 && (
+                <div className="vc-dmn-emoji-suggestions">
+                    {suggestions.map(s => (
+                        <div
+                            key={s.key}
+                            className="vc-dmn-emoji-suggestion"
+                            onMouseDown={e => { e.preventDefault(); applySuggestion(s); }}
+                        >
+                            {s.src ? <img src={s.src} alt={s.name} /> : <span className="vc-dmn-emoji-unicode">{s.unicode}</span>}
+                            <span>:{s.name}:</span>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {pickerOpen && (
+                <div className="vc-dmn-emoji-popover">
+                    <div className="vc-dmn-emoji-popover-search-wrap">
+                        <svg className="vc-dmn-emoji-popover-search-icon" width="14" height="14" viewBox="0 0 24 24">
+                            <path fill="currentColor" d="M10 2a8 8 0 1 0 4.9 14.32l5.39 5.38 1.42-1.41-5.39-5.39A8 8 0 0 0 10 2Zm0 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12Z" />
+                        </svg>
+                        <input
+                            autoFocus
+                            className="vc-dmn-emoji-popover-search"
+                            placeholder="Find the perfect emoji"
+                            value={pickerQuery}
+                            onChange={e => setPickerQuery(e.target.value)}
+                        />
+                    </div>
+                    <div className="vc-dmn-emoji-popover-body">
+                        {categories.length === 0 && (
+                            <div className="vc-dmn-emoji-empty">No emoji found</div>
+                        )}
+                        {categories.map(cat => (
+                            <div key={cat.label} className="vc-dmn-emoji-category">
+                                <div className="vc-dmn-emoji-category-label">{cat.label}</div>
+                                <div className="vc-dmn-emoji-grid">
+                                    {cat.emojis.map(s => (
+                                        <div
+                                            key={s.key}
+                                            className="vc-dmn-emoji-grid-item"
+                                            title={s.name}
+                                            onMouseDown={e => { e.preventDefault(); pickFromPopover(s); }}
+                                        >
+                                            {s.src ? <img src={s.src} alt={s.name} /> : s.unicode}
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <div className="vc-dmn-replyrow">
+                <button
+                    className={`vc-dmn-icon-btn${pickerOpen ? " vc-dmn-active" : ""}`}
+                    onClick={() => setPickerOpen(o => !o)}
+                    aria-label="Emoji"
+                    type="button"
+                >
+                    <svg width="18" height="18" viewBox="0 0 24 24">
+                        <path fill="currentColor" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 18a8 8 0 1 1 0-16 8 8 0 0 1 0 16Zm-3.5-9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm7 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM12 17.5c2.33 0 4.31-1.46 5.11-3.5H6.89c.8 2.04 2.78 3.5 5.11 3.5Z" />
+                    </svg>
+                </button>
+                <textarea
+                    ref={textareaRef}
+                    className="vc-dmn-textarea"
+                    placeholder={isGuildMessage ? `Reply to ${replyTo.author?.username ?? "message"}...` : `Message ${replyTo.author?.username ?? ""}...`}
+                    rows={1}
+                    value={value}
+                    onPaste={handlePaste}
+                    onFocus={() => setPickerOpen(false)}
+                    onChange={e => {
+                        setValue(e.target.value);
+                        updateSuggestions(e.target.value, e.target.selectionStart ?? e.target.value.length);
+                    }}
+                    onKeyDown={e => {
+                        if (e.key === "Enter" && !e.shiftKey) {
+                            e.preventDefault();
+                            handleSend();
+                        } else if (e.key === "Escape") {
+                            setSuggestions([]);
+                        }
+                    }}
+                />
+                <button
+                    className="vc-dmn-send-btn"
+                    disabled={!value.trim() || sending}
+                    onClick={handleSend}
+                    aria-label="Send"
+                >
+                    <svg width="18" height="18" viewBox="0 0 24 24">
+                        <path fill="currentColor" d="M2 21l21-9L2 3v7l15 2-15 2z" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/plugins/dmNotifications/Toast.tsx
+++ b/src/plugins/dmNotifications/Toast.tsx
@@ -1,0 +1,138 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import type { Channel, Message } from "@vencord/discord-types";
+import {
+    GuildStore,
+    IconUtils,
+    NavigationRouter,
+    Parser,
+    SelectedChannelStore,
+    useEffect,
+    useMemo,
+    UserStore,
+    useState
+} from "@webpack/common";
+
+import ReplyBar from "./ReplyBar";
+import { removeToast } from "./store";
+
+interface Props {
+    id: number;
+    message: Message;
+    channel: Channel;
+    duration: number;
+    showReplyBar: boolean;
+    closeOnReply: boolean;
+}
+
+function getContext(channel: Channel): { label: string; sub?: string; } {
+    if (channel.isDM()) return { label: "Direct Message" };
+    if (channel.isGroupDM?.() || channel.isMultiUserDM?.()) return { label: channel.name || "Group DM" };
+    const guild = channel.guild_id ? GuildStore.getGuild(channel.guild_id) : null;
+    return { label: `#${channel.name}`, sub: guild?.name };
+}
+
+function Toast({ id, message, channel, duration, showReplyBar, closeOnReply }: Props) {
+    const [closing, setClosing] = useState(false);
+    const [hovered, setHovered] = useState(false);
+    const [elapsed, setElapsed] = useState(0);
+
+    const close = () => {
+        if (closing) return;
+        setClosing(true);
+        setTimeout(() => removeToast(id), 220);
+    };
+
+    useEffect(() => {
+        if (hovered || duration <= 0) return;
+        const start = Date.now() - elapsed;
+        const interval = setInterval(() => {
+            const e = Date.now() - start;
+            if (e >= duration * 1000) close();
+            else setElapsed(e);
+        }, 50);
+        return () => clearInterval(interval);
+    }, [hovered]);
+
+    const avatar = useMemo(() => IconUtils.getUserAvatarURL(message.author, true), [message.author]);
+    const context = useMemo(() => getContext(channel), [channel]);
+
+    const content = useMemo(() => {
+        if (!message.content) {
+            if (message.attachments?.length) return <i>sent an attachment</i>;
+            if (message.embeds?.length) return <i>sent an embed</i>;
+            if ((message as any).sticker_items?.length) return <i>sent a sticker</i>;
+            return null;
+        }
+        try {
+            return Parser.parse(message.content, true, {
+                channelId: message.channel_id,
+                messageId: message.id,
+                allowLinks: true,
+                allowEmojiLinks: true,
+                viewingChannelId: SelectedChannelStore.getChannelId()
+            });
+        } catch {
+            return message.content;
+        }
+    }, [message.content]);
+
+    function openChannel() {
+        const path = channel.guild_id
+            ? `/channels/${channel.guild_id}/${channel.id}`
+            : `/channels/@me/${channel.id}`;
+        NavigationRouter.transitionTo(path);
+    }
+
+    return (
+        <div
+            className={`vc-dmn-toast${closing ? " vc-dmn-toast-closing" : ""}`}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+        >
+            <div className="vc-dmn-toast-surface">
+                <div className="vc-dmn-toast-clickable" onClick={openChannel}>
+                    <img className="vc-dmn-avatar" src={avatar} alt="" />
+                    <div className="vc-dmn-body">
+                        <div className="vc-dmn-header">
+                            <span className="vc-dmn-username">{UserStore.getUser(message.author.id)?.username ?? message.author.username}</span>
+                            <span className="vc-dmn-context">{context.label}{context.sub ? ` · ${context.sub}` : ""}</span>
+                        </div>
+                        <div className="vc-dmn-content">{content}</div>
+                    </div>
+                    <button
+                        className="vc-dmn-close"
+                        onClick={e => { e.stopPropagation(); close(); }}
+                        aria-label="Dismiss"
+                    >
+                        <svg width="16" height="16" viewBox="0 0 24 24">
+                            <path fill="currentColor" d="M18.4 4L12 10.4L5.6 4L4 5.6L10.4 12L4 18.4L5.6 20L12 13.6L18.4 20L20 18.4L13.6 12L20 5.6L18.4 4Z" />
+                        </svg>
+                    </button>
+                </div>
+
+                {duration > 0 && (
+                    <div
+                        className="vc-dmn-progress"
+                        style={{ width: `${Math.max(0, 100 - (elapsed / (duration * 1000)) * 100)}%` }}
+                    />
+                )}
+            </div>
+
+            {showReplyBar && (
+                <ReplyBar
+                    channel={channel}
+                    replyTo={message}
+                    onSent={() => { if (closeOnReply) close(); }}
+                />
+            )}
+        </div>
+    );
+}
+
+export default ErrorBoundary.wrap(Toast, { noop: true });

--- a/src/plugins/dmNotifications/emoji.ts
+++ b/src/plugins/dmNotifications/emoji.ts
@@ -1,0 +1,123 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { EmojiStore, GuildStore } from "@webpack/common";
+
+export interface EmojiSuggestion {
+    key: string;
+    name: string;
+    src?: string;
+    unicode?: string;
+}
+
+export interface EmojiCategory {
+    label: string;
+    icon?: string;
+    emojis: EmojiSuggestion[];
+}
+
+const COMMON_UNICODE: Record<string, string> = {
+    smile: "😄", joy: "😂", laughing: "😆", wink: "😉", blush: "😊",
+    heart: "❤️", heart_eyes: "😍", thumbsup: "👍", thumbsdown: "👎",
+    fire: "🔥", tada: "🎉", clap: "👏", eyes: "👀", cry: "😢",
+    sob: "😭", angry: "😡", thinking: "🤔", pray: "🙏", ok_hand: "👌",
+    100: "💯", skull: "💀", sunglasses: "😎", wave: "👋", rofl: "🤣",
+    heart_eyes_cat: "😻", scream: "😱", partying_face: "🥳", sparkles: "✨"
+};
+
+const RECENT_KEY = "vc-dmn-recent-emoji";
+const RECENT_LIMIT = 16;
+
+function unicodeEmoji(): EmojiSuggestion[] {
+    return Object.entries(COMMON_UNICODE).map(([name, unicode]) => ({ key: `u:${name}`, name, unicode }));
+}
+
+function guildEmoji(): EmojiCategory[] {
+    const categories: EmojiCategory[] = [];
+    try {
+        const guilds = Object.values(GuildStore.getGuilds()) as any[];
+        for (const guild of guilds) {
+            const emojis: any[] = EmojiStore.getGuildEmoji(guild.id) ?? [];
+            if (!emojis.length) continue;
+            categories.push({
+                label: guild.name,
+                icon: guild.icon ? `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}.webp?size=32` : undefined,
+                emojis: emojis.filter(e => e?.name && e?.id).map(e => ({
+                    key: `c:${e.id}`,
+                    name: e.name,
+                    src: `https://cdn.discordapp.com/emojis/${e.id}.${e.animated ? "gif" : "webp"}?size=32&quality=lossless`
+                }))
+            });
+        }
+    } catch {
+        // best effort only
+    }
+    return categories;
+}
+
+export function getRecentEmoji(): EmojiSuggestion[] {
+    try {
+        const raw = localStorage.getItem(RECENT_KEY);
+        return raw ? JSON.parse(raw) : [];
+    } catch {
+        return [];
+    }
+}
+
+export function recordRecentEmoji(emoji: EmojiSuggestion) {
+    try {
+        const recent = getRecentEmoji().filter(e => e.key !== emoji.key);
+        recent.unshift(emoji);
+        localStorage.setItem(RECENT_KEY, JSON.stringify(recent.slice(0, RECENT_LIMIT)));
+    } catch {
+        // ignore storage errors
+    }
+}
+
+/** Flat list used for the ":shortcode" inline autocomplete while typing. */
+export function searchEmoji(query: string, limit = 8): EmojiSuggestion[] {
+    const q = query.toLowerCase();
+    if (!q) return [];
+
+    const results: EmojiSuggestion[] = [];
+    for (const e of unicodeEmoji()) {
+        if (e.name.startsWith(q)) results.push(e);
+        if (results.length >= limit) return results;
+    }
+    for (const category of guildEmoji()) {
+        for (const e of category.emojis) {
+            if (!e.name.toLowerCase().startsWith(q)) continue;
+            results.push(e);
+            if (results.length >= limit) return results;
+        }
+    }
+    return results;
+}
+
+/** Categorized list used by the picker popover: Frequently Used, Smileys, then one section per server. */
+export function getEmojiCategories(query: string): EmojiCategory[] {
+    const q = query.trim().toLowerCase();
+
+    if (q) {
+        const emojis: EmojiSuggestion[] = [];
+        for (const e of unicodeEmoji()) if (e.name.includes(q)) emojis.push(e);
+        for (const category of guildEmoji()) for (const e of category.emojis) if (e.name.toLowerCase().includes(q)) emojis.push(e);
+        return emojis.length ? [{ label: "Search Results", emojis }] : [];
+    }
+
+    const categories: EmojiCategory[] = [];
+    const recent = getRecentEmoji();
+    if (recent.length) categories.push({ label: "Frequently Used", emojis: recent });
+    categories.push({ label: "Smileys & People", emojis: unicodeEmoji() });
+    categories.push(...guildEmoji());
+    return categories;
+}
+
+export function emojiToText(e: EmojiSuggestion): string {
+    if (e.unicode) return e.unicode;
+    const id = e.key.slice(2);
+    return `<:${e.name}:${id}>`;
+}

--- a/src/plugins/dmNotifications/index.tsx
+++ b/src/plugins/dmNotifications/index.tsx
@@ -1,0 +1,81 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import type { Message } from "@vencord/discord-types";
+import { findByCodeLazy } from "@webpack";
+import { ChannelStore, GuildMemberStore, SelectedChannelStore, UserStore } from "@webpack/common";
+
+import { mountNotifications, unmountNotifications } from "./NotificationManager";
+import { settings } from "./settings";
+import { pushToast } from "./store";
+
+// Discord's own internal check used to decide whether to show a notification
+// at all (respects muted channels/guilds, suppressed @everyone, and whether
+// you're already focused on that exact channel).
+const notificationsShouldNotify: (message: Message, channelId: string) => boolean =
+    findByCodeLazy(".SUPPRESS_NOTIFICATIONS))return!1");
+
+function isMentioned(message: Message, guildId: string): boolean {
+    const me = UserStore.getCurrentUser();
+    if ((message as any).mentions?.some((m: any) => m.id === me.id)) return true;
+    if ((message as any).mention_everyone) return true;
+
+    const roleMentions: string[] = (message as any).mention_roles ?? [];
+    if (!roleMentions.length) return false;
+
+    const myRoles = GuildMemberStore.getSelfMember(guildId)?.roles ?? [];
+    return roleMentions.some(r => myRoles.includes(r));
+}
+
+export default definePlugin({
+    name: "DMNotifications",
+    description: "Animated, customizable toast notifications for DMs and mentions with a quick reply bar, no matter what channel you're viewing.",
+    authors: [Devs.lunomium],
+    settings,
+
+    start() {
+        mountNotifications();
+    },
+
+    stop() {
+        unmountNotifications();
+    },
+
+    flux: {
+        MESSAGE_CREATE({ message, optimistic }: { message: Message; optimistic: boolean; }) {
+            if (optimistic) return;
+            if (message.author?.id === UserStore.getCurrentUser().id) return;
+            if (settings.store.ignoreBots && message.author?.bot) return;
+
+            const channel = ChannelStore.getChannel(message.channel_id);
+            if (!channel) return;
+
+            // Don't show a toast for the channel/DM you're currently looking at,
+            // regardless of whether the window has focus.
+            if (SelectedChannelStore.getChannelId() === message.channel_id) return;
+
+            if (!notificationsShouldNotify(message, message.channel_id)) return;
+
+            let allow = false;
+            if (channel.isDM()) {
+                allow = settings.store.notifyDms;
+            } else if (channel.isGroupDM?.() || channel.isMultiUserDM?.()) {
+                allow = settings.store.notifyGroupDms;
+            } else if (channel.guild_id) {
+                if (settings.store.notifyAllServerMessages) allow = true;
+                else if (settings.store.notifyMentionsInServers && isMentioned(message, channel.guild_id)) allow = true;
+            }
+
+            if (!allow) return;
+
+            pushToast(message, channel, settings.store.maxToasts);
+        }
+    }
+});

--- a/src/plugins/dmNotifications/settings.ts
+++ b/src/plugins/dmNotifications/settings.ts
@@ -1,0 +1,88 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { makeRange, OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    position: {
+        type: OptionType.SELECT,
+        description: "Where notifications appear on screen",
+        options: [
+            { label: "Top Right", value: "top-right", default: true },
+            { label: "Top Left", value: "top-left" },
+            { label: "Bottom Right", value: "bottom-right" },
+            { label: "Bottom Left", value: "bottom-left" }
+        ]
+    },
+    duration: {
+        type: OptionType.SLIDER,
+        description: "How long a notification stays on screen (seconds)",
+        default: 7,
+        markers: makeRange(2, 20, 1)
+    },
+    maxToasts: {
+        type: OptionType.SLIDER,
+        description: "Max notifications stacked at once",
+        default: 3,
+        markers: makeRange(1, 6, 1)
+    },
+    notifyDms: {
+        type: OptionType.BOOLEAN,
+        description: "Show notifications for Direct Messages",
+        default: true
+    },
+    notifyGroupDms: {
+        type: OptionType.BOOLEAN,
+        description: "Show notifications for Group DMs",
+        default: true
+    },
+    notifyMentionsInServers: {
+        type: OptionType.BOOLEAN,
+        description: "Show notifications when mentioned in a server",
+        default: true
+    },
+    notifyAllServerMessages: {
+        type: OptionType.BOOLEAN,
+        description: "Show notifications for every server message, not just mentions",
+        default: false
+    },
+    ignoreBots: {
+        type: OptionType.BOOLEAN,
+        description: "Don't show notifications from bot accounts",
+        default: false
+    },
+    showReplyBar: {
+        type: OptionType.BOOLEAN,
+        description: "Show a quick reply bar on notifications",
+        default: true
+    },
+    closeOnReply: {
+        type: OptionType.BOOLEAN,
+        description: "Close the notification after sending a reply",
+        default: true
+    },
+    backgroundColor: {
+        type: OptionType.STRING,
+        description: "Notification background color",
+        default: "#232428"
+    },
+    usernameColor: {
+        type: OptionType.STRING,
+        description: "Username text color",
+        default: "#ffffff"
+    },
+    textColor: {
+        type: OptionType.STRING,
+        description: "Message text color",
+        default: "#dbdee1"
+    },
+    accentColor: {
+        type: OptionType.STRING,
+        description: "Accent color (send button, progress bar)",
+        default: "#5865f2"
+    }
+});

--- a/src/plugins/dmNotifications/store.ts
+++ b/src/plugins/dmNotifications/store.ts
@@ -1,0 +1,51 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import type { Channel, Message } from "@vencord/discord-types";
+import { useEffect, useReducer } from "@webpack/common";
+
+export interface ToastItem {
+    id: number;
+    message: Message;
+    channel: Channel;
+}
+
+let toasts: ToastItem[] = [];
+let nextId = 1;
+const listeners = new Set<() => void>();
+
+function emit() {
+    listeners.forEach(l => l());
+}
+
+export function pushToast(message: Message, channel: Channel, maxToasts: number) {
+    const item: ToastItem = { id: nextId++, message, channel };
+    toasts = [item, ...toasts].slice(0, Math.max(1, maxToasts));
+    emit();
+}
+
+export function removeToast(id: number) {
+    toasts = toasts.filter(t => t.id !== id);
+    emit();
+}
+
+export function clearToasts() {
+    toasts = [];
+    emit();
+}
+
+export function getToasts() {
+    return toasts;
+}
+
+export function useToasts() {
+    const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+    useEffect(() => {
+        listeners.add(forceUpdate);
+        return () => void listeners.delete(forceUpdate);
+    }, []);
+    return toasts;
+}

--- a/src/plugins/dmNotifications/style.css
+++ b/src/plugins/dmNotifications/style.css
@@ -1,0 +1,411 @@
+.vc-dmn-container {
+    position: fixed;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 16px;
+    width: 340px;
+    max-width: calc(100vw - 32px);
+    pointer-events: none;
+}
+
+.vc-dmn-pos-top-right {
+    top: 0;
+    right: 0;
+}
+
+.vc-dmn-pos-top-left {
+    top: 0;
+    left: 0;
+}
+
+.vc-dmn-pos-bottom-right {
+    bottom: 0;
+    right: 0;
+    flex-direction: column-reverse;
+}
+
+.vc-dmn-pos-bottom-left {
+    bottom: 0;
+    left: 0;
+    flex-direction: column-reverse;
+}
+
+.vc-dmn-toast {
+    pointer-events: all;
+    position: relative;
+    animation: vc-dmn-in 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.vc-dmn-toast-surface {
+    position: relative;
+    overflow: hidden;
+    border-radius: 10px 10px 0 0;
+    background: var(--vc-dmn-bg, #232428);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 45%);
+    border: 1px solid rgb(255 255 255 / 6%);
+    border-bottom: none;
+}
+
+.vc-dmn-toast:not(:has(.vc-dmn-replybar)) .vc-dmn-toast-surface {
+    border-radius: 10px;
+    border-bottom: 1px solid rgb(255 255 255 / 6%);
+}
+
+.vc-dmn-pos-top-left .vc-dmn-toast,
+.vc-dmn-pos-bottom-left .vc-dmn-toast {
+    animation-name: vc-dmn-in-left;
+}
+
+.vc-dmn-toast-closing {
+    overflow: hidden;
+    animation: vc-dmn-out 0.2s ease forwards;
+}
+
+@keyframes vc-dmn-in {
+    from {
+        opacity: 0;
+        transform: translateX(24px) scale(0.96);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+    }
+}
+
+@keyframes vc-dmn-in-left {
+    from {
+        opacity: 0;
+        transform: translateX(-24px) scale(0.96);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+    }
+}
+
+@keyframes vc-dmn-out {
+    from {
+        opacity: 1;
+        transform: scale(1);
+        max-height: 400px;
+    }
+
+    to {
+        opacity: 0;
+        transform: scale(0.92);
+        max-height: 0;
+    }
+}
+
+.vc-dmn-toast-clickable {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px;
+    cursor: pointer;
+}
+
+.vc-dmn-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.vc-dmn-body {
+    flex: 1;
+    min-width: 0;
+}
+
+.vc-dmn-header {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.vc-dmn-username {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--vc-dmn-user, #fff);
+}
+
+.vc-dmn-context {
+    font-size: 11px;
+    color: var(--vc-dmn-text, #dbdee1);
+    opacity: 0.65;
+}
+
+.vc-dmn-content {
+    margin-top: 2px;
+    font-size: 13px;
+    line-height: 1.35;
+    color: var(--vc-dmn-text, #dbdee1);
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow-wrap: anywhere;
+}
+
+.vc-dmn-close {
+    background: transparent;
+    border: none;
+    color: var(--vc-dmn-text, #dbdee1);
+    opacity: 0.7;
+    cursor: pointer;
+    padding: 2px;
+    border-radius: 4px;
+    flex-shrink: 0;
+    transition: background 0.15s, opacity 0.15s;
+}
+
+.vc-dmn-close:hover {
+    opacity: 1;
+    background: rgb(255 255 255 / 8%);
+}
+
+.vc-dmn-progress {
+    height: 3px;
+    background: var(--vc-dmn-accent, #5865f2);
+    transition: width 0.05s linear;
+}
+
+.vc-dmn-replybar {
+    position: relative;
+    border-top: 1px solid rgb(255 255 255 / 6%);
+    border-left: 1px solid rgb(255 255 255 / 6%);
+    border-right: 1px solid rgb(255 255 255 / 6%);
+    border-bottom: 1px solid rgb(255 255 255 / 6%);
+    border-radius: 0 0 10px 10px;
+    padding: 8px;
+    background: var(--vc-dmn-bg, #232428);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 45%);
+}
+
+.vc-dmn-replyrow {
+    display: flex;
+    align-items: flex-end;
+    gap: 6px;
+}
+
+.vc-dmn-textarea {
+    flex: 1;
+    resize: none;
+    max-height: 90px;
+    min-height: 32px;
+    border-radius: 8px;
+    border: none;
+    outline: none;
+    padding: 7px 10px;
+    background: rgb(0 0 0 / 25%);
+    color: var(--vc-dmn-text, #dbdee1);
+    caret-color: var(--vc-dmn-user, #fff);
+    font-size: 13px;
+    font-family: inherit;
+    line-height: 1.3;
+}
+
+.vc-dmn-textarea::placeholder {
+    color: var(--vc-dmn-text, #dbdee1);
+    opacity: 0.45;
+}
+
+.vc-dmn-icon-btn {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    color: var(--vc-dmn-text, #dbdee1);
+    opacity: 0.75;
+    cursor: pointer;
+    font-size: 17px;
+    transition: background 0.15s, opacity 0.15s;
+}
+
+.vc-dmn-icon-btn:hover {
+    opacity: 1;
+    background: rgb(255 255 255 / 8%);
+}
+
+.vc-dmn-icon-btn.vc-dmn-active {
+    opacity: 1;
+    background: rgb(255 255 255 / 12%);
+}
+
+.vc-dmn-send-btn {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--vc-dmn-accent, #5865f2);
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.15s, opacity 0.15s, transform 0.1s;
+}
+
+.vc-dmn-send-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.vc-dmn-send-btn:hover:not(:disabled) {
+    filter: brightness(1.1);
+}
+
+.vc-dmn-send-btn:active:not(:disabled) {
+    transform: scale(0.92);
+}
+
+.vc-dmn-emoji-suggestions {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-height: 160px;
+    overflow-y: auto;
+    margin-bottom: 6px;
+    background: #18191c;
+    border-radius: 8px;
+    padding: 4px;
+}
+
+.vc-dmn-emoji-suggestion {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--vc-dmn-text, #dbdee1);
+}
+
+.vc-dmn-emoji-suggestion:hover {
+    background: rgb(255 255 255 / 8%);
+}
+
+.vc-dmn-emoji-suggestion img {
+    width: 20px;
+    height: 20px;
+}
+
+.vc-dmn-emoji-unicode {
+    font-size: 18px;
+    width: 20px;
+    text-align: center;
+}
+
+.vc-dmn-emoji-popover {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    right: 0;
+    width: 100%;
+    max-width: 320px;
+    height: 320px;
+    display: flex;
+    flex-direction: column;
+    background: #111214;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgb(0 0 0 / 50%);
+    border: 1px solid rgb(255 255 255 / 6%);
+    z-index: 1;
+    overflow: hidden;
+}
+
+.vc-dmn-emoji-popover-search-wrap {
+    position: relative;
+    flex-shrink: 0;
+    padding: 10px;
+    border-bottom: 1px solid rgb(255 255 255 / 6%);
+}
+
+.vc-dmn-emoji-popover-search-icon {
+    position: absolute;
+    left: 20px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--vc-dmn-text, #dbdee1);
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.vc-dmn-emoji-popover-search {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px 8px 30px;
+    border-radius: 4px;
+    border: none;
+    outline: none;
+    background: #1e1f22;
+    color: var(--vc-dmn-text, #dbdee1);
+    caret-color: var(--vc-dmn-user, #fff);
+    font-size: 13px;
+}
+
+.vc-dmn-emoji-popover-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 10px;
+}
+
+.vc-dmn-emoji-category + .vc-dmn-emoji-category {
+    margin-top: 12px;
+}
+
+.vc-dmn-emoji-category-label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    color: var(--vc-dmn-text, #dbdee1);
+    opacity: 0.5;
+    margin-bottom: 6px;
+}
+
+.vc-dmn-emoji-empty {
+    text-align: center;
+    padding: 24px 8px;
+    font-size: 13px;
+    color: var(--vc-dmn-text, #dbdee1);
+    opacity: 0.5;
+}
+
+.vc-dmn-emoji-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+    gap: 2px;
+}
+
+.vc-dmn-emoji-grid-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    border-radius: 6px;
+    cursor: pointer;
+    aspect-ratio: 1;
+    transition: background 0.1s, transform 0.08s;
+}
+
+.vc-dmn-emoji-grid-item:hover {
+    background: rgb(255 255 255 / 8%);
+    transform: scale(1.12);
+}
+
+.vc-dmn-emoji-grid-item img {
+    width: 24px;
+    height: 24px;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -646,6 +646,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "NightmareSan",
         id: 304239816466235392n
     },
+    lunomium: {
+        name: "lunomium",
+        id: 1123264655595405382n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Animated, customizable toast notifications for DMs and mentions that show regardless of the channel currently being viewed, with a quick reply bar (including a Discord-style emoji picker) built into each toast.

<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
