### PR TITLE
Fix StickerPaste/FakeNitro conflict – #3691

### DIFF
--- a/src/api/MessageEvents.ts
+++ b/src/api/MessageEvents.ts
@@ -17,7 +17,7 @@
 */
 
 import { Logger } from "@utils/Logger";
-import type { Channel, CustomEmoji, Message } from "@vencord/discord-types";
+import type { Channel, CloudUpload, CustomEmoji, Message } from "@vencord/discord-types";
 import { MessageStore } from "@webpack/common";
 import type { Promisable } from "type-fest";
 
@@ -38,6 +38,7 @@ export interface SendMessageOptions {
     };
     location: string;
     stickerIds?: string[];
+    attachmentsToUpload?: CloudUpload[];
     alsoForwardToChannelId?: string;
 
     // If you end up using these, update their type

--- a/src/api/MessageEvents.ts
+++ b/src/api/MessageEvents.ts
@@ -17,7 +17,7 @@
 */
 
 import { Logger } from "@utils/Logger";
-import type { Channel, CloudUpload, CustomEmoji, Message } from "@vencord/discord-types";
+import type { Channel, CustomEmoji, Message } from "@vencord/discord-types";
 import { MessageStore } from "@webpack/common";
 import type { Promisable } from "type-fest";
 
@@ -38,7 +38,6 @@ export interface SendMessageOptions {
     };
     location: string;
     stickerIds?: string[];
-    attachmentsToUpload?: CloudUpload[];
     alsoForwardToChannelId?: string;
 
     // If you end up using these, update their type

--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -17,20 +17,22 @@
 */
 
 import { addMessagePreEditListener, addMessagePreSendListener, removeMessagePreEditListener, removeMessagePreSendListener } from "@api/MessageEvents";
+import { isPluginEnabled } from "@api/PluginManager";
 import { definePluginSettings } from "@api/Settings";
 import { ApngBlendOp, ApngDisposeOp, parseAPNG } from "@utils/apng";
 import { Devs } from "@utils/constants";
 import { getCurrentGuild } from "@utils/discord";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
-import type { Emoji, Message, RenderModalProps, Sticker } from "@vencord/discord-types";
-import { StickerFormatType } from "@vencord/discord-types/enums";
-import { findByCodeLazy, findByPropsLazy, proxyLazyWebpack } from "@webpack";
+import type { CloudUpload as TCloudUpload, Emoji, Message, RenderModalProps, Sticker } from "@vencord/discord-types";
+import { CloudUploadPlatform, StickerFormatType } from "@vencord/discord-types/enums";
+import { findByCodeLazy, findByPropsLazy, findLazy, proxyLazyWebpack } from "@webpack";
 import { ChannelStore, ConfirmModal, DraftType, EmojiStore, FluxDispatcher, Forms, GuildMemberStore, IconUtils, lodash, openModal, Parser, PermissionsBits, PermissionStore, StickersStore, UploadHandler, UserSettingsActionCreators, UserSettingsProtoStore, UserStore } from "@webpack/common";
 import { applyPalette, GIFEncoder, quantize } from "gifenc";
 import type { ReactElement, ReactNode } from "react";
 
 const BINARY_READ_OPTIONS = findByPropsLazy("readerFactory");
+const CloudUpload: typeof TCloudUpload = findLazy(m => m.prototype?.trackUploadFinished);
 
 function searchProtoClassField(localName: string, protoClass: any) {
     const field = protoClass?.fields?.find((field: any) => field.localName === localName);
@@ -72,6 +74,17 @@ const fakeNitroEmojiRegex = /\/emojis\/(\d+?)\.(png|webp|gif)/;
 const fakeNitroStickerRegex = /\/stickers\/(\d+?)\./;
 const fakeNitroGifStickerRegex = /\/attachments\/\d+?\/\d+?\/(\d+?)\.gif/;
 const hyperLinkRegex = /\[.+?\]\((https?:\/\/.+?)\)/;
+
+function messageContainsStickerLink(content: string, stickerId: string) {
+    return content.includes(`/stickers/${stickerId}.`);
+}
+
+function removeStickerLink(content: string, stickerId: string) {
+    return content
+        .replace(new RegExp(String.raw`\s*\[.*?\]\(https?:\/\/[^\s)]*\/stickers\/${stickerId}\.[^\s)]*\)`, "g"), "")
+        .replace(new RegExp(String.raw`\s*https?:\/\/\S*\/stickers\/${stickerId}\.\S+`, "g"), "")
+        .trim();
+}
 
 const settings = definePluginSettings({
     enableEmojiBypass: {
@@ -182,7 +195,7 @@ function showCannotEmbedNotice() {
 
 export default definePlugin({
     name: "FakeNitro",
-    authors: [Devs.Arjix, Devs.D3SOX, Devs.Ven, Devs.fawn, Devs.captain, Devs.Nuckyz, Devs.AutumnVN, Devs.sadan],
+    authors: [Devs.Arjix, Devs.D3SOX, Devs.Ven, Devs.fawn, Devs.captain, Devs.Nuckyz, Devs.AutumnVN, Devs.sadan, Devs.theo],
     description: "Allows you to send fake emojis/stickers, use nitro themes, and stream in nitro quality",
     tags: ["Emotes", "Appearance", "Customisation", "Chat"],
     dependencies: ["MessageEventsAPI"],
@@ -740,8 +753,7 @@ export default definePlugin({
         return `https://media.discordapp.net/stickers/${id}.${ext}?size=${settings.store.stickerSize}`;
     },
 
-    async sendAnimatedSticker(stickerLink: string, stickerId: string, channelId: string) {
-
+    async makeAnimatedStickerFile(stickerLink: string, stickerId: string) {
         const { frames, width, height } = await fetch(stickerLink)
             .then(res => res.arrayBuffer())
             .then(parseAPNG);
@@ -793,7 +805,11 @@ export default definePlugin({
 
         gif.finish();
 
-        const file = new File([gif.bytesView() as Uint8Array<ArrayBuffer>], `${stickerId}.gif`, { type: "image/gif" });
+        return new File([gif.bytesView() as Uint8Array<ArrayBuffer>], `${stickerId}.gif`, { type: "image/gif" });
+    },
+
+    async sendAnimatedSticker(stickerLink: string, stickerId: string, channelId: string) {
+        const file = await this.makeAnimatedStickerFile(stickerLink, stickerId);
         UploadHandler.promptToUpload([file], ChannelStore.getChannel(channelId), DraftType.ChannelMessage);
     },
 
@@ -835,6 +851,12 @@ export default definePlugin({
                 if (!sticker)
                     break stickerBypass;
 
+                const shouldAttachSticker = isPluginEnabled("StickerPaste") && sticker.format_type === StickerFormatType.APNG;
+                if (!shouldAttachSticker && messageContainsStickerLink(messageObj.content, sticker.id)) {
+                    options.stickerIds!.length = 0;
+                    break stickerBypass;
+                }
+
                 // Discord Stickers are now free yayyy!! :D
                 if ("pack_id" in sticker)
                     break stickerBypass;
@@ -862,7 +884,19 @@ export default definePlugin({
                                 </div>
                             </ConfirmModal>
                         ));
+                    } else if (shouldAttachSticker) {
+                        const file = await this.makeAnimatedStickerFile(link, sticker.id);
+                        options.attachmentsToUpload ??= [];
+                        options.attachmentsToUpload.push(new CloudUpload({
+                            file,
+                            isThumbnail: false,
+                            platform: CloudUploadPlatform.WEB
+                        }, channelId));
+                        options.stickerIds!.length = 0;
+                        messageObj.content = removeStickerLink(messageObj.content, sticker.id);
+                        break stickerBypass;
                     } else {
+                        options.stickerIds!.length = 0;
                         this.sendAnimatedSticker(link, sticker.id, channelId);
                     }
 

--- a/src/plugins/fakeNitro/index.tsx
+++ b/src/plugins/fakeNitro/index.tsx
@@ -27,12 +27,28 @@ import definePlugin, { OptionType } from "@utils/types";
 import type { CloudUpload as TCloudUpload, Emoji, Message, RenderModalProps, Sticker } from "@vencord/discord-types";
 import { CloudUploadPlatform, StickerFormatType } from "@vencord/discord-types/enums";
 import { findByCodeLazy, findByPropsLazy, findLazy, proxyLazyWebpack } from "@webpack";
-import { ChannelStore, ConfirmModal, DraftType, EmojiStore, FluxDispatcher, Forms, GuildMemberStore, IconUtils, lodash, openModal, Parser, PermissionsBits, PermissionStore, StickersStore, UploadHandler, UserSettingsActionCreators, UserSettingsProtoStore, UserStore } from "@webpack/common";
+import { ChannelStore, ConfirmModal, DraftType, EmojiStore, FluxDispatcher, Forms, GuildMemberStore, IconUtils, lodash, openModal, Parser, PermissionsBits, PermissionStore, StickersStore, UploadAttachmentStore, UploadHandler, UserSettingsActionCreators, UserSettingsProtoStore, UserStore } from "@webpack/common";
 import { applyPalette, GIFEncoder, quantize } from "gifenc";
 import type { ReactElement, ReactNode } from "react";
 
 const BINARY_READ_OPTIONS = findByPropsLazy("readerFactory");
 const CloudUpload: typeof TCloudUpload = findLazy(m => m.prototype?.trackUploadFinished);
+
+function addFileToDraft(channelId: string, file: File) {
+    const uploads: TCloudUpload[] = UploadAttachmentStore.getUploads(channelId, DraftType.ChannelMessage);
+    uploads.push(new CloudUpload({
+        file,
+        isThumbnail: false,
+        platform: CloudUploadPlatform.WEB
+    }, channelId));
+
+    FluxDispatcher.dispatch({
+        type: "UPLOAD_ATTACHMENT_SET_UPLOADS",
+        uploads: [...uploads],
+        channelId,
+        draftType: DraftType.ChannelMessage
+    });
+}
 
 function searchProtoClassField(localName: string, protoClass: any) {
     const field = protoClass?.fields?.find((field: any) => field.localName === localName);
@@ -886,12 +902,7 @@ export default definePlugin({
                         ));
                     } else if (shouldAttachSticker) {
                         const file = await this.makeAnimatedStickerFile(link, sticker.id);
-                        options.attachmentsToUpload ??= [];
-                        options.attachmentsToUpload.push(new CloudUpload({
-                            file,
-                            isThumbnail: false,
-                            platform: CloudUploadPlatform.WEB
-                        }, channelId));
+                        addFileToDraft(channelId, file);
                         options.stickerIds!.length = 0;
                         messageObj.content = removeStickerLink(messageObj.content, sticker.id);
                         break stickerBypass;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -646,6 +646,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "NightmareSan",
         id: 304239816466235392n
     },
+    theo: {
+        name: "theo",
+        id: 1081551899397992509n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

Fixes https://github.com/Vendicated/Vencord/issues/3691

StickerPaste already handles sending stickers later, so FakeNitro shouldn't call `promptToUpload` and upload the generated GIF a second time. Pasted stickers now get attached to the current send options instead. I have no idea if there's a better way to do this but it doesn't seem like it as I tried a few different fixes.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
