### PR TITLE
Add support for local ListenBrainz compatible servers

### DIFF
--- a/src/plugins/musicRichPresence/index.tsx
+++ b/src/plugins/musicRichPresence/index.tsx
@@ -29,7 +29,7 @@ import { ActivityFlags, ActivityStatusDisplayType, ActivityType } from "@vencord
 import { ApplicationAssetUtils, AuthenticationStore, FluxDispatcher, PresenceStore } from "@webpack/common";
 
 import { LastFMScrobbler } from "./lastfm";
-import { ListenBrainzScrobbler } from "./listenbrainz";
+import { ListenBrainzScrobbler, makeListenBrainzScrobbler } from "./listenbrainz";
 
 export interface TrackData {
     name: string;
@@ -90,8 +90,17 @@ const settings = definePluginSettings({
             {
                 "label": "ListenBrainz",
                 "value": "listenbrainz"
+            },
+            {
+                "label": "Local (ListenBrainz-compatible)",
+                "value": "local"
             }
         ] as const
+    },
+    serverUrl: {
+        displayName: "Server URL",
+        description: "URL of your local ListenBrainz-compatible server",
+        type: OptionType.STRING,
     },
     apiKey: {
         displayName: "API Key",
@@ -212,6 +221,10 @@ const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         default: true,
     }
+}, {
+    serverUrl: {
+        hidden() { return this.store.scrobblerBackend !== "local"; }
+    }
 });
 
 migratePluginSettings("MusicRichPresence", "LastFMRichPresence");
@@ -261,6 +274,9 @@ export default definePlugin({
         if (!settings.store.username)
             return null;
 
+        if (settings.store.scrobblerBackend === "local" && !settings.store.serverUrl)
+            return null;
+
         if (settings.store.hideWithActivity) {
             if (PresenceStore.getActivities(AuthenticationStore.getId()).some(a => a.application_id !== DISCORD_APP_ID && a.type !== ActivityType.CUSTOM_STATUS)) {
                 return null;
@@ -274,7 +290,16 @@ export default definePlugin({
             }
         }
 
-        const scrobbler = settings.store.scrobblerBackend === "lastfm" ? LastFMScrobbler : ListenBrainzScrobbler;
+        const scrobbler = (() => {
+            switch (settings.store.scrobblerBackend) {
+                case "lastfm": return LastFMScrobbler;
+                case "local": {
+                    const serverUrl = settings.store.serverUrl!.replace(/\/+$/, "");
+                    return makeListenBrainzScrobbler("Local", "listenbrainz", serverUrl, serverUrl);
+                }
+                default: return ListenBrainzScrobbler;
+            }
+        })();
 
         const trackData = await scrobbler.fetchTrackData(settings.store.username, settings.store.apiKey || LASTFM_API_KEY);
         if (!trackData) return null;

--- a/src/plugins/musicRichPresence/listenbrainz.ts
+++ b/src/plugins/musicRichPresence/listenbrainz.ts
@@ -11,7 +11,8 @@ import { ScrobblerBackend, TrackData } from ".";
 
 const logger = new Logger("AudioScrobblerRichPresence/ListenBrainz");
 
-const url = (path: string) => `https://listenbrainz.org${path}`;
+export const LISTENBRAINZ_URL = "https://listenbrainz.org";
+export const LISTENBRAINZ_API_URL = "https://api.listenbrainz.org";
 
 async function fetchCoverArt(releaseGroupMBID: string) {
     const res = await fetch(`https://coverartarchive.org/release-group/${releaseGroupMBID}`);
@@ -19,7 +20,7 @@ async function fetchCoverArt(releaseGroupMBID: string) {
     return res.json().then(json => json.images[0].thumbnails.large);
 }
 
-async function getUrls(additionalInfo: Record<string, string> | undefined, trackName: string, artistName: string, releaseName: string): Promise<Partial<TrackData>> {
+async function getUrls(url: (path: string) => string, additionalInfo: Record<string, string> | undefined, trackName: string, artistName: string, releaseName: string): Promise<Partial<TrackData>> {
     // Well tagged music will have MBIDs which we can use directly. These are optional but highly recommended in ListenBrainz scrobbles.
     // If your music doesn't have these, it's highly recommended to use https://picard.musicbrainz.org/ to automatically add them
     if (additionalInfo?.recording_mbid) {
@@ -68,38 +69,44 @@ async function getUrls(additionalInfo: Record<string, string> | undefined, track
     };
 }
 
-export const ListenBrainzScrobbler: ScrobblerBackend = {
-    name: "ListenBrainz",
-    id: "listenbrainz",
+export function makeListenBrainzScrobbler(name: string, id: string, webUrl: string, apiUrl: string): ScrobblerBackend {
+    const url = (path: string) => `${webUrl}${path}`;
 
-    async fetchTrackData(username: string, _apiKey?: string): Promise<TrackData | null> {
-        try {
-            const res = await fetch(`https://api.listenbrainz.org/1/user/${username}/playing-now`);
-            if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return {
+        name,
+        id,
 
-            const data = await res.json().then(json => json.payload?.listens[0]);
-            if (!data?.playing_now || !data?.track_metadata)
+        async fetchTrackData(username: string, _apiKey?: string): Promise<TrackData | null> {
+            try {
+                const res = await fetch(`${apiUrl}/1/user/${username}/playing-now`);
+                if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+
+                const data = await res.json().then(json => json.payload?.listens[0]);
+                if (!data?.playing_now || !data?.track_metadata)
+                    return null;
+
+                const { track_name, artist_name, release_name, additional_info } = data.track_metadata;
+
+                const trackData = {
+                    name: track_name || "Unknown",
+                    artist: artist_name,
+                    album: release_name || "Unknown",
+                    serviceName: additional_info?.music_service_name || additional_info?.submission_client,
+                    ...await getUrls(url, additional_info, track_name, artist_name, release_name)
+                } as TrackData;
+
+                return trackData;
+            } catch (e) {
+                logger.error(`Failed to query ${name} API`, e);
+                // will clear the rich presence if API fails
                 return null;
+            }
+        },
 
-            const { track_name, artist_name, release_name, additional_info } = data.track_metadata;
-
-            const trackData = {
-                name: track_name || "Unknown",
-                artist: artist_name,
-                album: release_name || "Unknown",
-                serviceName: additional_info?.music_service_name || additional_info?.submission_client,
-                ...await getUrls(additional_info, track_name, artist_name, release_name)
-            } as TrackData;
-
-            return trackData;
-        } catch (e) {
-            logger.error("Failed to query ListenBrainz API", e);
-            // will clear the rich presence if API fails
-            return null;
+        getUserURL(username: string): string {
+            return url(`/user/${username}`);
         }
-    },
+    };
+}
 
-    getUserURL(username: string): string {
-        return url(`/user/${username}`);
-    }
-};
+export const ListenBrainzScrobbler = makeListenBrainzScrobbler("ListenBrainz", "listenbrainz", LISTENBRAINZ_URL, LISTENBRAINZ_API_URL);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -649,6 +649,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Lunascape: {
         name: "Lunascape",
         id: 383365021415243776n
+    },
+     jax: {
+        name: "jax",
+        id: 1493703027801194598n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
## Describe your Changes

Adds support for using a local ListenBrainz compatible server with MusicRichPresence.
Solves #4409

The ListenBrainz scrobbler previously had the API and website URLs hardcoded, making it impossible to use with self hosted ListenBrainz compatible services. The scrobbler creation logic was moved into a reusable function so both the default ListenBrainz backend and a new local backend can share the same behavior.

Added:
- A new "Local" option in the scrobbler backend selector
- A configurable server URL setting shown only when the local backend is selected
- Support for using the configured server for both API requests and profile URLs

Existing ListenBrainz and Last.fm behavior remains unchanged.
> Hopefully this change is big enough lol
## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent