### PR TITLE
Fix NewGuildSettings not applying when joining via browser invites

### DIFF
--- a/src/plugins/newGuildSettings/index.tsx
+++ b/src/plugins/newGuildSettings/index.tsx
@@ -144,6 +144,9 @@ export default definePlugin({
     settings,
     applyDefaultSettings,
     flux: {
+        GUILD_JOIN({ guildId }) {
+            applyDefaultSettings(guildId);
+        },
         GUILD_JOIN_REQUEST_UPDATE({ guildId, request, status }) {
             if (status === "APPROVED" && request.user_id === UserStore.getCurrentUser().id)
                 applyDefaultSettings(guildId);


### PR DESCRIPTION
## Describe your Changes

Fix `NewGuildSettings` not applying default settings when joining a guild through a browser opened invite (e.g. Disboard).
Fixes #4422

The plugin only handled specific join paths (`acceptInvite`, `joinGuild`, and membership screening). Browser hand off joins bypass those hooks, so `applyDefaultSettings` was never called.

Handle the `GUILD_JOIN` Flux event so defaults are applied regardless of how the guild was joined.


## Checklist before submitting

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent