### PR TITLE
Add RememberWindowState plugin

### DIFF
--- a/src/plugins/rememberWindowState.desktop/index.ts
+++ b/src/plugins/rememberWindowState.desktop/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin, { PluginNative, StartAt } from "@utils/types";
+
+const Native = VencordNative.pluginHelpers.RememberWindowState as PluginNative<typeof import("./native")>;
+
+export default definePlugin({
+    name: "RememberWindowState",
+    description: "Remember Discord's window position, size, and maximized state.",
+    authors: [Devs.bonk],
+    startAt: StartAt.Init,
+
+    start() {
+        Native.start();
+    },
+
+    stop() {
+        Native.stop();
+    }
+});

--- a/src/plugins/rememberWindowState.desktop/native.ts
+++ b/src/plugins/rememberWindowState.desktop/native.ts
@@ -1,0 +1,102 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { NativeSettings } from "@main/settings";
+import { BrowserWindow, type IpcMainInvokeEvent, type Rectangle, screen } from "electron";
+
+interface SavedWindowState {
+    bounds: Rectangle;
+    maximized: boolean;
+}
+
+let window: BrowserWindow | undefined;
+let saveTimer: NodeJS.Timeout | undefined;
+
+function isValidState(state: any): state is SavedWindowState {
+    const { bounds } = state ?? {};
+    return typeof state?.maximized === "boolean"
+        && Number.isFinite(bounds?.x)
+        && Number.isFinite(bounds?.y)
+        && Number.isFinite(bounds?.width)
+        && Number.isFinite(bounds?.height)
+        && bounds.width > 0
+        && bounds.height > 0;
+}
+
+function clampBounds(bounds: Rectangle): Rectangle {
+    const { workArea } = screen.getDisplayMatching(bounds);
+    const x = bounds.width > workArea.width
+        ? workArea.x
+        : Math.min(Math.max(bounds.x, workArea.x), workArea.x + workArea.width - bounds.width);
+    const y = bounds.height > workArea.height
+        ? workArea.y
+        : Math.min(Math.max(bounds.y, workArea.y), workArea.y + workArea.height - bounds.height);
+
+    return { ...bounds, x, y };
+}
+
+function saveWindowState() {
+    if (!window || window.isDestroyed()) return;
+
+    NativeSettings.store.plugins.RememberWindowState = {
+        bounds: window.getNormalBounds(),
+        maximized: window.isMaximized()
+    };
+}
+
+function scheduleSave() {
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(saveWindowState, 300);
+}
+
+function flushSave() {
+    clearTimeout(saveTimer);
+    saveTimer = undefined;
+    saveWindowState();
+}
+
+function addListeners() {
+    if (!window) return;
+
+    window.on("move", scheduleSave);
+    window.on("resize", scheduleSave);
+    window.on("maximize", scheduleSave);
+    window.on("unmaximize", scheduleSave);
+    window.on("close", flushSave);
+}
+
+function removeListeners() {
+    if (!window || window.isDestroyed()) return;
+
+    window.off("move", scheduleSave);
+    window.off("resize", scheduleSave);
+    window.off("maximize", scheduleSave);
+    window.off("unmaximize", scheduleSave);
+    window.off("close", flushSave);
+}
+
+export function start(event: IpcMainInvokeEvent) {
+    const newWindow = BrowserWindow.fromWebContents(event.sender);
+    if (!newWindow) return;
+    if (window && !window.isDestroyed()) return;
+
+    window = newWindow;
+
+    const savedState = NativeSettings.plain.plugins.RememberWindowState;
+    if (isValidState(savedState)) {
+        if (window.isMaximized()) window.unmaximize();
+        window.setBounds(clampBounds(savedState.bounds));
+        if (savedState.maximized) window.maximize();
+    }
+
+    addListeners();
+}
+
+export function stop(_: IpcMainInvokeEvent) {
+    flushSave();
+    removeListeners();
+    window = undefined;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -649,7 +649,11 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Lunascape: {
         name: "Lunascape",
         id: 383365021415243776n
-    }
+    },
+    bonk: {
+        name: "bonk",
+        id: 379022874872381440n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
This plugin saves the window bounds and maximized state to NativeSettings (debounced, on move/resize/maximize) and restores them on startup, clamped to the current work area so the window can't end up off-screen if your monitor setup changed.

This plugin saves the window bounds and maximized state to NativeSettings as a workaround for [this](https://support.discord.com/hc/en-us/community/posts/360042495671-Save-client-window-position-after-restart) Discord issue.

There are a couple of other workarounds, [putting Discord in windowed mode and quitting the application](https://support.discord.com/hc/en-us/community/posts/360042495671/comments/360005668572) and [editing the settings file](https://support.discord.com/hc/en-us/community/posts/360042495671/comments/4403393714455), but I find both annoying and cumbersome.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
