### PR TITLE
Add CopyProfileColors plugin

### DIFF
--- a/src/plugins/copyProfileColors/index.tsx
+++ b/src/plugins/copyProfileColors/index.tsx
@@ -38,7 +38,7 @@ const userContextPatch: NavContextMenuPatchCallback = (children, { user }: { use
 
 export default definePlugin({
     name: "CopyProfileColors",
-    description: "Adds a right click button to the user's profile to copy their profile colors ",
+    description: "Adds a right click button to the user's profile to copy their profile colors.",
     authors: [Devs.alexagian],
     tags: ["Utility", "Appearance"],
 

--- a/src/plugins/copyProfileColors/index.tsx
+++ b/src/plugins/copyProfileColors/index.tsx
@@ -1,0 +1,50 @@
+
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { Devs } from "@utils/constants";
+import { copyWithToast, fetchUserProfile } from "@utils/discord";
+import definePlugin from "@utils/types";
+import { User } from "@vencord/discord-types";
+import { Menu, showToast, Toasts } from "@webpack/common";
+
+function toHex(color: number) {
+    return `#${color.toString(16).padStart(6, "0")}`;
+}
+
+async function copyProfileColors(user: User) {
+    const profile = await fetchUserProfile(user.id);
+    const colors = profile?.themeColors;
+
+    if (!colors) {
+        showToast("This user doesn't have any profile theme colors", Toasts.Type.FAILURE);
+        return;
+    }
+
+    const [primary, accent] = colors;
+    copyWithToast(`Primary: ${toHex(primary)}, Accent: ${toHex(accent)}`, "Profile colors copied");
+}
+
+const userContextPatch: NavContextMenuPatchCallback = (children, { user }: { user?: User; }) => {
+    if (!user) return;
+
+    children.push(
+        <Menu.MenuItem
+            id="copy-profile-colors"
+            key="copy-profile-colors"
+            label="Copy Profile Colors"
+            action={() => copyProfileColors(user)}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "CopyProfileColors",
+    description: "Adds a right click button to the user's profile to copy their profile colors ",
+    authors: [Devs.alexagian],
+    tags: ["Utility", "Appearance"],
+
+    contextMenus: {
+        "user-context": userContextPatch,
+        "user-profile-actions": userContextPatch,
+        "user-profile-overflow-menu": userContextPatch
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -649,6 +649,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Lunascape: {
         name: "Lunascape",
         id: 383365021415243776n
+    },
+    alexagian: {
+        name: "alexagian",
+        id: 1043876811664273549n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
## Describe your Changes
This plugin allows you to copy the profile colors of a user. You just right click the user and press the button "Copy Profile Colors" or in their profile press the 3 dots and press the same button.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
