### PR TITLE
MusicRRPC: add caching & custom listenbrainz instance support

### DIFF
--- a/src/plugins/musicRichPresence/index.tsx
+++ b/src/plugins/musicRichPresence/index.tsx
@@ -29,7 +29,7 @@ import { ActivityFlags, ActivityStatusDisplayType, ActivityType } from "@vencord
 import { ApplicationAssetUtils, AuthenticationStore, FluxDispatcher, PresenceStore } from "@webpack/common";
 
 import { LastFMScrobbler } from "./lastfm";
-import { ListenBrainzScrobbler } from "./listenbrainz";
+import { invalidateListenBrainzCache, ListenBrainzScrobbler } from "./listenbrainz";
 
 export interface TrackData {
     name: string;
@@ -98,12 +98,14 @@ export const settings = definePluginSettings({
     instanceBaseURL: {
         description: "The base url of your ListenBrainz instance.",
         type: OptionType.STRING,
-        placeholder: "https://example.org"
+        placeholder: "https://example.org",
+        onChange: invalidateListenBrainzCache
     },
     instanceAPIBaseUrl: {
         description: "The base url of your ListenBrainz API.",
         type: OptionType.STRING,
-        placeholder: "https://api.example.org"
+        placeholder: "https://api.example.org",
+        onChange: invalidateListenBrainzCache
     },
     apiKey: {
         displayName: "API Key",

--- a/src/plugins/musicRichPresence/index.tsx
+++ b/src/plugins/musicRichPresence/index.tsx
@@ -46,7 +46,7 @@ export interface ScrobblerBackend {
     name: string,
     id: string,
 
-    fetchTrackData(username: string, apiKey?: string): Promise<TrackData | null>;
+    fetchTrackData(): Promise<TrackData | null>;
     getUserURL(username: string): string;
 }
 
@@ -60,8 +60,6 @@ const enum NameFormat {
     ServiceName = "service-name"
 }
 
-// Last.fm API keys are essentially public information and have no access to your account, so including one here is fine.
-const LASTFM_API_KEY = "790c37d90400163a5a5fe00d6ca32ef0";
 const DISCORD_APP_ID = "1108588077900898414";
 const LASTFM_PLACEHOLDER_IMAGE_HASH = "2a96cbd8b46e442fc41c2b86b821562f";
 
@@ -77,7 +75,7 @@ function setActivity(activity: Activity | null) {
     });
 }
 
-const settings = definePluginSettings({
+export const settings = definePluginSettings({
     scrobblerBackend: {
         description: "The scrobbler backend to use.",
         type: OptionType.SELECT,
@@ -90,12 +88,26 @@ const settings = definePluginSettings({
             {
                 "label": "ListenBrainz",
                 "value": "listenbrainz"
+            },
+            {
+                "label": "ListenBrainz Compatible (self-hosted)",
+                "value": "listenbrainz-compatible"
             }
         ] as const
     },
+    instanceBaseURL: {
+        description: "The base url of your ListenBrainz instance.",
+        type: OptionType.STRING,
+        placeholder: "https://example.org"
+    },
+    instanceAPIBaseUrl: {
+        description: "The base url of your ListenBrainz API.",
+        type: OptionType.STRING,
+        placeholder: "https://api.example.org"
+    },
     apiKey: {
         displayName: "API Key",
-        description: "Custom Last.fm API key. Not required but highly recommended to avoid rate limiting with our shared key",
+        description: "Last.fm API key. Not required but highly recommended to avoid rate limiting with our shared key",
         type: OptionType.STRING,
     },
     username: {
@@ -212,6 +224,10 @@ const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         default: true,
     }
+}, {
+    apiKey: { hidden() { return this.store.scrobblerBackend !== "lastfm"; } },
+    instanceBaseURL: { hidden() { return this.store.scrobblerBackend !== "listenbrainz-compatible"; } },
+    instanceAPIBaseUrl: { hidden() { return this.store.scrobblerBackend !== "listenbrainz-compatible"; } },
 });
 
 migratePluginSettings("MusicRichPresence", "LastFMRichPresence");
@@ -226,6 +242,9 @@ export default definePlugin({
     settings,
 
     settingsAboutComponent() {
+        if (settings.store.scrobblerBackend !== "lastfm")
+            return null;
+
         return (
             <Card>
                 <Heading tag="h2">Last.FM</Heading>
@@ -246,6 +265,11 @@ export default definePlugin({
     },
 
     async updatePresence() {
+        const { username, scrobblerBackend, instanceAPIBaseUrl, instanceBaseURL } = settings.store;
+
+        if (!username) return;
+        if (scrobblerBackend === "listenbrainz-compatible" && (!instanceAPIBaseUrl || !instanceBaseURL)) return;
+
         setActivity(await this.getActivity());
     },
 
@@ -258,8 +282,6 @@ export default definePlugin({
     },
 
     async getActivity(): Promise<Activity | null> {
-        if (!settings.store.username)
-            return null;
 
         if (settings.store.hideWithActivity) {
             if (PresenceStore.getActivities(AuthenticationStore.getId()).some(a => a.application_id !== DISCORD_APP_ID && a.type !== ActivityType.CUSTOM_STATUS)) {
@@ -276,7 +298,7 @@ export default definePlugin({
 
         const scrobbler = settings.store.scrobblerBackend === "lastfm" ? LastFMScrobbler : ListenBrainzScrobbler;
 
-        const trackData = await scrobbler.fetchTrackData(settings.store.username, settings.store.apiKey || LASTFM_API_KEY);
+        const trackData = await scrobbler.fetchTrackData();
         if (!trackData) return null;
 
         const largeImage = this.getLargeImage(trackData);

--- a/src/plugins/musicRichPresence/lastfm.ts
+++ b/src/plugins/musicRichPresence/lastfm.ts
@@ -6,7 +6,10 @@
 
 import { Logger } from "@utils/Logger";
 
-import { ScrobblerBackend, TrackData } from ".";
+import { ScrobblerBackend, settings, TrackData } from ".";
+
+// Last.fm API keys are essentially public information and have no access to your account, so including one here is fine.
+const LASTFM_API_KEY = "790c37d90400163a5a5fe00d6ca32ef0";
 
 const logger = new Logger("MusicRichPresence/LastFM");
 
@@ -16,12 +19,12 @@ export const LastFMScrobbler: ScrobblerBackend = {
     name: "Last.FM",
     id: "lastfm",
 
-    async fetchTrackData(username: string, apiKey: string): Promise<TrackData | null> {
+    async fetchTrackData(): Promise<TrackData | null> {
         try {
             const params = new URLSearchParams({
                 method: "user.getrecenttracks",
-                api_key: apiKey,
-                user: username,
+                api_key: settings.store.apiKey || LASTFM_API_KEY,
+                user: settings.store.username!,
                 limit: "1",
                 format: "json"
             });

--- a/src/plugins/musicRichPresence/listenbrainz.ts
+++ b/src/plugins/musicRichPresence/listenbrainz.ts
@@ -6,17 +6,32 @@
 
 import { VENCORD_USER_AGENT } from "@shared/vencordUserAgent";
 import { Logger } from "@utils/Logger";
+import { TTLMap } from "@utils/TTLMap";
 
-import { ScrobblerBackend, TrackData } from ".";
+import { ScrobblerBackend, settings, TrackData } from ".";
 
 const logger = new Logger("AudioScrobblerRichPresence/ListenBrainz");
 
-const url = (path: string) => `https://listenbrainz.org${path}`;
+// 15 minutes
+const coverArtCache = new TTLMap<string, string>(15 * 60 * 1000);
+const metadataCache = new TTLMap<string, Partial<TrackData> | null>(15 * 60 * 1000);
+
+const isCustomInstance = () => settings.store.scrobblerBackend === "listenbrainz-compatible";
+const url = (path: string) => `${isCustomInstance() ? settings.store.instanceBaseURL : "https://listenbrainz.org"}${path}`;
+const apiUrl = (path: string) => `${isCustomInstance() ? settings.store.instanceAPIBaseUrl : "https://api.listenbrainz.org"}${path}`;
 
 async function fetchCoverArt(releaseGroupMBID: string) {
+    if (coverArtCache.has(releaseGroupMBID)) {
+        return coverArtCache.get(releaseGroupMBID);
+    }
+
     const res = await fetch(`https://coverartarchive.org/release-group/${releaseGroupMBID}`);
     if (!res.ok) return null;
-    return res.json().then(json => json.images[0].thumbnails.large);
+
+    const url = await res.json().then(json => json.images[0].thumbnails.large);
+    coverArtCache.set(releaseGroupMBID, url);
+
+    return url;
 }
 
 async function getUrls(additionalInfo: Record<string, string> | undefined, trackName: string, artistName: string, releaseName: string): Promise<Partial<TrackData>> {
@@ -42,6 +57,10 @@ async function getUrls(additionalInfo: Record<string, string> | undefined, track
     // this needs to be encoded separately—URLSearchParams encodes spaces as "+"
     const query = encodeURIComponent(`artist:"${artistName}" AND recording:"${trackName}" AND album:${releaseName}`);
 
+    if (metadataCache.has(query)) {
+        return metadataCache.get(query) ?? {};
+    }
+
     const params = new URLSearchParams({
         fmt: "json",
         limit: "1"
@@ -54,27 +73,31 @@ async function getUrls(additionalInfo: Record<string, string> | undefined, track
         .then(json => json.recordings?.[0]);
 
     if (!metadata) {
+        metadataCache.set(query, null);
         return {};
     }
 
     const artist = metadata["artist-credit"]?.[0]?.artist;
     const release = metadata.releases?.[0];
 
-    return {
+    const data: Partial<TrackData> = {
         imageURL: release?.["release-group"] ? await fetchCoverArt(release["release-group"].id) : undefined,
         trackURL: url(`/track/${metadata.id}/`),
         albumURL: release?.id ? url(`/release/${release.id}/`) : release?.["release-group"]?.id ? url(`/release-group/${release["release-group"].id}/`) : undefined,
         artistURL: artist?.id ? url(`/artist/${artist.id}/`) : undefined,
     };
+    metadataCache.set(query, data);
+
+    return data;
 }
 
 export const ListenBrainzScrobbler: ScrobblerBackend = {
     name: "ListenBrainz",
     id: "listenbrainz",
 
-    async fetchTrackData(username: string, _apiKey?: string): Promise<TrackData | null> {
+    async fetchTrackData(): Promise<TrackData | null> {
         try {
-            const res = await fetch(`https://api.listenbrainz.org/1/user/${username}/playing-now`);
+            const res = await fetch(apiUrl(`/1/user/${settings.store.username}/playing-now`));
             if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
 
             const data = await res.json().then(json => json.payload?.listens[0]);

--- a/src/plugins/musicRichPresence/listenbrainz.ts
+++ b/src/plugins/musicRichPresence/listenbrainz.ts
@@ -61,7 +61,7 @@ async function getUrls(additionalInfo: Record<string, string> | undefined, track
 
     let rawQuery = `artist:"${artistName}" AND recording:"${trackName}"`;
     if (releaseName)
-        rawQuery += ` AND album:${releaseName}`;
+        rawQuery += ` AND album:"${releaseName}"`;
     const query = encodeURIComponent(rawQuery);
 
     if (metadataCache.has(query)) {

--- a/src/plugins/musicRichPresence/listenbrainz.ts
+++ b/src/plugins/musicRichPresence/listenbrainz.ts
@@ -59,8 +59,10 @@ async function getUrls(additionalInfo: Record<string, string> | undefined, track
 
     // If no MBIDs are present, try to search for the track on MusicBrainz
 
-    // this needs to be encoded separately—URLSearchParams encodes spaces as "+"
-    const query = encodeURIComponent(`artist:"${artistName}" AND recording:"${trackName}" AND album:${releaseName}`);
+    let rawQuery = `artist:"${artistName}" AND recording:"${trackName}"`;
+    if (releaseName)
+        rawQuery += ` AND album:${releaseName}`;
+    const query = encodeURIComponent(rawQuery);
 
     if (metadataCache.has(query)) {
         return metadataCache.get(query) ?? {};

--- a/src/plugins/musicRichPresence/listenbrainz.ts
+++ b/src/plugins/musicRichPresence/listenbrainz.ts
@@ -20,6 +20,11 @@ const isCustomInstance = () => settings.store.scrobblerBackend === "listenbrainz
 const url = (path: string) => `${isCustomInstance() ? settings.store.instanceBaseURL : "https://listenbrainz.org"}${path}`;
 const apiUrl = (path: string) => `${isCustomInstance() ? settings.store.instanceAPIBaseUrl : "https://api.listenbrainz.org"}${path}`;
 
+export function invalidateListenBrainzCache() {
+    coverArtCache.clear();
+    metadataCache.clear();
+}
+
 async function fetchCoverArt(releaseGroupMBID: string) {
     if (coverArtCache.has(releaseGroupMBID)) {
         return coverArtCache.get(releaseGroupMBID);

--- a/src/plugins/musicRichPresence/listenbrainz.ts
+++ b/src/plugins/musicRichPresence/listenbrainz.ts
@@ -31,7 +31,7 @@ function fallbackToYoutubeThumbnail(originUrl: string | undefined): string | und
     if (!originUrl) return undefined;
 
     const match = originUrl.match(YoutubeVideoURLRegex);
-    return match ? `https://img.youtube.com/vi/${match[5]}/hqdefault.jpg` : undefined;
+    return match ? `https://i.ytimg.com/vi/${match[5]}/maxresdefault.jpg` : undefined;
 }
 
 async function fetchCoverArt(releaseGroupMBID: string, originUrl?: string): Promise<string | undefined> {

--- a/src/plugins/musicRichPresence/listenbrainz.ts
+++ b/src/plugins/musicRichPresence/listenbrainz.ts
@@ -25,15 +25,27 @@ export function invalidateListenBrainzCache() {
     metadataCache.clear();
 }
 
-async function fetchCoverArt(releaseGroupMBID: string) {
+const YoutubeVideoURLRegex = /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(?:-nocookie)?\.com|youtu.be))(\/(?:[\w-]+\?v=|embed\/|live\/|v\/)?)([\w-]+)(\S+)?$/;
+
+function fallbackToYoutubeThumbnail(originUrl: string | undefined): string | undefined {
+    if (!originUrl) return undefined;
+
+    const match = originUrl.match(YoutubeVideoURLRegex);
+    return match ? `https://img.youtube.com/vi/${match[5]}/hqdefault.jpg` : undefined;
+}
+
+async function fetchCoverArt(releaseGroupMBID: string, originUrl?: string): Promise<string | undefined> {
+    if (!releaseGroupMBID) return fallbackToYoutubeThumbnail(originUrl);
+
     if (coverArtCache.has(releaseGroupMBID)) {
         return coverArtCache.get(releaseGroupMBID);
     }
 
     const res = await fetch(`https://coverartarchive.org/release-group/${releaseGroupMBID}`);
-    if (!res.ok) return null;
+    if (!res.ok) return fallbackToYoutubeThumbnail(originUrl);
 
-    const url = await res.json().then(json => json.images[0].thumbnails.large);
+    const url = await res.json()
+        .then(json => json.images[0].thumbnails.large ?? fallbackToYoutubeThumbnail(originUrl));
     coverArtCache.set(releaseGroupMBID, url);
 
     return url;
@@ -43,10 +55,10 @@ async function getUrls(additionalInfo: Record<string, string> | undefined, track
     // Well tagged music will have MBIDs which we can use directly. These are optional but highly recommended in ListenBrainz scrobbles.
     // If your music doesn't have these, it's highly recommended to use https://picard.musicbrainz.org/ to automatically add them
     if (additionalInfo?.recording_mbid) {
-        const { release_group_mbid, release_mbid, recording_mbid, artist_mbids } = additionalInfo;
+        const { release_group_mbid, release_mbid, recording_mbid, artist_mbids, origin_url } = additionalInfo;
 
         return {
-            imageURL: release_group_mbid ? await fetchCoverArt(release_group_mbid) : undefined,
+            imageURL: await fetchCoverArt(release_group_mbid, origin_url),
             trackURL: recording_mbid ? url(`/track/${recording_mbid}`) : undefined,
             albumURL: release_group_mbid
                 ? url(`/release-group/${release_group_mbid}`)
@@ -81,14 +93,14 @@ async function getUrls(additionalInfo: Record<string, string> | undefined, track
 
     if (!metadata) {
         metadataCache.set(query, null);
-        return {};
+        return additionalInfo?.origin_url ? { imageURL: fallbackToYoutubeThumbnail(additionalInfo.origin_url) } : {};
     }
 
     const artist = metadata["artist-credit"]?.[0]?.artist;
     const release = metadata.releases?.[0];
 
     const data: Partial<TrackData> = {
-        imageURL: release?.["release-group"] ? await fetchCoverArt(release["release-group"].id) : undefined,
+        imageURL: await fetchCoverArt(release?.["release-group"]?.id, additionalInfo?.origin_url),
         trackURL: url(`/track/${metadata.id}/`),
         albumURL: release?.id ? url(`/release/${release.id}/`) : release?.["release-group"]?.id ? url(`/release-group/${release["release-group"].id}/`) : undefined,
         artistURL: artist?.id ? url(`/artist/${artist.id}/`) : undefined,

--- a/src/plugins/musicRichPresence/listenbrainz.ts
+++ b/src/plugins/musicRichPresence/listenbrainz.ts
@@ -92,8 +92,9 @@ async function getUrls(additionalInfo: Record<string, string> | undefined, track
         .then(json => json.recordings?.[0]);
 
     if (!metadata) {
-        metadataCache.set(query, null);
-        return additionalInfo?.origin_url ? { imageURL: fallbackToYoutubeThumbnail(additionalInfo.origin_url) } : {};
+        const data = additionalInfo?.origin_url ? { imageURL: fallbackToYoutubeThumbnail(additionalInfo.origin_url) } : {};
+        metadataCache.set(query, data);
+        return data;
     }
 
     const artist = metadata["artist-credit"]?.[0]?.artist;

--- a/src/utils/TTLMap.ts
+++ b/src/utils/TTLMap.ts
@@ -1,0 +1,43 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * A Map whose entries expire after a given amount of time. When an entry expires, it is automatically removed from the map and an optional callback is called.
+ */
+export class TTLMap<K, V> extends Map<K, V> {
+    private readonly _timers = new Map<K, NodeJS.Timeout>();
+
+    public constructor(public readonly expiryMs: number, private readonly onExpire?: (key: K, value: V) => void) {
+        super();
+    }
+
+    public set(key: K, value: V) {
+        const timeoutId = setTimeout(() => {
+            this.delete(key);
+            this.onExpire?.(key, value);
+        }, this.expiryMs);
+        this._timers.set(key, timeoutId);
+
+        return super.set(key, value);
+    }
+
+    public delete(key: K) {
+        if (this._timers.has(key)) {
+            clearTimeout(this._timers.get(key));
+            this._timers.delete(key);
+        }
+
+        return super.delete(key);
+    }
+
+    clear(): void {
+        for (const timeoutId of this._timers.values())
+            clearTimeout(timeoutId);
+
+        this._timers.clear();
+        return super.clear();
+    }
+}


### PR DESCRIPTION
- Caches musicbrainz and coveractarchive api lookups for 15mins
- Adds support for self hosted instances
- If no valid cover is found, checks if the scrobble originates from a youtube video and if yes uses its thumbnail as cover art
 
<img width="320" height="320" alt="image" src="https://github.com/user-attachments/assets/bcfaf6d0-9938-4e9f-b799-f39bad127e37" />
