### PR TITLE
Translate: Add per server settings (#4435)

### DIFF
--- a/src/plugins/translate/TranslateIcon.tsx
+++ b/src/plugins/translate/TranslateIcon.tsx
@@ -18,10 +18,11 @@
 
 import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
 import { TooltipContainer } from "@components/TooltipContainer";
+import { getCurrentChannel, getCurrentGuild } from "@utils/discord";
 import { classes } from "@utils/misc";
 import { IconComponent } from "@utils/types";
 import { RenderModalProps } from "@vencord/discord-types";
-import { ConfirmModal,openModal, useEffect, useState } from "@webpack/common";
+import { ConfirmModal, openModal, useEffect, useState } from "@webpack/common";
 
 import { settings } from "./settings";
 import { openTranslateModal } from "./TranslateModal";
@@ -63,7 +64,9 @@ function AutoTranslateConfirmModal(props: RenderModalProps) {
 }
 
 export const TranslateChatBarIcon: ChatBarButtonFactory = ({ isMainChat }) => {
-    const { autoTranslate } = settings.use(["autoTranslate"]);
+    const { autoTranslate: globalAutoTranslate } = settings.use(["autoTranslate"]);
+    const perServer = settings.use(["perServerAutoTranslate"]).perServerAutoTranslate;
+    const { perServerScope } = settings.use(["perServerScope"]);
 
     const [shouldShowTranslateEnabledTooltip, setter] = useState(false);
     useEffect(() => {
@@ -73,9 +76,26 @@ export const TranslateChatBarIcon: ChatBarButtonFactory = ({ isMainChat }) => {
 
     if (!isMainChat) return null;
 
+    const channelId = getCurrentChannel()?.id;
+    const guildId = getCurrentGuild()?.id;
+
+    const { perServerRecord } = settings.use(["perServerRecord"]);
+
+    const isScoped = perServer && (channelId || guildId);
+    const shouldTranslate = isScoped
+        ? perServerRecord[perServerScope === "server" && guildId ? guildId : channelId!] ?? globalAutoTranslate
+        : globalAutoTranslate;
+
     const toggle = () => {
-        const newState = !autoTranslate;
-        settings.store.autoTranslate = newState;
+        const newState = !shouldTranslate;
+
+        if (isScoped) {
+            const key = perServerScope === "server" && guildId ? guildId : channelId!;
+            settings.store.perServerRecord = { ...settings.store.perServerRecord, [key]: newState };
+        } else {
+            settings.store.autoTranslate = newState;
+        }
+
         if (newState && !settings.store.dismissedAutoTranslateAlert)
             openModal(props => <AutoTranslateConfirmModal {...props} />);
     };
@@ -85,14 +105,14 @@ export const TranslateChatBarIcon: ChatBarButtonFactory = ({ isMainChat }) => {
             tooltip="Open Translate Modal"
             onClick={e => {
                 if (e.shiftKey) return toggle();
-                else openTranslateModal();
+                else openTranslateModal(channelId, guildId);
             }}
             onContextMenu={toggle}
             buttonProps={{
                 "aria-haspopup": "dialog"
             }}
         >
-            <TranslateIcon className={cl({ "auto-translate": autoTranslate, "chat-button": true })} />
+            <TranslateIcon className={cl({ "auto-translate": shouldTranslate, "chat-button": true })} />
         </ChatBarButton>
     );
 

--- a/src/plugins/translate/TranslateIcon.tsx
+++ b/src/plugins/translate/TranslateIcon.tsx
@@ -26,7 +26,7 @@ import { ConfirmModal, openModal, useEffect, useState } from "@webpack/common";
 
 import { settings } from "./settings";
 import { openTranslateModal } from "./TranslateModal";
-import { cl } from "./utils";
+import { cl, getScopeKey } from "./utils";
 
 export const TranslateIcon: IconComponent = ({ height = 20, width = 20, className }) => {
     return (
@@ -65,7 +65,7 @@ function AutoTranslateConfirmModal(props: RenderModalProps) {
 
 export const TranslateChatBarIcon: ChatBarButtonFactory = ({ isMainChat }) => {
     const { autoTranslate: globalAutoTranslate } = settings.use(["autoTranslate"]);
-    const perServer = settings.use(["perServerAutoTranslate"]).perServerAutoTranslate;
+    const { perServerAutoTranslate } = settings.use(["perServerAutoTranslate"]);
     const { perServerScope } = settings.use(["perServerScope"]);
 
     const [shouldShowTranslateEnabledTooltip, setter] = useState(false);
@@ -81,16 +81,16 @@ export const TranslateChatBarIcon: ChatBarButtonFactory = ({ isMainChat }) => {
 
     const { perServerRecord } = settings.use(["perServerRecord"]);
 
-    const isScoped = perServer && (channelId || guildId);
+    const isScoped = perServerAutoTranslate && (channelId || guildId);
     const shouldTranslate = isScoped
-        ? perServerRecord[perServerScope === "server" && guildId ? guildId : channelId!] ?? globalAutoTranslate
+        ? perServerRecord[getScopeKey(channelId, guildId)] ?? globalAutoTranslate
         : globalAutoTranslate;
 
     const toggle = () => {
         const newState = !shouldTranslate;
 
         if (isScoped) {
-            const key = perServerScope === "server" && guildId ? guildId : channelId!;
+            const key = getScopeKey(channelId, guildId);
             settings.store.perServerRecord = { ...settings.store.perServerRecord, [key]: newState };
         } else {
             settings.store.autoTranslate = newState;

--- a/src/plugins/translate/TranslateModal.tsx
+++ b/src/plugins/translate/TranslateModal.tsx
@@ -23,7 +23,7 @@ import { RenderModalProps } from "@vencord/discord-types";
 import { Forms, Modal, openModal, SearchableSelect, useMemo } from "@webpack/common";
 
 import { settings } from "./settings";
-import { getLanguages } from "./utils";
+import { getLanguages, getScopeKey } from "./utils";
 
 const LanguageSettingKeys = ["receivedInput", "receivedOutput", "sentInput", "sentOutput"] as const;
 
@@ -59,17 +59,16 @@ function LanguageSelect({ settingsKey, includeAuto }: { settingsKey: typeof Lang
 }
 
 function AutoTranslateToggle({ channelId, guildId }: { channelId?: string; guildId?: string; }) {
-    const globalAutoTranslate = settings.use(["autoTranslate"]).autoTranslate;
-    const perServer = settings.use(["perServerAutoTranslate"]).perServerAutoTranslate;
-    const { perServerScope } = settings.use(["perServerScope"]);
-    const { perServerRecord } = settings.use(["perServerRecord"]);
+    const { autoTranslate: globalAutoTranslate, perServerAutoTranslate: perServer, perServerScope, perServerRecord } = settings.use([
+        "autoTranslate", "perServerAutoTranslate", "perServerScope", "perServerRecord"
+    ]);
 
     const isScoped = perServer && (channelId || guildId);
     const value = isScoped
-        ? perServerRecord[perServerScope === "server" && guildId ? guildId : channelId!] ?? globalAutoTranslate
+        ? perServerRecord[getScopeKey(channelId, guildId)] ?? globalAutoTranslate
         : globalAutoTranslate;
 
-    const appendedText = isScoped ? ` (on this ${perServerScope === "server" ? (guildId ? "Server" : "Channel") : "Channel"})` : "";
+    const appendedText = isScoped ? ` (in this ${perServerScope === "server" ? (guildId ? "Server" : "Channel") : "Channel"})` : "";
 
     return (
         <FormSwitch
@@ -78,7 +77,7 @@ function AutoTranslateToggle({ channelId, guildId }: { channelId?: string; guild
             value={value}
             onChange={v => {
                 if (isScoped) {
-                    const key = perServerScope === "server" && guildId ? guildId : channelId!;
+                    const key = getScopeKey(channelId, guildId);
                     settings.store.perServerRecord = { ...settings.store.perServerRecord, [key]: v };
                 } else {
                     settings.store.autoTranslate = v;

--- a/src/plugins/translate/TranslateModal.tsx
+++ b/src/plugins/translate/TranslateModal.tsx
@@ -20,7 +20,7 @@ import { Divider } from "@components/Divider";
 import { FormSwitch } from "@components/FormSwitch";
 import { Margins } from "@utils/margins";
 import { RenderModalProps } from "@vencord/discord-types";
-import { Forms, Modal,openModal, SearchableSelect, useMemo } from "@webpack/common";
+import { Forms, Modal, openModal, SearchableSelect, useMemo } from "@webpack/common";
 
 import { settings } from "./settings";
 import { getLanguages } from "./utils";
@@ -58,22 +58,38 @@ function LanguageSelect({ settingsKey, includeAuto }: { settingsKey: typeof Lang
     );
 }
 
-function AutoTranslateToggle() {
-    const value = settings.use(["autoTranslate"]).autoTranslate;
+function AutoTranslateToggle({ channelId, guildId }: { channelId?: string; guildId?: string; }) {
+    const globalAutoTranslate = settings.use(["autoTranslate"]).autoTranslate;
+    const perServer = settings.use(["perServerAutoTranslate"]).perServerAutoTranslate;
+    const { perServerScope } = settings.use(["perServerScope"]);
+    const { perServerRecord } = settings.use(["perServerRecord"]);
+
+    const isScoped = perServer && (channelId || guildId);
+    const value = isScoped
+        ? perServerRecord[perServerScope === "server" && guildId ? guildId : channelId!] ?? globalAutoTranslate
+        : globalAutoTranslate;
+
+    const appendedText = isScoped ? ` (on this ${perServerScope === "server" ? (guildId ? "Server" : "Channel") : "Channel"})` : "";
 
     return (
         <FormSwitch
-            title="Auto Translate"
+            title={`Auto Translate${appendedText}`}
             description={settings.def.autoTranslate.description}
             value={value}
-            onChange={v => settings.store.autoTranslate = v}
+            onChange={v => {
+                if (isScoped) {
+                    const key = perServerScope === "server" && guildId ? guildId : channelId!;
+                    settings.store.perServerRecord = { ...settings.store.perServerRecord, [key]: v };
+                } else {
+                    settings.store.autoTranslate = v;
+                }
+            }}
             hideBorder
         />
     );
 }
 
-
-function TranslateModal({ rootProps }: { rootProps: RenderModalProps; }) {
+function TranslateModal({ rootProps, channelId, guildId }: { rootProps: RenderModalProps; channelId?: string; guildId?: string; }) {
     return (
         <Modal
             {...rootProps}
@@ -89,11 +105,11 @@ function TranslateModal({ rootProps }: { rootProps: RenderModalProps; }) {
 
             <Divider className={Margins.bottom16} />
 
-            <AutoTranslateToggle />
+            <AutoTranslateToggle channelId={channelId} guildId={guildId} />
         </Modal>
     );
 }
 
-export function openTranslateModal() {
-    openModal(props => <TranslateModal rootProps={props} />);
+export function openTranslateModal(channelId?: string, guildId?: string) {
+    openModal(props => <TranslateModal rootProps={props} channelId={channelId} guildId={guildId} />);
 }

--- a/src/plugins/translate/index.tsx
+++ b/src/plugins/translate/index.tsx
@@ -20,7 +20,7 @@ import "./styles.css";
 
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Devs } from "@utils/constants";
-import { getCurrentChannel, getCurrentGuild } from "@utils/index";
+import { getCurrentChannel, getCurrentGuild } from "@utils/discord";
 import definePlugin from "@utils/types";
 import { Message } from "@vencord/discord-types";
 import { ChannelStore, Menu } from "@webpack/common";

--- a/src/plugins/translate/index.tsx
+++ b/src/plugins/translate/index.tsx
@@ -20,6 +20,7 @@ import "./styles.css";
 
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { Devs } from "@utils/constants";
+import { getCurrentChannel, getCurrentGuild } from "@utils/index";
 import definePlugin from "@utils/types";
 import { Message } from "@vencord/discord-types";
 import { ChannelStore, Menu } from "@webpack/common";
@@ -27,7 +28,7 @@ import { ChannelStore, Menu } from "@webpack/common";
 import { settings } from "./settings";
 import { setShouldShowTranslateEnabledTooltip, TranslateChatBarIcon, TranslateIcon } from "./TranslateIcon";
 import { handleTranslate, TranslationAccessory } from "./TranslationAccessory";
-import { translate } from "./utils";
+import { shouldTranslate, translate } from "./utils";
 
 const messageCtxPatch: NavContextMenuPatchCallback = (children, { message }: { message: Message; }) => {
     const content = getMessageContent(message);
@@ -65,7 +66,7 @@ export default definePlugin({
     name: "Translate",
     description: "Translate messages with Google Translate, DeepL or Kagi.",
     tags: ["Chat", "Utility"],
-    authors: [Devs.Ven, Devs.AshtonMemer, Devs.koish1],
+    authors: [Devs.Ven, Devs.AshtonMemer, Devs.koish1, Devs.Av32000],
     settings,
     contextMenus: {
         "message": messageCtxPatch
@@ -100,7 +101,9 @@ export default definePlugin({
     },
 
     async onBeforeMessageSend(_, message) {
-        if (!settings.store.autoTranslate) return;
+        const channelId = getCurrentChannel()?.id;
+        const guildId = getCurrentGuild()?.id;
+        if (!shouldTranslate(channelId, guildId)) return;
         if (!message.content) return;
 
         setShouldShowTranslateEnabledTooltip?.(true);

--- a/src/plugins/translate/settings.tsx
+++ b/src/plugins/translate/settings.tsx
@@ -83,10 +83,27 @@ export const settings = definePluginSettings({
     manageTranslateSettings: {
         type: OptionType.COMPONENT,
         component: () => (
-            <Button onClick={openTranslateModal}>
+            <Button onClick={() => openTranslateModal()}>
                 Customize translation languages & Auto-Translate
             </Button>
         )
+    },
+    perServerAutoTranslate: {
+        type: OptionType.BOOLEAN,
+        description: "Save the auto translate setting per server instead of globally",
+    },
+    perServerScope: {
+        type: OptionType.SELECT,
+        description: "Whether the auto translate setting is saved per server or per channel",
+        options: [
+            { label: "Per Server & DM", value: "server", default: true },
+            { label: "Per Channel & DM", value: "channel" }
+        ]
+    },
+    perServerRecord: {
+        type: OptionType.CUSTOM,
+        hidden: true,
+        default: {} as Record<string, boolean>,
     }
 }, {
     deeplApiKey: {

--- a/src/plugins/translate/utils.ts
+++ b/src/plugins/translate/utils.ts
@@ -199,3 +199,20 @@ async function kagiTranslate(text: string, sourceLang: string, targetLang: strin
         text: translation
     };
 }
+
+// Returns whether the message should be translated based on the current settings and the channel/guild context
+export function shouldTranslate(channelId: string | undefined, guildId: string | null | undefined): boolean {
+    if (settings.store.perServerAutoTranslate && (channelId || guildId)) {
+        // It's a DM
+        if (!guildId) {
+            const record = settings.store.perServerRecord[channelId!];
+            return record ?? settings.store.autoTranslate;
+        }
+
+        // Search record for guildId or channelId based on the perServerScope setting
+        const record = settings.store.perServerRecord[settings.store.perServerScope === "server" ? guildId : channelId!];
+        return record ?? settings.store.autoTranslate;
+    }
+
+    return settings.store.autoTranslate;
+}

--- a/src/plugins/translate/utils.ts
+++ b/src/plugins/translate/utils.ts
@@ -201,7 +201,7 @@ async function kagiTranslate(text: string, sourceLang: string, targetLang: strin
 }
 
 // Returns whether the message should be translated based on the current settings and the channel/guild context
-export function shouldTranslate(channelId: string | undefined, guildId: string | null | undefined): boolean {
+export function shouldTranslate(channelId: string | undefined, guildId: string | undefined): boolean {
     if (settings.store.perServerAutoTranslate && (channelId || guildId)) {
         // It's a DM
         if (!guildId) {
@@ -210,9 +210,14 @@ export function shouldTranslate(channelId: string | undefined, guildId: string |
         }
 
         // Search record for guildId or channelId based on the perServerScope setting
-        const record = settings.store.perServerRecord[settings.store.perServerScope === "server" ? guildId : channelId!];
+        const record = settings.store.perServerRecord[getScopeKey(channelId, guildId)];
         return record ?? settings.store.autoTranslate;
     }
 
     return settings.store.autoTranslate;
+}
+
+// Return the record key to use in perServerRecord
+export function getScopeKey(channelId: string | undefined, guildId: string | undefined): string {
+    return settings.store.perServerScope === "server" && guildId ? guildId : channelId!;
 }


### PR DESCRIPTION
## Describe your Changes
This pull request adds new settings to the `Translate` plugin, as requested in #4435

`Per Server Auto Translate` and `Per Server Scope` allow users to have the auto-translate settings enabled globally (which is the current default) or configured per channel/server. When `Per Server Auto Translate` is enabled, the auto-translate on/off toggle state is stored alongside the guild or channel ID in a record, ensuring it is only applied to that specific context.

Closes #4435 
## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
