### PR TITLE
fix(utils/text): don't throw when a word is empty

### DIFF
--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -26,15 +26,19 @@ export const wordsFromKebab = (text: string) => text.toLowerCase().split("-");
 export const wordsFromPascal = (text: string) => text.split(/(?=[A-Z])/).map(w => w.toLowerCase());
 export const wordsFromTitle = (text: string) => text.toLowerCase().split(" ");
 
+// The wordsFrom* helpers above yield an empty string for a leading, trailing or
+// repeated separator, so capitalising blind throws on input like "-foo" or "a__b".
+const capitalize = (w: string) => w ? w[0].toUpperCase() + w.slice(1) : w;
+
 // Words to case style
 export const wordsToCamel = (words: string[]) =>
-    words.map((w, i) => (i ? w[0].toUpperCase() + w.slice(1) : w)).join("");
+    words.map((w, i) => (i ? capitalize(w) : w)).join("");
 export const wordsToSnake = (words: string[]) => words.join("_").toUpperCase();
 export const wordsToKebab = (words: string[]) => words.join("-").toLowerCase();
 export const wordsToPascal = (words: string[]) =>
-    words.map(w => w[0].toUpperCase() + w.slice(1)).join("");
+    words.map(capitalize).join("");
 export const wordsToTitle = (words: string[]) =>
-    words.map(w => w[0].toUpperCase() + w.slice(1)).join(" ");
+    words.map(capitalize).join(" ");
 
 const units = ["years", "months", "weeks", "days", "hours", "minutes", "seconds"] as const;
 type Units = typeof units[number];


### PR DESCRIPTION
### The problem

`wordsToCamel`, `wordsToPascal` and `wordsToTitle` read `w[0]` before uppercasing it:

```ts
words.map(w => w[0].toUpperCase() + w.slice(1))
```

An empty word makes `w[0]` `undefined` and the call throws. Every `wordsFrom*` helper produces an empty word for a leading, trailing or repeated separator, because they all end in a bare `.split()`:

```ts
wordsFromKebab("-leading")   // ["", "leading"]
wordsFromSnake("trail_")     // ["trail", ""]
wordsFromCamel("")           // [""]
```

So the composition this file's own comment recommends throws on fairly ordinary input:

```ts
// "Utils for readable text transformations eg: `toTitle(fromKebab())`"

wordsToTitle(wordsFromKebab("-leading"))   // TypeError: Cannot read properties of undefined
wordsToTitle(wordsFromSnake("a__b"))       // TypeError
wordsToTitle(wordsFromCamel(""))           // TypeError
```

Running every `wordsFrom*` into every `wordsTo*` across a set of ordinary strings, 40 of 285 combinations throw, spread over 13 distinct chains.

### How reachable is it

Honestly, not very, from the current in-tree call sites. `Common.tsx`, `vencordToolbox/menu.tsx` and `shikiCodeblocks` all pass identifiers that are already well formed, and I could only reach those through an empty string. So this is closer to hardening an exported utility than to fixing a live crash, and I did not want to oversell it.

It still seemed worth doing because these are exported from `@utils/text` for plugins to use, and the documented composition is exactly the thing that breaks.

### The change

```ts
const capitalize = (w: string) => w ? w[0].toUpperCase() + w.slice(1) : w;
```

used by the three affected functions. `wordsToSnake` and `wordsToKebab` never indexed, so they are untouched.

After it, none of the 285 combinations throw, and output for well-formed input is identical (`"fooBar"` to `"Foo Bar"`, `"ABCFoo"` to `"ABC Foo"`, and so on).

Empty segments now survive into the output rather than crashing, so `wordsFromKebab("-leading")` titles to `" Leading"` with a leading space. If you would rather they vanished, adding `.filter(Boolean)` to the `wordsFrom*` helpers would give `"Leading"` instead. I left that out because it changes the length of the returned array and felt like a separate decision. Happy to add it if you prefer.

### Checks

`pnpm` would not run here (`corepack` hit `EPERM` on this machine), so I could not run the full `pnpm test` pipeline. I typechecked `src/utils/text.ts` in isolation instead; the only diagnostics are the pre-existing `require` and `RegExp.escape` ones that come from compiling the file outside the project's `tsconfig`, and the new helper adds none.
