### PR TITLE
Fix MemberCount causing high idle CPU and heap growth

### DIFF
--- a/src/plugins/memberCount/MemberCount.tsx
+++ b/src/plugins/memberCount/MemberCount.tsx
@@ -48,23 +48,36 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
         () => OnlineMemberCountStore.getCount(guildId)
     );
 
-    const { groups } = useStateFromStores(
+    const memberListOnlineCount = useStateFromStores(
         [ChannelMemberStore],
-        () => ChannelMemberStore.getProps(guildId, currentChannel?.id)
+        () => {
+            if (isTooltip) return null;
+
+            const { groups } = ChannelMemberStore.getProps(guildId, currentChannel?.id);
+            if (groups.length >= 1 || groups[0].id !== "unknown") {
+                return groups.reduce((total, curr) => total + (curr.id === "offline" ? 0 : curr.count), 0);
+            }
+
+            return null;
+        }
     );
 
-    const threadGroups = useStateFromStores(
+    const threadListOnlineCount = useStateFromStores(
         [ThreadMemberListStore],
-        () => ThreadMemberListStore.getMemberListSections(currentChannel?.id)
+        () => {
+            if (isTooltip) return null;
+
+            const threadGroups = ThreadMemberListStore.getMemberListSections(currentChannel?.id);
+            if (threadGroups && !isObjectEmpty(threadGroups)) {
+                return Object.values(threadGroups).reduce((total, curr) => total + (curr.sectionId === "offline" ? 0 : curr.userIds.length), 0);
+            }
+
+            return null;
+        }
     );
 
-    if (!isTooltip && (groups.length >= 1 || groups[0].id !== "unknown")) {
-        onlineCount = groups.reduce((total, curr) => total + (curr.id === "offline" ? 0 : curr.count), 0);
-    }
-
-    if (!isTooltip && threadGroups && !isObjectEmpty(threadGroups)) {
-        onlineCount = Object.values(threadGroups).reduce((total, curr) => total + (curr.sectionId === "offline" ? 0 : curr.userIds.length), 0);
-    }
+    if (memberListOnlineCount != null) onlineCount = memberListOnlineCount;
+    if (threadListOnlineCount != null) onlineCount = threadListOnlineCount;
 
     useEffect(() => {
         OnlineMemberCountStore.ensureCount(guildId);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -646,6 +646,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "NightmareSan",
         id: 304239816466235392n
     },
+    jax: {
+        name: "jax",
+        id: 1493703027801194598n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Describe your Changes

Fixes #4394

While testing MemberCount, I noticed my CPU usage was slowly increasing and the JS heap kept growing over time.

After looking into it, I found that MemberCount was causing unnecessary rerenders because `ChannelMemberStore.getProps()` and `ThreadMemberListStore.getMemberListSections()` were creating new objects/arrays every time they were called. Since `useStateFromStores` compares references, it thought the value changed even when the actual count stayed the same.

I changed the selectors to return the member count directly instead of the whole object/array, so it only updates when the count actually changes.

Also skipped the store calls for the tooltip version since it doesn't use those values anyway.

## Checklist before submitting

- [x] I have read the CONTRIBUTING.md file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent