### PR TITLE
Fix MessagePopoverAPI

### DIFF
--- a/src/plugins/_api/messagePopover.ts
+++ b/src/plugins/_api/messagePopover.ts
@@ -27,9 +27,9 @@ export default definePlugin({
         {
             find: "#{intl::MESSAGE_UTILITIES_A11Y_LABEL}",
             replacement: {
-                match: /(?<=\]\}\)),(.{0,40}togglePopout:.+?\}\))\]\}\):null,(?<=\((\i\.\i),\{label:.+?:null,(\i)\?\(0,\i\.jsxs?\)\(\i\.Fragment.+?message:(\i).+?)/,
-                replace: (_, ReactButton, ButtonComponent, showReactButton, message) => "" +
-                    `]}):null,Vencord.Api.MessagePopover._buildPopoverElements(${ButtonComponent},${message}),${showReactButton}?${ReactButton}:null,`
+                match: /,(\(0,\i\.jsx\)\((\i),\{togglePopout:.+?message:(\i)\}\))\]/,
+                replace: (_, ReactButton, ButtonComponent, message) => "" +
+                    `,Vencord.Api.MessagePopover._buildPopoverElements(${ButtonComponent},${message}),${ReactButton}]`
             }
         }
     ]


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

Fixes the broken MessagePoperoverAPI patch that causes translate and other buttons not show on messages anymore.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
