### PR TITLE
feat(readAllNotificationsButton): add Read All DMs button

### DIFF
--- a/src/plugins/readAllNotificationsButton/index.tsx
+++ b/src/plugins/readAllNotificationsButton/index.tsx
@@ -90,9 +90,9 @@ const settings = definePluginSettings({
         description: "Which buttons to show",
         type: OptionType.SELECT,
         options: [
-            { label: "Both", value: 0, default: true },
-            { label: "Only Guilds (Servers)", value: 1 },
-            { label: "Only DMs", value: 2 }
+            { label: "Both", value: "BOTH", default: true },
+            { label: "Only Guilds (Servers)", value: "GUILDS" },
+            { label: "Only DMs", value: "DMS" }
         ]
     }
 });
@@ -149,14 +149,14 @@ export default definePlugin({
                     Read All
                 </BaseText>
 
-                {(mode === 0 || mode === 1) && (
+                {(mode == "BOTH" || mode == "GUILDS") && (
                     <ReadButton onClick={onClickGuilds}>
                         <GuildsIcon />
                         Guilds
                     </ReadButton>
                 )}
 
-                {(mode === 0 || mode === 2) && (
+                {(mode == "BOTH" || mode == "DMS") && (
                     <ReadButton onClick={onClickDMs}>
                         <DMsIcon />
                         DMs

--- a/src/plugins/readAllNotificationsButton/index.tsx
+++ b/src/plugins/readAllNotificationsButton/index.tsx
@@ -18,14 +18,16 @@
 
 import "./style.css";
 
+import { definePluginSettings } from "@api/Settings";
 import { addServerListElement, removeServerListElement, ServerListRenderPosition } from "@api/ServerList";
 import { TextButton } from "@components/Button";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
-import definePlugin from "@utils/types";
-import { ActiveJoinedThreadsStore, FluxDispatcher, GuildChannelStore, GuildStore, React, ReadStateStore } from "@webpack/common";
+import definePlugin, { OptionType } from "@utils/types";
+import { ActiveJoinedThreadsStore, FluxDispatcher, GuildChannelStore, ChannelStore, GuildStore, React, ReadStateStore } from "@webpack/common";
+import { BaseText } from "@components/index";
 
-function onClick() {
+function onClickGuilds() {
     const channels: Array<any> = [];
 
     Object.values(GuildStore.getGuilds()).forEach(guild => {
@@ -53,30 +55,122 @@ function onClick() {
     });
 }
 
-const ReadAllButton = () => (
+const DM_TYPES = [1, 3];
+
+function onClickDMs() {
+    const channels: Array<any> = [];
+
+    Object.values(ChannelStore.getMutablePrivateChannels())
+        .filter(channel => {
+            if (!channel || !DM_TYPES.includes(channel.type))
+                return false;
+
+            if (!ReadStateStore.hasUnread(channel.id)) return;
+
+            return true;
+        })
+        .forEach(channel => {
+            channels.push({
+                channelId: channel.id,
+                messageId: ReadStateStore.lastMessageId(channel.id),
+                readStateType: 0
+            });
+        });
+
+    FluxDispatcher.dispatch({
+        type: "BULK_ACK",
+        context: "APP",
+        channels: channels
+    });
+}
+
+const settings = definePluginSettings({
+    visibleButtons: {
+        displayName: "Visible Buttons",
+        description: "Which buttons to show",
+        type: OptionType.SELECT,
+        options: [
+            { label: "Both", value: 0, default: true },
+            { label: "Only Guilds (Servers)", value: 1 },
+            { label: "Only DMs", value: 2 }
+        ]
+    }
+});
+
+const ReadButton = ({ children, onClick }: { children: React.ReactNode; onClick: () => void; }) => (
     <TextButton
         variant="secondary"
         onClick={onClick}
         className="vc-ranb-button"
     >
-        Read All
+        {children}
     </TextButton>
+);
+
+const DMsIcon = ({ size = 14 }: { size?: number; }) => (
+    <svg
+        width={size}
+        height={size}
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+    >
+        <path d="M13 10a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z" />
+        <path d="M3 5v-.75C3 3.56 3.56 3 4.25 3s1.24.56 1.33 1.25C6.12 8.65 9.46 12 13 12h1a8 8 0 0 1 8 8 2 2 0 0 1-2 2 .21.21 0 0 1-.2-.15 7.65 7.65 0 0 0-1.32-2.3c-.15-.2-.42-.06-.39.17l.25 2c.02.15-.1.28-.25.28H9a2 2 0 0 1-2-2v-2.22c0-1.57-.67-3.05-1.53-4.37A15.85 15.85 0 0 1 3 5Z" />
+    </svg>
+);
+
+const GuildsIcon = ({ size = 14 }: { size?: number; }) => (
+    <svg
+        width={size}
+        height={size}
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+    >
+        <path d="M19.73 4.87a18.2 18.2 0 0 0-4.6-1.44c-.21.4-.4.8-.58 1.21-1.69-.25-3.4-.25-5.1 0-.18-.41-.37-.82-.59-1.2-1.6.27-3.14.75-4.6 1.43A19.04 19.04 0 0 0 .96 17.7a18.43 18.43 0 0 0 5.63 2.87c.46-.62.86-1.28 1.2-1.98-.65-.25-1.29-.55-1.9-.92.17-.12.32-.24.47-.37 3.58 1.7 7.7 1.7 11.28 0l.46.37c-.6.36-1.25.67-1.9.92.35.7.75 1.35 1.2 1.98 2.03-.63 3.94-1.6 5.64-2.87.47-4.87-.78-9.09-3.3-12.83ZM8.3 15.12c-1.1 0-2-1.02-2-2.27 0-1.24.88-2.26 2-2.26s2.02 1.02 2 2.26c0 1.25-.89 2.27-2 2.27Zm7.4 0c-1.1 0-2-1.02-2-2.27 0-1.24.88-2.26 2-2.26s2.02 1.02 2 2.26c0 1.25-.88 2.27-2 2.27Z" />
+    </svg>
 );
 
 export default definePlugin({
     name: "ReadAllNotificationsButton",
-    description: "Read all server notifications with a single button click!",
+    description: "Read all server or direct message notifications with a single button click!",
     tags: ["Notifications", "Shortcuts"],
-    authors: [Devs.kemo],
+    authors: [Devs.kemo, Devs.tekken],
     dependencies: ["ServerListAPI"],
+    settings,
 
-    renderReadAllButton: ErrorBoundary.wrap(ReadAllButton, { noop: true }),
+    renderReadButtons: ErrorBoundary.wrap(() => {
+        const mode = settings.store.visibleButtons;
+
+        return (
+            <div>
+                <BaseText size="sm" className="vc-ranb-text">
+                    Read All
+                </BaseText>
+
+                {(mode === 0 || mode === 1) && (
+                    <ReadButton onClick={onClickGuilds}>
+                        <GuildsIcon />
+                        Guilds
+                    </ReadButton>
+                )}
+
+                {(mode === 0 || mode === 2) && (
+                    <ReadButton onClick={onClickDMs}>
+                        <DMsIcon />
+                        DMs
+                    </ReadButton>
+                )}
+            </div>
+        );
+    }, { noop: true }),
 
     start() {
-        addServerListElement(ServerListRenderPosition.Above, this.renderReadAllButton);
+        addServerListElement(ServerListRenderPosition.Above, this.renderReadButtons);
     },
 
     stop() {
-        removeServerListElement(ServerListRenderPosition.Above, this.renderReadAllButton);
+        removeServerListElement(ServerListRenderPosition.Above, this.renderReadButtons);
     }
 });

--- a/src/plugins/readAllNotificationsButton/style.css
+++ b/src/plugins/readAllNotificationsButton/style.css
@@ -1,12 +1,15 @@
 .vc-ranb-button {
     color: var(--interactive-icon-default);
-    padding: 0 0.5em;
     width: 100%;
-    font-size: 14px;
-    white-space: nowrap;
+    font-size: 0.875rem;
     box-sizing: border-box;
 }
 
 .vc-ranb-button:hover {
     color: var(--interactive-icon-active);
+}
+
+.vc-ranb-text {
+    color: var(--interactive-icon-default);
+    text-align: center;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -649,6 +649,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Lunascape: {
         name: "Lunascape",
         id: 383365021415243776n
+    },
+    tekken: {
+        name: "tekken",
+        id: 680541988625711136n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION

<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

Adds a button to Read All DMs to the existing readAllNotificationsButton plugin, along with options to display both buttons, only the Guilds (Servers) button, or only the DMs button.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
