### PR TITLE
feat(plugins): SoundboardUnlocker

### DIFF
--- a/src/plugins/soundboardUnlocker/README.md
+++ b/src/plugins/soundboardUnlocker/README.md
@@ -1,0 +1,5 @@
+# Soundboard Unlocker
+
+A Vencord user plugin that makes soundboard sounds from your other guilds selectable without Nitro.
+
+The plugin patches Discord's client-side Soundboard Everywhere entitlement and removes the Nitro-locked marker from external guild sections. It does not grant guild permissions, therefore you must still be able to view the source guild, join the destination voice channel, and have Use External Sounds permission there.

--- a/src/plugins/soundboardUnlocker/index.ts
+++ b/src/plugins/soundboardUnlocker/index.ts
@@ -1,0 +1,31 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "SoundboardUnlocker",
+    description: "Allows using soundboard sounds from other guilds without Nitro.",
+    authors: [Devs.Adversing],
+
+    patches: [
+        {
+            find: "canUseSoundboardEverywhere:function",
+            replacement: {
+                match: /(?<=canUseSoundboardEverywhere:function\(\i\)\{)/,
+                replace: "return true;"
+            }
+        },
+        {
+            find: "SOUNDBOARD_SOUND_PICKER_UPSELL,upsellViewedTrackingData:",
+            replacement: {
+                match: /isNitroLocked:!\i(?=},key:\i\.id,items:\i)/,
+                replace: "isNitroLocked:false"
+            }
+        }
+    ]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -646,6 +646,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "NightmareSan",
         id: 304239816466235392n
     },
+    Adversing: {
+        name: "Adversing",
+        id: 369846142025859082n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
This plugin allows you to use soundboards without having a Nitro subscription. 
The workaround is simple: Discord asks 'Can this user use soundboard sounds everywhere?' and I force the answer to always be positive; then when the Discord client checks whether the soundboard sound is locked behind Nitro, I set the value to false.

Known limitations:
1) If Discord ever moves the nitro subscription check for this feature on their end, this plugin won't work anymore.
2) You must have the permission to use the soundboard feature in the voice channel you're into.
3) The plugin could also stop working if Discord simply renames or restructures the client code.

## Checklist before submitting
- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [X] This pull request was written by me, and not an AI agent