### PR TITLE
New plugin: AutoJumpToMessage

### DIFF
--- a/src/plugins/AutoJumpToMessage/index.ts
+++ b/src/plugins/AutoJumpToMessage/index.ts
@@ -1,19 +1,21 @@
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
-import { definePluginSettings } from "@api/Settings";
 import { ChannelRouter, FluxDispatcher } from "@webpack/common";
 
 const settings = definePluginSettings({
     onlyWhenOutOfFocus: {
         type: OptionType.BOOLEAN,
         default: true,
-        description: "Only automatically jump to messages when Discord's window is out of focus.",
-    }
+        description:
+            "Only automatically jump to messages when Discord's window is out of focus.",
+    },
 });
 
 export default definePlugin({
     name: "AutoJumpToMessage",
-    description: "Automatically opens the channel from new messages. Muted channels are ignored. Made for those who keep Discord on another monitor.",
+    description:
+        "Automatically opens the channel from new messages. Muted channels are ignored. Made for those who keep Discord on another monitor.",
     tags: ["Chat", "Utility"],
     searchTerms: ["jump", "message", "auto", "notification", "focus"],
     authors: [Devs.k304, Devs.k304],
@@ -37,12 +39,18 @@ export default definePlugin({
     },
 
     start() {
-        FluxDispatcher.subscribe("RPC_NOTIFICATION_CREATE", this.handleNotification);
+        FluxDispatcher.subscribe(
+            "RPC_NOTIFICATION_CREATE",
+            this.handleNotification,
+        );
         console.log("AutoJumpToMessage plugin is UP!.");
     },
 
     stop() {
-        FluxDispatcher.unsubscribe("RPC_NOTIFICATION_CREATE", this.handleNotification);
+        FluxDispatcher.unsubscribe(
+            "RPC_NOTIFICATION_CREATE",
+            this.handleNotification,
+        );
         console.log("AutoJumpToMessage plugin stoped.");
     },
 });

--- a/src/plugins/AutoJumpToMessage/index.ts
+++ b/src/plugins/AutoJumpToMessage/index.ts
@@ -4,11 +4,11 @@ import definePlugin, { OptionType } from "@utils/types";
 import { ChannelRouter, FluxDispatcher } from "@webpack/common";
 
 const settings = definePluginSettings({
-    onlyWhenOutOfFocus: {
+    onlyWhenUnfocused: {
         type: OptionType.BOOLEAN,
         default: true,
         description:
-            "Only automatically jump to messages when Discord's window is out of focus.",
+            "Only automatically jump to messages when Discord's window is unfocused.",
     },
 });
 
@@ -17,7 +17,7 @@ export default definePlugin({
     description:
         "Automatically opens the channel from new messages. Muted channels are ignored. Made for those who keep Discord on another monitor.",
     tags: ["Chat", "Utility"],
-    searchTerms: ["jump", "message", "auto", "notification", "focus"],
+    searchTerms: ["jump", "message", "auto", "notification", "focus", "unfocused"],
     authors: [Devs.k304, Devs.k304],
     settings,
 
@@ -26,7 +26,7 @@ export default definePlugin({
 
         if (payload.type === "RPC_NOTIFICATION_CREATE") {
             // Dont do anything if discord is in focus
-            if (settings.store.onlyWhenOutOfFocus && document.hasFocus()) {
+            if (settings.store.onlyWhenUnfocused && document.hasFocus()) {
                 return;
             }
 

--- a/src/plugins/AutoJumpToMessage/index.ts
+++ b/src/plugins/AutoJumpToMessage/index.ts
@@ -1,0 +1,48 @@
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { definePluginSettings } from "@api/Settings";
+import { ChannelRouter, FluxDispatcher } from "@webpack/common";
+
+const settings = definePluginSettings({
+    onlyWhenOutOfFocus: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Only automatically jump to messages when Discord's window is out of focus.",
+    }
+});
+
+export default definePlugin({
+    name: "AutoJumpToMessage",
+    description: "Automatically opens the channel from new messages. Muted channels are ignored. Made for those who keep Discord on another monitor.",
+    tags: ["Chat", "Utility"],
+    searchTerms: ["jump", "message", "auto", "notification", "focus"],
+    authors: [Devs.k304, Devs.k304],
+    settings,
+
+    handleNotification(payload: any) {
+        if (!payload) return;
+
+        if (payload.type === "RPC_NOTIFICATION_CREATE") {
+            // Dont do anything if discord is in focus
+            if (settings.store.onlyWhenOutOfFocus && document.hasFocus()) {
+                return;
+            }
+
+            const channelId = payload.channelId;
+
+            if (channelId) {
+                ChannelRouter.transitionToChannel(channelId);
+            }
+        }
+    },
+
+    start() {
+        FluxDispatcher.subscribe("RPC_NOTIFICATION_CREATE", this.handleNotification);
+        console.log("AutoJumpToMessage plugin is UP!.");
+    },
+
+    stop() {
+        FluxDispatcher.unsubscribe("RPC_NOTIFICATION_CREATE", this.handleNotification);
+        console.log("AutoJumpToMessage plugin stoped.");
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -657,6 +657,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     yuna0x0: {
         name: "yuna0x0",
         id: 213656926414831616n
+    },
+    k304: {
+        name: "k304",
+        id: 255004979637649408n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
## Describe your Changes

This plugin is a quality-of-life improvement for anyone who keeps Discord open on a second monitor.

I often find myself having to stop what I'm doing just to click on Discord, switch chats, and view a message I've received. This frequently happens when someone I'm on a call with wants to show me something, like: "Hey, I sent a screenshot/something to your chat."

I'm tired of that.

With this plugin, if someone sends me a message, the plugin automatically switches the active chat to the one containing the new message.

I tried to make the plugin as user-friendly as possible. By default (though this is configurable), it only performs these switches when the Discord window isn't in focus; we don't want to take control away from the user.

Also, muted channels are ignored. I see no point in jumping to every single message from every server I'm in, lol.

The trick I used to build this plugin is simple: the behavior hooks into Discord's own notification-generation event.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
