### PR TITLE
Fix ViewIcons bugs

### DIFF
--- a/src/plugins/viewIcons/index.tsx
+++ b/src/plugins/viewIcons/index.tsx
@@ -219,7 +219,8 @@ export default definePlugin({
             replacement: {
                 match: /null==\i\.icon\?.+?src:(\(0,\i\.\i\).+?\))(?=[,}])/,
                 // We have to check that icon is not an unread GDM in the server bar
-                replace: (m, iconUrl) => `${m},onClick:()=>arguments[0]?.size!=="SIZE_48"&&$self.openAvatar(${iconUrl})`
+                replace: (m, iconUrl) =>
+                    `${m},onClick:e=>{arguments[0]?.channel?.type===3&&arguments[0]?.size!=="SIZE_40"&&(e.stopPropagation(),$self.openAvatar(${iconUrl}))}`
             }
         },
         // User DMs top small icon
@@ -227,7 +228,8 @@ export default definePlugin({
             find: ".channel.getRecipientId(),",
             replacement: {
                 match: /(?=,src:(\i.getAvatarURL\(.+?[)]))/,
-                replace: (_, avatarUrl) => `,onClick:()=>$self.openAvatar(${avatarUrl})`
+                replace: (_, avatarUrl) =>
+                    `,onClick:e=>{e.stopPropagation();$self.openAvatar(${avatarUrl})}`
             }
         },
         // User Dms top large icon
@@ -235,7 +237,8 @@ export default definePlugin({
             find: ".EMPTY_GROUP_DM)",
             replacement: {
                 match: /(?<=SIZE_80,)(?=src:(.+?\))[,}])/,
-                replace: (_, avatarUrl) => `onClick:()=>$self.openAvatar(${avatarUrl}),`
+                replace: (_, avatarUrl) =>
+                    `,onClick:e=>{e.stopPropagation();$self.openAvatar(${avatarUrl})}`
             }
         }
     ]


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

### Bug 1

Check was broken for group DM's on the server list causing the icon to be opened

https://github.com/user-attachments/assets/22e12cb2-71dc-494d-90a5-9ebd1f7d9176

### Bug 2

Clicking at the top of a group DM on the icon opens both the edit group popup & view icon popup

https://github.com/user-attachments/assets/7bde0e30-6900-41a9-a910-fc06da765f45

### Bug 3

Clicking at the top of a DM on the profile picture opens both the user profile & view icon popup

https://github.com/user-attachments/assets/93d7f7f8-eb17-42c5-81e3-7fa1443005e0


## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
