### PR TITLE
MessageLogger: fix new attachments being dropped on edit

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -216,7 +216,7 @@ export default definePlugin({
     name: "MessageLogger",
     description: "Temporarily logs deleted and edited messages.",
     tags: ["Chat", "Utility"],
-    authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN, Devs.Nickyux, Devs.Kyuuhachi, Devs.sadan],
+    authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN, Devs.Nickyux, Devs.Kyuuhachi, Devs.sadan, Devs.yuna0x0],
     dependencies: ["MessageUpdaterAPI"],
     settings,
     contextMenus: {
@@ -274,15 +274,12 @@ export default definePlugin({
         if (!newMessage.attachments?.length) {
             return oldMessage.attachments.map((a): MLAttachment => ({ ...a, deleted: true }));
         }
-        const attachments: MLAttachment[] = [];
-        for (const oldAttachment of oldMessage.attachments) {
-            const wasDeleted = newMessage.attachments.every(a => a.id !== oldAttachment.id);
-            if (wasDeleted) {
-                attachments.push({ ...oldAttachment, deleted: true });
-            } else {
-                attachments.push(oldAttachment);
-            }
-        }
+        const attachments = oldMessage.attachments
+            .map((oldAttachment): MLAttachment =>
+                newMessage.attachments.find(a => a.id === oldAttachment.id)
+                ?? { ...oldAttachment, deleted: true }
+            )
+            .concat(newMessage.attachments.filter(a => oldMessage.attachments.every(o => o.id !== a.id)));
         return attachments;
     },
 

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -274,13 +274,12 @@ export default definePlugin({
         if (!newMessage.attachments?.length) {
             return oldMessage.attachments.map((a): MLAttachment => ({ ...a, deleted: true }));
         }
-        const attachments = oldMessage.attachments
+        return oldMessage.attachments
             .map((oldAttachment): MLAttachment =>
                 newMessage.attachments.find(a => a.id === oldAttachment.id)
                 ?? { ...oldAttachment, deleted: true }
             )
-            .concat(newMessage.attachments.filter(a => oldMessage.attachments.every(o => o.id !== a.id)));
-        return attachments;
+            .concat(newMessage.attachments.filter(a => !oldMessage.attachments.some(o => o.id === a.id)));
     },
 
     handleDelete(cache: any, data: { ids: string[], id: string; mlDeleted?: boolean; }, isBulk: boolean) {

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -216,7 +216,7 @@ export default definePlugin({
     name: "MessageLogger",
     description: "Temporarily logs deleted and edited messages.",
     tags: ["Chat", "Utility"],
-    authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN, Devs.Nickyux, Devs.Kyuuhachi, Devs.sadan, Devs.yuna0x0],
+    authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN, Devs.Nickyux, Devs.Kyuuhachi, Devs.sadan],
     dependencies: ["MessageUpdaterAPI"],
     settings,
     contextMenus: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -649,6 +649,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Lunascape: {
         name: "Lunascape",
         id: 383365021415243776n
+    },
+    yuna0x0: {
+        name: "yuna0x0",
+        id: 213656926414831616n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
fix new attachments added to the same message are dropped without pushing back into the `attachments`

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
