### PR TITLE
Add AutoWatchScreenshares Plugin

### DIFF
--- a/src/plugins/autoWatchScreenshares/README.md
+++ b/src/plugins/autoWatchScreenshares/README.md
@@ -1,0 +1,4 @@
+# AutoWatchScreenshares
+
+Automatically starts watching screenshares of users when you join a voice channel, or a screenshare begins.
+By default the plugin will only start playback of users who you are friends with but it can be configured to apply to anyone.

--- a/src/plugins/autoWatchScreenshares/index.ts
+++ b/src/plugins/autoWatchScreenshares/index.ts
@@ -47,10 +47,8 @@ export default definePlugin({
             const currentUser = UserStore.getCurrentUser();
             const currentVoice = VoiceStateStore.getVoiceStateForUser(currentUser.id);
 
-            console.log(currentVoice);
             for (const state of voiceStates) {
                 if (!state.channelId || state.channelId !== currentVoice?.channelId) continue;
-                if (state.userId === currentUser.id) continue;
 
                 const activeStreams = ApplicationStreamingStore.getAllActiveStreamsForChannel(state.channelId);
                 const streams = ApplicationStreamingStore.getAllApplicationStreamsForChannel(state.channelId);

--- a/src/plugins/autoWatchScreenshares/index.ts
+++ b/src/plugins/autoWatchScreenshares/index.ts
@@ -36,6 +36,41 @@ interface VoiceStateChangeEvent {
     sessionId: string;
 }
 
+const ignoredStreams = new Set<string>();
+
+function getStreamKey(stream: any, guildId: string, channelId: string) {
+    return stream.streamType === "guild"
+        ? `guild:${guildId}:${channelId}:${stream.ownerId}`
+        : `call:${channelId}:${stream.ownerId}`;
+}
+
+function watchStreams(channelId: string, guildId: string) {
+    const activeStreams = ApplicationStreamingStore.getAllActiveStreamsForChannel(channelId);
+    const streams = ApplicationStreamingStore.getAllApplicationStreamsForChannel(channelId);
+
+    const currentKeys = new Set<string>();
+    for (const stream of streams) {
+        const streamKey = getStreamKey(stream, guildId, channelId);
+        currentKeys.add(streamKey);
+
+        if (activeStreams.some(s => s.ownerId === stream.ownerId)) continue;
+        if (ignoredStreams.has(streamKey)) continue;
+        if (settings.store.friendsOnly && !RelationshipStore.isFriend(stream.ownerId)) continue;
+
+        FluxDispatcher.dispatch({
+            type: "STREAM_WATCH",
+            streamKey,
+            allowMultiple: true
+        });
+    }
+
+    for (const key of ignoredStreams) {
+        if (!currentKeys.has(key)) {
+            ignoredStreams.delete(key);
+        }
+    }
+}
+
 export default definePlugin({
     name: "AutoWatchScreenshares",
     description: "Automatically watches screenshares when joining a voice channel or a screenshare starts",
@@ -47,33 +82,17 @@ export default definePlugin({
             const currentUser = UserStore.getCurrentUser();
             const currentVoice = VoiceStateStore.getVoiceStateForUser(currentUser.id);
 
+            if (!currentVoice?.channelId) return;
             for (const state of voiceStates) {
-                if (!state.channelId || state.channelId !== currentVoice?.channelId) continue;
+                if (state.channelId !== currentVoice.channelId) continue;
 
-                const activeStreams = ApplicationStreamingStore.getAllActiveStreamsForChannel(state.channelId);
-                const streams = ApplicationStreamingStore.getAllApplicationStreamsForChannel(state.channelId);
+                watchStreams(state.channelId, state.guildId!);
+            }
+        },
 
-                let watchedCount = 0;
-                for (const stream of streams) {
-                    // check if tthe stream is already being watched
-                    if (activeStreams.some(s => s.ownerId === stream.ownerId)) {
-                        watchedCount++;
-                        continue;
-                    }
-
-                    if (watchedCount >= settings.store.maxStreams) break;
-                    if (settings.store.friendsOnly && !RelationshipStore.isFriend(stream.ownerId)) continue;
-
-                    FluxDispatcher.dispatch({
-                        type: "STREAM_WATCH",
-                        streamKey: stream.streamType === "guild" ?
-                            `guild:${state.guildId}:${state.channelId}:${stream.ownerId}` :
-                            `call:${state.channelId}:${stream.ownerId}`,
-                        allowMultiple: true
-                    });
-
-                    watchedCount++;
-                }
+        STREAM_DELETE({ streamKey, reason }: { streamKey: string; reason: string; }) {
+            if (reason === "user_requested") {
+                ignoredStreams.add(streamKey);
             }
         }
     }

--- a/src/plugins/autoWatchScreenshares/index.ts
+++ b/src/plugins/autoWatchScreenshares/index.ts
@@ -49,12 +49,19 @@ function watchStreams(channelId: string, guildId: string) {
     const streams = ApplicationStreamingStore.getAllApplicationStreamsForChannel(channelId);
 
     const currentKeys = new Set<string>();
+    let watchedCount = 0;
+
     for (const stream of streams) {
         const streamKey = getStreamKey(stream, guildId, channelId);
         currentKeys.add(streamKey);
 
-        if (activeStreams.some(s => s.ownerId === stream.ownerId)) continue;
+        if (activeStreams.some(s => s.ownerId === stream.ownerId)) {
+            watchedCount++;
+            continue;
+        }
+
         if (ignoredStreams.has(streamKey)) continue;
+        if (watchedCount >= settings.store.maxStreams) break;
         if (settings.store.friendsOnly && !RelationshipStore.isFriend(stream.ownerId)) continue;
 
         FluxDispatcher.dispatch({
@@ -62,6 +69,8 @@ function watchStreams(channelId: string, guildId: string) {
             streamKey,
             allowMultiple: true
         });
+
+        watchedCount++;
     }
 
     for (const key of ignoredStreams) {

--- a/src/plugins/autoWatchScreenshares/index.ts
+++ b/src/plugins/autoWatchScreenshares/index.ts
@@ -1,0 +1,77 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { makeRange, OptionType } from "@utils/types";
+import { ApplicationStreamingStore, FluxDispatcher, RelationshipStore } from "@webpack/common";
+
+const settings = definePluginSettings({
+    friendsOnly: {
+        type: OptionType.BOOLEAN,
+        description: "Only start watching the screen of people you are friends with",
+        default: true
+    },
+    maxStreams: {
+        type: OptionType.SLIDER,
+        description: "The maximum amount of streams to watch",
+        markers: makeRange(1, 10, 1),
+        stickToMarkers: true,
+        default: 5
+    }
+});
+
+interface VoiceStateChangeEvent {
+    userId: string;
+    channelId?: string;
+    guildId?: string;
+    oldChannelId?: string;
+    deaf: boolean;
+    mute: boolean;
+    selfDeaf: boolean;
+    selfMute: boolean;
+    sessionId: string;
+}
+
+export default definePlugin({
+    name: "AutoWatchScreenshares",
+    description: "Automatically watches screenshares when joining a voice channel or a screenshare starts",
+    authors: [Devs.theo],
+    settings,
+
+    flux: {
+        VOICE_STATE_UPDATES({ voiceStates }: { voiceStates: VoiceStateChangeEvent[]; }) {
+            for (const state of voiceStates) {
+                if (!state.channelId) continue;
+
+                const activeStreams = ApplicationStreamingStore.getAllActiveStreamsForChannel(state.channelId);
+                const streams = ApplicationStreamingStore.getAllApplicationStreamsForChannel(state.channelId);
+
+                let watchedCount = 0;
+                for (const stream of streams) {
+                    // check if tthe stream is already being watched
+                    if (activeStreams.some(s => s.ownerId === stream.ownerId)) {
+                        watchedCount++;
+                        continue;
+                    }
+
+                    if (watchedCount >= settings.store.maxStreams) break;
+                    if (settings.store.friendsOnly && !RelationshipStore.isFriend(stream.ownerId)) continue;
+
+                    FluxDispatcher.dispatch({
+                        type: "STREAM_WATCH",
+                        streamKey: stream.streamType === "guild" ?
+                            `guild:${state.guildId}:${state.channelId}:${stream.ownerId}` :
+                            `call:${state.channelId}:${stream.ownerId}`,
+                        allowMultiple: true
+                    });
+
+                    watchedCount++;
+                }
+            }
+        }
+    }
+});

--- a/src/plugins/autoWatchScreenshares/index.ts
+++ b/src/plugins/autoWatchScreenshares/index.ts
@@ -7,7 +7,7 @@
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { makeRange, OptionType } from "@utils/types";
-import { ApplicationStreamingStore, FluxDispatcher, RelationshipStore } from "@webpack/common";
+import { ApplicationStreamingStore, FluxDispatcher, RelationshipStore, UserStore, VoiceStateStore } from "@webpack/common";
 
 const settings = definePluginSettings({
     friendsOnly: {
@@ -44,8 +44,13 @@ export default definePlugin({
 
     flux: {
         VOICE_STATE_UPDATES({ voiceStates }: { voiceStates: VoiceStateChangeEvent[]; }) {
+            const currentUser = UserStore.getCurrentUser();
+            const currentVoice = VoiceStateStore.getVoiceStateForUser(currentUser.id);
+
+            console.log(currentVoice);
             for (const state of voiceStates) {
-                if (!state.channelId) continue;
+                if (!state.channelId || state.channelId !== currentVoice?.channelId) continue;
+                if (state.userId === currentUser.id) continue;
 
                 const activeStreams = ApplicationStreamingStore.getAllActiveStreamsForChannel(state.channelId);
                 const streams = ApplicationStreamingStore.getAllApplicationStreamsForChannel(state.channelId);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -649,6 +649,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Lunascape: {
         name: "Lunascape",
         id: 383365021415243776n
+    },
+    theo: {
+        name: "theo",
+        id: 1081551899397992509n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

Automatically starts watching screenshares when you join a voice channel, or a screenshare begins.
By default the plugin will only start playback of users who you are friends with but it can be configured to apply to anyone.

I made this plugin for myself because in my friend group basically everyone is screensharing and I was tired of manually clicking on each screenshare to start watching it.

I decided I may as well make a PR and see if it could be added, it is fine if not.

https://github.com/user-attachments/assets/d472f3cb-6aa8-436b-8a54-db9352bdac54

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
