### PR TITLE
ReviewDB: Add GIF and bot popout support

### DIFF
--- a/src/main/csp/index.ts
+++ b/src/main/csp/index.ts
@@ -72,6 +72,9 @@ export const CspPolicies: PolicyMap = {
     // Tenor, used by TenorSearch plugin and some themes
     "*.tenor.com": ImageAndMediaSrc,
     "*.tenor.co": ImageAndMediaSrc,
+    "*.giphy.com": ImageAndMediaSrc,
+    "*.klipy.com": ImageAndMediaSrc,
+    "*.klipy.co": ImageAndMediaSrc,
 };
 
 const findHeader = (headers: PolicyMap, headerName: Lowercase<string>) => {

--- a/src/plugins/reviewDB/components/ReviewComponent.tsx
+++ b/src/plugins/reviewDB/components/ReviewComponent.tsx
@@ -37,6 +37,33 @@ const ButtonClasses = findCssClassesLazy("button", "wrapper", "selected");
 const BotTagClasses = findCssClassesLazy("botTagVerified", "botTagRegular", "botText", "px", "rem");
 
 const dateFormat = new Intl.DateTimeFormat();
+const gifLinkRegex = /https:\/\/[^\s<]+/g;
+
+function isGifProvider(hostname: string) {
+    return /(?:^|\.)(?:giphy\.com|klipy\.com|klipy\.co|tenor\.com|tenor\.co)$/.test(hostname);
+}
+
+function getGifLinks(comment: string) {
+    return [...new Set(comment.match(gifLinkRegex)?.filter(link => {
+        try {
+            return isGifProvider(new URL(link).hostname);
+        } catch {
+            return false;
+        }
+    }) ?? [])];
+}
+
+function ReviewGif({ link }: { link: string; }) {
+    try {
+        const url = new URL(link);
+        if (url.protocol === "https:" && isGifProvider(url.hostname) && /(?:\.(?:gif|webp|mp4)|\/mp4)$/i.test(url.pathname)) {
+            return /(?:\.mp4|\/mp4)$/i.test(url.pathname)
+                ? <video className={cl("review-gif")} src={url.href} aria-label="GIF" autoPlay loop muted playsInline />
+                : <img className={cl("review-gif")} src={url.href} alt="GIF" />;
+        }
+    } catch { }
+    return null;
+}
 
 export default function ReviewComponent({ review, refetch, profileId }: { review: Review; refetch(): void; profileId: string; }) {
     const [showAll, setShowAll] = useState(false);
@@ -237,6 +264,7 @@ export default function ReviewComponent({ review, refetch, profileId }: { review
                     )
                     : Parser.parseGuildEventDescription(review.comment)}
             </div>
+            {getGifLinks(review.comment).map(link => <ReviewGif key={link} link={link} />)}
 
             {review.id !== 0 && (
                 <div className={classes(ContainerClasses.container, ContainerClasses.isHeader, MessageClasses.buttons)} style={{

--- a/src/plugins/reviewDB/components/ReviewsView.tsx
+++ b/src/plugins/reviewDB/components/ReviewsView.tsx
@@ -129,8 +129,11 @@ export function ReviewsInputComponent(
 ) {
     const { token } = Auth;
     const editorRef = useRef<any>(null);
-    const inputType = ChatInputTypes.USER_PROFILE_REPLY;
-    inputType.disableAutoFocus = true;
+    const inputType = {
+        ...ChatInputTypes.USER_PROFILE_REPLY,
+        disableAutoFocus: true,
+        gifs: { button: true, allowSending: true },
+    };
 
     const channel = createChannelRecordFromServer({ id: "0", type: 1 });
 
@@ -159,9 +162,12 @@ export function ReviewsInputComponent(
                     textValue=""
                     onSubmit={
                         async res => {
+                            const gifUrl = res.isGif
+                                ? res.gifMetadata?.gif_src?.replace(/^https:\/\/images-ext-\d+\.discordapp\.net\/external\/[^/]+\/https\//, "https://")
+                                : undefined;
                             const response = await addReview({
                                 userid: discordId,
-                                comment: res.value,
+                                comment: gifUrl?.startsWith("//") ? `https:${gifUrl}` : gifUrl ?? res.value,
                             });
 
                             if (response) {

--- a/src/plugins/reviewDB/index.tsx
+++ b/src/plugins/reviewDB/index.tsx
@@ -101,9 +101,10 @@ export default definePlugin({
         },
         {
             // User profile popout.
+            // Same find as ShowConnections
             find: '"UserProfilePopout");',
             replacement: {
-                match: /\(0,\i\.jsx\)\(\i\.\i,\{userId:(\i)\.id,userBio:\i\?\.bio,hidePersonalInformation:\i,onClose:\i\}\),/,
+                match: /user:(\i),widgets:.{0,100}?\}\),/,
                 replace: "$&$self.renderProfileComponent({user:$1}),"
             }
         },

--- a/src/plugins/reviewDB/index.tsx
+++ b/src/plugins/reviewDB/index.tsx
@@ -92,12 +92,27 @@ export default definePlugin({
             }
         },
         {
-            // User popout
-            // Same find as ShowConnections
+            // Bot profile popout.
+            find: /\(0,\i\.jsx\)\(\i\.\i,\{userId:\i\.id,userBio:\i\?\.bio,hidePersonalInformation:\i,onClose:\i\}\),.{0,500}popularApplicationCommandIds/,
+            replacement: {
+                match: /\(0,\i\.jsx\)\(\i\.\i,\{userId:(\i)\.id,userBio:\i\?\.bio,hidePersonalInformation:\i,onClose:\i\}\),/,
+                replace: "$&$self.renderProfileComponent({user:$1}),"
+            }
+        },
+        {
+            // User profile popout.
             find: '"UserProfilePopout");',
             replacement: {
-                match: /user:(\i),widgets:.{0,100}?\}\),/,
+                match: /\(0,\i\.jsx\)\(\i\.\i,\{userId:(\i)\.id,userBio:\i\?\.bio,hidePersonalInformation:\i,onClose:\i\}\),/,
                 replace: "$&$self.renderProfileComponent({user:$1}),"
+            }
+        },
+        {
+            // Preserve direct provider media for ReviewDB instead of the share page URL.
+            find: 'source_object:"GIF Picker",gif_url:',
+            replacement: {
+                match: /gif_url:(\i)\.url,gif_id:\1\.id/,
+                replace: "gif_url:$1.url,gif_src:$1.gifSrc??$1.src,gif_id:$1.id"
             }
         }
     ],

--- a/src/plugins/reviewDB/style.css
+++ b/src/plugins/reviewDB/style.css
@@ -63,6 +63,14 @@
     font-size: 15px;
 }
 
+.vc-rdb-review-gif {
+    display: block;
+    max-width: min(100%, 400px);
+    max-height: 300px;
+    margin-bottom: 8px;
+    border-radius: 4px;
+}
+
 .vc-rdb-blocked-badge {
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary

- enable Discord's GIF picker in the ReviewDB input and preserve direct provider media for favorites
- render direct Tenor, Giphy, and Klipy GIF/WebP/MP4 media in reviews
- show ReviewDB in compact bot profile popouts while retaining user popout support
- allow the required provider domains through desktop CSP

## Testing

- `pnpm testTsc`
- `pnpm exec eslint src/plugins/reviewDB`
- `pnpm exec stylelint src/plugins/reviewDB/style.css`
- `pnpm buildStandalone`
- `pnpm generatePluginJson`