### PR TITLE
MemberCount: improve performance

### DIFF
--- a/src/plugins/memberCount/MemberCount.tsx
+++ b/src/plugins/memberCount/MemberCount.tsx
@@ -17,13 +17,19 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
     const { voiceActivity } = settings.use(["voiceActivity"]);
     const includeVoice = voiceActivity && !isTooltip;
 
-    const currentChannel = useStateFromStores([SelectedChannelStore], () => getCurrentChannel());
-    const guildId = isTooltip ? tooltipGuildId! : currentChannel?.guild_id;
+    const currentChannel = useStateFromStores(
+        [SelectedChannelStore],
+        () => isTooltip ? undefined : getCurrentChannel(),
+        [],
+        (a, b) => a?.id === b?.id
+    );
+
+    const guildId = tooltipGuildId ?? currentChannel?.guild_id;
 
     const voiceActivityCount = useStateFromStores(
         [VoiceStateStore],
         () => {
-            if (!includeVoice) return 0;
+            if (!includeVoice || !guildId) return 0;
 
             const voiceStates = VoiceStateStore.getVoiceStates(guildId);
             if (!voiceStates) return 0;
@@ -31,6 +37,7 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
             return Object.values(voiceStates)
                 .filter(({ channelId }) => {
                     if (!channelId) return false;
+
                     const channel = ChannelStore.getChannel(channelId);
                     return channel && PermissionStore.can(PermissionsBits.VIEW_CHANNEL, channel);
                 })
@@ -40,34 +47,57 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
 
     const totalCount = useStateFromStores(
         [GuildMemberCountStore],
-        () => GuildMemberCountStore.getMemberCount(guildId!)
+        () => guildId ? GuildMemberCountStore.getMemberCount(guildId) : null
     );
 
     let onlineCount = useStateFromStores(
         [OnlineMemberCountStore],
-        () => OnlineMemberCountStore.getCount(guildId)
+        () => guildId ? OnlineMemberCountStore.getCount(guildId) : null
     );
 
-    const { groups } = useStateFromStores(
+    const memberListOnlineCount = useStateFromStores(
         [ChannelMemberStore],
-        () => ChannelMemberStore.getProps(guildId, currentChannel?.id)
+        () => {
+            if (isTooltip || !guildId) return null;
+
+            const { groups } = ChannelMemberStore.getProps(guildId, currentChannel?.id);
+
+            if (groups.length >= 1 || groups[0].id !== "unknown") {
+                return groups.reduce(
+                    (total, curr) => total + (curr.id === "offline" ? 0 : curr.count),
+                    0
+                );
+            }
+
+            return null;
+        }
     );
 
-    const threadGroups = useStateFromStores(
+    const threadListOnlineCount = useStateFromStores(
         [ThreadMemberListStore],
-        () => ThreadMemberListStore.getMemberListSections(currentChannel?.id)
+        () => {
+            if (isTooltip) return null;
+
+            const threadGroups = ThreadMemberListStore.getMemberListSections(currentChannel?.id);
+
+            if (threadGroups && !isObjectEmpty(threadGroups)) {
+                return Object.values(threadGroups).reduce(
+                    (total, curr) => total + (curr.sectionId === "offline" ? 0 : curr.userIds.length),
+                    0
+                );
+            }
+
+            return null;
+        }
     );
 
-    if (!isTooltip && (groups.length >= 1 || groups[0].id !== "unknown")) {
-        onlineCount = groups.reduce((total, curr) => total + (curr.id === "offline" ? 0 : curr.count), 0);
-    }
-
-    if (!isTooltip && threadGroups && !isObjectEmpty(threadGroups)) {
-        onlineCount = Object.values(threadGroups).reduce((total, curr) => total + (curr.sectionId === "offline" ? 0 : curr.userIds.length), 0);
-    }
+    if (memberListOnlineCount != null) onlineCount = memberListOnlineCount;
+    if (threadListOnlineCount != null) onlineCount = threadListOnlineCount;
 
     useEffect(() => {
-        OnlineMemberCountStore.ensureCount(guildId);
+        if (guildId) {
+            OnlineMemberCountStore.ensureCount(guildId);
+        }
     }, [guildId]);
 
     if (totalCount == null)
@@ -82,10 +112,11 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
                 {props => (
                     <div {...props} className={cl("container")}>
                         <CircleIcon className={cl("online-count")} />
-                        <span className={cl("online")}>{formattedOnlineCount}</span>
+                        <span className={cl("online-count")}>{formattedOnlineCount}</span>
                     </div>
                 )}
             </Tooltip>
+
             <Tooltip text={`${numberFormat(totalCount)} total server members`} position="bottom">
                 {props => (
                     <div {...props} className={cl("container")}>
@@ -94,6 +125,7 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
                     </div>
                 )}
             </Tooltip>
+
             {includeVoice && voiceActivityCount > 0 &&
                 <Tooltip text={`${formattedVoiceCount} members in voice`} position="bottom">
                     {props => (

--- a/src/plugins/memberCount/MemberCount.tsx
+++ b/src/plugins/memberCount/MemberCount.tsx
@@ -18,10 +18,8 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
     const includeVoice = voiceActivity && !isTooltip;
 
     const currentChannel = useStateFromStores(
-        [SelectedChannelStore],
-        () => isTooltip ? undefined : getCurrentChannel(),
-        [],
-        (a, b) => a?.id === b?.id
+        [SelectedChannelStore], () => isTooltip ? undefined : getCurrentChannel(),
+        [], (a, b) => a?.id === b?.id
     );
 
     const guildId = tooltipGuildId ?? currentChannel?.guild_id;
@@ -112,7 +110,7 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
                 {props => (
                     <div {...props} className={cl("container")}>
                         <CircleIcon className={cl("online-count")} />
-                        <span className={cl("online-count")}>{formattedOnlineCount}</span>
+                        <span className={cl("online")}>{formattedOnlineCount}</span>
                     </div>
                 )}
             </Tooltip>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -649,6 +649,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Lunascape: {
         name: "Lunascape",
         id: 383365021415243776n
+    },
+    jax: {
+        name: "jax",
+        id: 1493703027801194598n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
## Describe your Changes

Fixes #4394
> This pr was mistakenly closed by me today so this is a duplicate pr :D

While testing MemberCount, I noticed my CPU usage was slowly increasing and the JS heap kept growing over time.

After looking into it, I found that MemberCount was causing unnecessary rerenders because `ChannelMemberStore.getProps()` and `ThreadMemberListStore.getMemberListSections()` were creating new objects/arrays every time they were called. Since `useStateFromStores` compares references, it thought the value changed even when the actual count stayed the same.

I changed the selectors to return the member count directly instead of the whole object/array, so it only updates when the count actually changes.

Also skipped the store calls for the tooltip version since it doesn't use those values anyway.

## Checklist before submitting

- [x] I have read the CONTRIBUTING.md file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent