### PR TITLE
Fix link widths in theme settings

### DIFF
--- a/src/components/settings/tabs/themes/LocalThemesTab.tsx
+++ b/src/components/settings/tabs/themes/LocalThemesTab.tsx
@@ -87,11 +87,13 @@ export function LocalThemesTab() {
         <Flex flexDirection="column" gap="1em">
             <Card>
                 <Forms.FormTitle tag="h5">Find Themes:</Forms.FormTitle>
-                <div style={{ marginBottom: ".5em", display: "flex", flexDirection: "column" }}>
-                    <Link style={{ marginRight: ".5em" }} href="https://betterdiscord.app/themes">
+                <div style={{ marginBottom: ".5em", display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+                    <Link style={{ width: "fit-content" }} href="https://betterdiscord.app/themes">
                         BetterDiscord Themes
                     </Link>
-                    <Link href="https://github.com/search?q=discord+theme">GitHub</Link>
+                    <Link style={{ width: "fit-content" }} href="https://github.com/search?q=discord+theme">
+                        GitHub
+                    </Link>
                 </div>
                 <Forms.FormText>If using the BD site, click on "Download" and place the downloaded .theme.css file into your themes folder.</Forms.FormText>
             </Card>


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

This is a very minor issue that probably isnt even worth making a PR over. The links on the theme page occupy the full width of the card and make it so clicking anywhere next to them will open the link (found out because I misclicked while reading)

### Before:
<img width="416" height="303" alt="image" src="https://github.com/user-attachments/assets/50dcb162-8d15-4f80-9e4a-993cd5cf7ff8" />

### After:

<img width="400" height="283" alt="image" src="https://github.com/user-attachments/assets/d6e0106b-aa68-44cc-9bb4-af0b95ef2cc7" />

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
