### PR TITLE
WebContextMenus: fix Copy Image for webp/avif

### DIFF
--- a/src/plugins/webContextMenus.web/index.ts
+++ b/src/plugins/webContextMenus.web/index.ts
@@ -131,6 +131,12 @@ export default definePlugin({
                 {
                     match: /(?<=canCopyImage\(.+?)typeof \i\.clipboard\.copyImage/,
                     replace: '"function"'
+                },
+                {
+                    // Discord's copy allowlist is missing formats like webp & avif that its save
+                    // allowlist has. copyImage re-encodes to png anyway, so they work fine
+                    match: /\["jpg","jpeg","jfif","png"\]/,
+                    replace: '["jpg","jpeg","jfif","png","webp","avif"]'
                 }
             ]
         },


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

**The problem:**
When I right-click a **WebP** or **AVIF** image, **"Copy Image"** doesn't show up, but **"Save Image"** still does. Since Discord converts most uploaded images to WebP, this happens all the time.

**Why it happens:**
Discord's `canCopyImage` function only checks for `jpg`, `jpeg`, `jfif`, and `png`. The plugin was already patching the other checks in that function, but it wasn't touching the format whitelist.

**What I did:**
I patched that whitelist and added `webp` and `avif`. This is safe because the plugin's `copyImage` function already converts any non-PNG image to PNG using a canvas before copying it.

**How I tested:**
I injected the build into Discord, right-clicked a WebP image, and confirmed that **"Copy Image"** now appears. I also verified that copying and pasting the image works as expected.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent

Fixes #4429
