### PR TITLE
Add PreviewZip Plugin

### DIFF
--- a/src/plugins/previewZip/index.tsx
+++ b/src/plugins/previewZip/index.tsx
@@ -1,0 +1,133 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { Devs } from "@utils/constants";
+import definePlugin, { PluginNative } from "@utils/types";
+import { React } from "@webpack/common";
+import { unzip } from "fflate";
+
+const Native = VencordNative.pluginHelpers.PreviewZip as PluginNative<typeof import("./native")>;
+
+interface TreeNode {
+    name: string;
+    isDir: boolean;
+    size: number;
+    children: Map<string, TreeNode>;
+}
+
+// keeps already loaded the ZIP files so we don't read the same file twice. :p
+const cache = new Map<string, TreeNode | string>();
+
+function formatSize(bytes: number) {
+    if (bytes < 1024) return bytes + " B";
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+    return (bytes / 1024 / 1024).toFixed(1) + " MB";
+}
+
+function buildTree(files: { name: string, size: number; }[]) {
+    const root: TreeNode = { name: "", isDir: true, size: 0, children: new Map() };
+
+    for (const file of files) {
+        const parts = file.name.split("/").filter(Boolean);
+        let node = root;
+
+        for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
+            const last = i === parts.length - 1;
+
+            if (!node.children.has(part)) {
+                node.children.set(part, {
+                    name: part,
+                    isDir: !last || file.name.endsWith("/"),
+                    size: 0,
+                    children: new Map()
+                });
+            }
+
+            node = node.children.get(part)!;
+            if (last) node.size = file.size;
+        }
+    }
+
+    return root;
+}
+
+function Tree({ node, depth = 0 }: { node: TreeNode, depth?: number; }) {
+    const entries = [...node.children.values()].sort((a, b) => {
+        if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+        return a.name.localeCompare(b.name);
+    });
+
+    return (
+        <>
+            {entries.map(entry => (
+                <React.Fragment key={entry.name}>
+                    <div className="previewzip-row" style={{ paddingLeft: depth * 14 }}>
+                        <span className="previewzip-name">{entry.name}{entry.isDir ? "/" : ""}</span>
+                        {!entry.isDir && <span className="previewzip-size"> ({formatSize(entry.size)})</span>}
+                    </div>
+                    {entry.isDir && <Tree node={entry} depth={depth + 1} />}
+                </React.Fragment>
+            ))}
+        </>
+    );
+}
+
+function ZipCard({ filename, url, size }: { filename: string, url: string, size: number; }) {
+    const [tree, setTree] = React.useState<TreeNode | string | null>(cache.get(url) ?? null);
+
+    React.useEffect(() => {
+        if (cache.has(url)) return;
+
+        Native.fetchZip(url).then(bytes => {
+            const files: { name: string, size: number; }[] = [];
+
+            unzip(bytes, {
+                filter(f) {
+                    files.push({ name: f.name, size: f.originalSize ?? 0 });
+                    return false;
+                }
+            }, err => {
+                if (!err) {
+                    const result = buildTree(files);
+                    cache.set(url, result);
+                    setTree(result);
+                }
+            });
+        }).catch(() => {
+        });
+    }, [url]);
+
+    return (
+        <div className="previewzip-card">
+            <div className="previewzip-header">
+                <span className="previewzip-icon">💕</span>
+                <div className="previewzip-header-text">
+                    <a href={url} target="_blank" rel="noreferrer" className="previewzip-filename">{filename}</a>
+                    <span className="previewzip-header-size">{formatSize(size)}</span>
+                </div>
+            </div>
+            <div className="previewzip-body">
+                {tree && typeof tree !== "string" && <Tree node={tree} />}
+            </div>
+        </div>
+    );
+}
+
+export default definePlugin({
+    name: "PreviewZip",
+    description: "Shows what is inside the .zip folder without having to download them",
+    authors: [Devs.alexagian],
+
+    renderMessageAccessory(props) {
+        const zips = props.message.attachments?.filter(a => a.filename.toLowerCase().endsWith(".zip"));
+        if (!zips?.length) return null;
+
+        return <>{zips.map(a => <ZipCard key={a.id} filename={a.filename} url={a.url} size={a.size} />)}</>;
+    }
+});

--- a/src/plugins/previewZip/index.tsx
+++ b/src/plugins/previewZip/index.tsx
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2023 Vendicated and contributors
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/plugins/previewZip/native.ts
+++ b/src/plugins/previewZip/native.ts
@@ -1,0 +1,15 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import type { IpcMainInvokeEvent } from "electron";
+
+export async function fetchZip(_event: IpcMainInvokeEvent, url: string) {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`failed ${res.status}`);
+
+    const buf = await res.arrayBuffer();
+    return new Uint8Array(buf);
+}

--- a/src/plugins/previewZip/native.ts
+++ b/src/plugins/previewZip/native.ts
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2023 Vendicated and contributors
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/plugins/previewZip/style.css
+++ b/src/plugins/previewZip/style.css
@@ -1,0 +1,73 @@
+.previewzip-card {
+    margin-top: 4px;
+    max-width: 480px;
+    border-radius: 6px;
+    background: #2b2d31;
+    border: 1px solid #1e1f22;
+    overflow: hidden;
+}
+
+.previewzip-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+}
+
+.previewzip-icon {
+    font-size: 22px;
+    line-height: 1;
+}
+
+.previewzip-header-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.previewzip-filename {
+    color: #00a8fc;
+    font-weight: 600;
+    font-size: 14px;
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.previewzip-filename:hover {
+    text-decoration: underline;
+}
+
+.previewzip-header-size {
+    color: #b5bac1;
+    font-size: 12px;
+}
+
+.previewzip-body {
+    max-height: 240px;
+    overflow-y: auto;
+    padding: 0 12px 10px;
+}
+
+.previewzip-row {
+    padding: 1px 0;
+    font-size: 13px;
+    white-space: nowrap;
+}
+
+.previewzip-name {
+    color: #00a8fc;
+    text-decoration: underline;
+    cursor: default;
+}
+
+.previewzip-size {
+    color: #b5bac1;
+}
+
+.previewzip-status {
+    padding: 4px 0;
+    color: #b5bac1;
+    font-size: 13px;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -649,6 +649,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Lunascape: {
         name: "Lunascape",
         id: 383365021415243776n
+    },
+    alexagian: {
+        name: "alexagian",
+        id: 1043876811664273549n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
## Describe your Changes
This plugin allows you to view the files of a zip folder with out having to download it, so basically if somebody sent you a zip folder in discord and you were worried that it could have some sussy files in there with this plugin you could check what files it has without downloading the zip folder. 

Example: 
<img width="581" height="253" alt="Screenshot 2026-07-20 110823" src="https://github.com/user-attachments/assets/8b4cd7ae-50d0-4701-afc3-02aae5a2132d" />


## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
