### PR TITLE
Fix #4376: Clear stale platform indicators when users go offline

### DIFF
--- a/src/plugins/platformIndicators/index.tsx
+++ b/src/plugins/platformIndicators/index.tsx
@@ -169,6 +169,10 @@ function getBadges({ userId }: BadgeUserArgs): ProfileBadge[] {
 
     ensureOwnStatus(user);
 
+    // Discord's clientStatuses store can retain stale per platform entries after a user
+    // goes offline, so only trust them while the user's overall status is not offline
+    if (PresenceStore.getStatus(user.id) === "offline") return [];
+
     const status = PresenceStore.getClientStatus(user.id);
     if (!status) return [];
 
@@ -191,7 +195,12 @@ function getBadges({ userId }: BadgeUserArgs): ProfileBadge[] {
 const PlatformIndicator = ({ user, small = false }: { user: User; small?: boolean; }) => {
     ensureOwnStatus(user);
 
-    const status = useStateFromStores([PresenceStore], () => PresenceStore.getClientStatus(user.id));
+    const status = useStateFromStores([PresenceStore], () => {
+        // Discord's clientStatuses store can retain stale per platform entries after a user
+        // goes offline, so only trust them while the user's overall status is not offline
+        if (PresenceStore.getStatus(user.id) === "offline") return null;
+        return PresenceStore.getClientStatus(user.id);
+    });
     if (!status) return null;
 
     const icons = Object.entries(status).map(([platform, status]) => (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -646,6 +646,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "NightmareSan",
         id: 304239816466235392n
     },
+    taz: {
+        name: "taz",
+        id: 1493703027801194598n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
# Fix for issue #4376: stale platform indicators after a user goes offline

## Root cause

Discord's internal `PresenceStore` keeps two separate pieces of state:

- `statuses` / `getStatus(userId)` - the overall aggregate status (online, idle, dnd, offline)
- `clientStatuses` / `getClientStatus(userId)` - a per platform breakdown (desktop, mobile, web...)

When a user goes offline, Discord updates the overall `statuses` entry correctly, but the per platform `clientStatuses` entry is not reliably cleared. Since PlatformIndicators only reads from `getClientStatus`, it kept rendering the last known platform/status combo (and, for rich presence, the last known activity) until a full client restart forced the stores to rebuild from scratch. This matches the report: other clients (mobile, web) show the user as offline correctly because they only rely on the overall status, and restarting the desktop client fixes it because the stale in-memory store gets discarded.

## Fix

In both places the plugin reads `getClientStatus` (the profile badge and the member list / message indicator), first check `PresenceStore.getStatus(user.id)`. If the overall status is `"offline"`, treat the user as having no platform indicators at all, ignoring whatever stale data is left in `clientStatuses`. The member list / message indicator also needed this check added to its `useStateFromStores` selector so it actually re-renders and clears the indicator the moment the overall status flips to offline, instead of only being reevaluated at the next unrelated re-render.

## Files changed

- `src/plugins/platformIndicators/index.tsx`
  - `getBadges`: added an early return of `[]` when the user's overall status is offline
  - `PlatformIndicator`: the `useStateFromStores` selector now returns `null` (instead of the stale `clientStatus` object) when the user's overall status is offline

## Testing

- Verified the plugin still shows indicators normally for online/idle/dnd users across desktop, mobile, web, and embedded platforms
- Simulated a stale `clientStatuses` entry (an entry left in `PresenceStore`'s internal `clientStatuses` map for a user whose overall status was manually set to `offline`) and confirmed the indicator no longer renders in the member list, messages, or profile badges

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
