### PR TITLE
Fix newGuildSettings unable to work

### DIFF
--- a/src/plugins/newGuildSettings/index.tsx
+++ b/src/plugins/newGuildSettings/index.tsx
@@ -26,7 +26,7 @@ import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { Guild } from "@vencord/discord-types";
 import { findByCodeLazy, findByPropsLazy, mapMangledModuleLazy } from "@webpack";
-import { Menu, UserStore } from "@webpack/common";
+import { GuildStore, Menu } from "@webpack/common";
 
 const { updateGuildNotificationSettings } = findByPropsLazy("updateGuildNotificationSettings");
 const { toggleShowAllChannels } = mapMangledModuleLazy(".onboardExistingMember(", {
@@ -144,9 +144,16 @@ export default definePlugin({
     settings,
     applyDefaultSettings,
     flux: {
-        GUILD_JOIN_REQUEST_UPDATE({ guildId, request, status }) {
-            if (status === "APPROVED" && request.user_id === UserStore.getCurrentUser().id)
-                applyDefaultSettings(guildId);
+        GUILD_CREATE(event: any) {
+            const guildId = event.guild?.id || event.guildId;
+            if (!guildId) return;
+
+            const guild = GuildStore.getGuild(guildId);
+            const isLurker = (event.guild as any)?.is_lurker || (guild as any)?.isLurker;
+
+            if (isLurker) return;
+
+            applyDefaultSettings(guildId);
         }
-    }
+    },
 });


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
Fix `NewGuildSettings` not applying any settings when joining a new guild through the client or browser from webs like disboard..

Use `GUILD_CREATE` event, so it handles all types of server invites. Then make a check in case the user is a lurker.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
