### PR TITLE
OnePingPerChannel - Add a visuel notification, reaction, and affect discord server

### DIFF
--- a/src/plugins/onePingPerDM/index.ts
+++ b/src/plugins/onePingPerDM/index.ts
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2023 Vendicated and contributors
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
@@ -9,33 +9,41 @@ import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { MessageJSON } from "@vencord/discord-types";
 import { ChannelType } from "@vencord/discord-types/enums";
-import { ChannelStore, ReadStateStore, UserStore } from "@webpack/common";
+import { ChannelStore, FluxDispatcher, ReadStateStore, UserStore } from "@webpack/common";
+
+const pingedReactionChannels = new Set<string>();
 
 const settings = definePluginSettings({
-    channelToAffect: {
-        type: OptionType.SELECT,
-        description: "Select the type of DM for the plugin to affect",
-        options: [
-            { label: "Both", value: "both_dms", default: true },
-            { label: "User DMs", value: "user_dm" },
-            { label: "Group DMs", value: "group_dm" },
-        ]
+    affectDMs: {
+        type: OptionType.BOOLEAN,
+        description: "Limit repeated notifications in DMs (1-on-1)",
+        default: true,
+    },
+    affectGroupDMs: {
+        type: OptionType.BOOLEAN,
+        description: "Limit repeated notifications in group DMs",
+        default: true,
+    },
+    affectServers: {
+        type: OptionType.BOOLEAN,
+        description: "Limit repeated notifications in server channels",
+        default: true,
     },
     allowMentions: {
         type: OptionType.BOOLEAN,
-        description: "Receive audio pings for @mentions",
+        description: "Always receive a ping for direct @mentions",
         default: false,
     },
     allowEveryone: {
         type: OptionType.BOOLEAN,
-        description: "Receive audio pings for @everyone and @here in group DMs",
+        description: "Always receive a ping for @everyone and @here",
         default: false,
     },
 });
 
 export default definePlugin({
-    name: "OnePingPerDM",
-    description: "If unread messages are sent by a user in DMs multiple times, you'll only receive one audio ping. Read the messages to reset the limit",
+    name: "OnePingPerChannel",
+    description: "If multiple unread messages or reactions arrive in the same channel (DM, group, or server), you'll only get one ping. Reading the messages resets the limit.",
     tags: ["Notifications", "Customisation"],
     authors: [Devs.ProffDea],
     settings,
@@ -45,26 +53,67 @@ export default definePlugin({
             replacement: [
                 {
                     match: /(\i\.\i\.getDesktopType\(\)===\i\.\i\.NEVER)\)/,
-                    replace: "$&if(!$self.isPrivateChannelRead(arguments[0]?.message))return;else "
+                    replace: "$&if(!$self.shouldPing(arguments[0]?.message))return;else "
                 },
                 {
-                    match: /sound:(\i\?\i:void 0,volume:\i,onClick)/,
-                    replace: "sound:!$self.isPrivateChannelRead(arguments[0]?.message)?undefined:$1"
+                    match: /\i\(\i\),\i\.\i\.showNotification\(\i,\i,\i,\{notif_type:"MESSAGE_CREATE"/,
+                    replace: "if(!$self.shouldPing(arguments[0]?.message))return;$&"
+                },
+                {
+                    match: /\i\.\i\.showNotification\(\i,\i,\i,\{notif_type:\i,notif_user_id:\i,message_id:\i\.id\}/,
+                    replace: "if(!$self.shouldPingReaction(arguments[0]?.message))return;$&"
                 }
             ]
         }
     ],
-    isPrivateChannelRead(message: MessageJSON) {
+    start() {
+        FluxDispatcher.subscribe("MESSAGE_ACK", this.onMessageAck);
+    },
+    stop() {
+        FluxDispatcher.unsubscribe("MESSAGE_ACK", this.onMessageAck);
+    },
+    onMessageAck({ channelId }: { channelId: string; }) {
+        pingedReactionChannels.delete(channelId);
+    },
+    shouldPing(message: MessageJSON) {
         const channelType = ChannelStore.getChannel(message.channel_id)?.type;
+        const isDM = channelType === ChannelType.DM;
+        const isGroupDM = channelType === ChannelType.GROUP_DM;
+        const isServerChannel = !isDM && !isGroupDM;
+
         if (
-            (channelType !== ChannelType.DM && channelType !== ChannelType.GROUP_DM) ||
-            (channelType === ChannelType.DM && settings.store.channelToAffect === "group_dm") ||
-            (channelType === ChannelType.GROUP_DM && settings.store.channelToAffect === "user_dm") ||
+            (isDM && !settings.store.affectDMs) ||
+            (isGroupDM && !settings.store.affectGroupDMs) ||
+            (isServerChannel && !settings.store.affectServers) ||
             (settings.store.allowMentions && message.mentions.some(m => m.id === UserStore.getCurrentUser().id)) ||
             (settings.store.allowEveryone && message.mention_everyone)
         ) {
             return true;
         }
+
         return ReadStateStore.getOldestUnreadMessageId(message.channel_id) === message.id;
+    },
+    // Reactions aren't tied to an "unread message" like normal messages, so we track
+    // per-channel whether a reaction ping has already fired since the channel was last read.
+    shouldPingReaction(message: MessageJSON) {
+        const channelType = ChannelStore.getChannel(message.channel_id)?.type;
+        const isDM = channelType === ChannelType.DM;
+        const isGroupDM = channelType === ChannelType.GROUP_DM;
+        const isServerChannel = !isDM && !isGroupDM;
+
+        if (
+            (isDM && !settings.store.affectDMs) ||
+            (isGroupDM && !settings.store.affectGroupDMs) ||
+            (isServerChannel && !settings.store.affectServers)
+        ) {
+            return true;
+        }
+
+        if (pingedReactionChannels.has(message.channel_id)) {
+            return false;
+        }
+
+        pingedReactionChannels.add(message.channel_id);
+        return true;
     },
 });


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><h1>OnePingPerChannel — Changelog</h1>
<p>Fork of <a href="https://github.com/Vendicated/Vencord"><code>OnePingPerDM</code></a> by <code>Devs.ProffDea</code>, extended to cover server channels, visual (toast) notifications, and reactions, in addition to the original DM-only audio ping limiting.</p>
<hr>
<h2>Summary</h2>

  | Before (OnePingPerDM) | After (OnePingPerChannel)
-- | -- | --
Scope | DMs and group DMs only | DMs, group DMs, and server channels
Notification types limited | Audio ping only | Audio ping and visual popup (toast)
Message reactions | Not handled | Limited the same way as messages


<hr>
<h2>1. Renamed the plugin</h2>
<ul>
<li><code>name</code>: <code>OnePingPerDM</code> → <code>OnePingPerChannel</code></li>
<li><code>description</code> updated to reflect the wider scope (channels + reactions instead of DMs-only messages).</li>
</ul>
<hr>
<h2>2. Extended scope from DMs-only to all channel types</h2>
<p><strong>Before:</strong> a single <code>SELECT</code> setting (<code>channelToAffect</code>) let you choose <code>Both</code> / <code>User DMs</code> / <code>Group DMs</code> — server channels were always excluded by a hardcoded check in <code>isPrivateChannelRead</code>:</p>
<pre><code class="language-ts">(channelType !== ChannelType.DM &amp;&amp; channelType !== ChannelType.GROUP_DM) // always bail out for servers
</code></pre>
<p><strong>After:</strong> replaced the single select with three independent booleans, all <code>true</code> by default:</p>
<pre><code class="language-ts">affectDMs: boolean       // default: true
affectGroupDMs: boolean  // default: true
affectServers: boolean   // default: true (new)
</code></pre>
<p>The core check function was renamed <code>isPrivateChannelRead</code> → <code>shouldPing</code> and rewritten to treat DMs, group DMs, and server channels uniformly:</p>
<pre><code class="language-ts">const isDM = channelType === ChannelType.DM;
const isGroupDM = channelType === ChannelType.GROUP_DM;
const isServerChannel = !isDM &amp;&amp; !isGroupDM;

if (
    (isDM &amp;&amp; !settings.store.affectDMs) ||
    (isGroupDM &amp;&amp; !settings.store.affectGroupDMs) ||
    (isServerChannel &amp;&amp; !settings.store.affectServers) ||
    ...
) return true; // don't suppress
</code></pre>
<p>No changes were needed to the existing patches for this step — the underlying Discord notification module already processes all channel types; only the plugin's own filtering logic was gate-keeping servers out.</p>
<hr>
<h2>3. Added visual (toast) notification suppression</h2>
<p><strong>Problem:</strong> the original plugin only silenced the <strong>sound</strong> (<code>sound: I ? tr : void 0</code> in Discord's own code) — the desktop popup/toast still appeared on every repeated message, which was the main complaint (screenshot showed repeated Windows toasts while typing in a server).</p>
<p><strong>Fix:</strong> added a new <code>replacement</code> entry that blocks the entire <code>showNotification(...)</code> call (icon, title, body, sound, onClick — everything) instead of only nulling the sound property, whenever <code>shouldPing</code> returns <code>false</code>:</p>
<pre><code class="language-ts">{
    match: /\i\(\i\),\i\.\i\.showNotification\(\i,\i,\i,\{notif_type:"MESSAGE_CREATE"/,
    replace: "if(!$self.shouldPing(arguments[0]?.message))return;$&amp;"
}
