### PR TITLE
Add HiddenMessages plugin

### DIFF
--- a/src/plugins/hiddenMessages/crypto.ts
+++ b/src/plugins/hiddenMessages/crypto.ts
@@ -1,0 +1,178 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+const MARKER = "\u2063\u2062\u2064\u2063";
+const ALPHABET = "\u200C\u200D\u2060\u2061";
+const LEGACY_MARKER = "\u2063\uFE00\uFE01\uFE02\uFE03";
+const AAD = new TextEncoder().encode("Vencord HiddenMessages v1");
+const ITERATIONS = 310_000;
+const SALT_BYTES = 16;
+const IV_BYTES = 12;
+const OPEN_KEY_BYTES = 32;
+
+function encodeBytes(bytes: Uint8Array) {
+    let result = "";
+    for (const byte of bytes) {
+        result += ALPHABET[byte >> 6]
+            + ALPHABET[byte >> 4 & 3]
+            + ALPHABET[byte >> 2 & 3]
+            + ALPHABET[byte & 3];
+    }
+    return result;
+}
+
+function decodeBytes(encoded: string) {
+    if (!encoded || encoded.length % 4) throw new Error("Invalid hidden message");
+
+    const bytes = new Uint8Array(encoded.length / 4);
+    for (let i = 0; i < encoded.length; i += 4) {
+        const values = [...encoded.slice(i, i + 4)].map(char => ALPHABET.indexOf(char));
+        if (values.some(value => value < 0)) throw new Error("Invalid hidden message");
+        bytes[i / 4] = values[0] << 6 | values[1] << 4 | values[2] << 2 | values[3];
+    }
+    return bytes;
+}
+
+function decodeLegacyBytes(encoded: string) {
+    if (!encoded || encoded.length % 2) throw new Error("Invalid hidden message");
+
+    const bytes = new Uint8Array(encoded.length / 2);
+    for (let i = 0; i < encoded.length; i += 2) {
+        const high = encoded.charCodeAt(i) - 0xFE00;
+        const low = encoded.charCodeAt(i + 1) - 0xFE00;
+        if (high < 0 || high > 15 || low < 0 || low > 15) throw new Error("Invalid hidden message");
+        bytes[i / 2] = high << 4 | low;
+    }
+    return bytes;
+}
+
+function getPacket(content: string) {
+    const start = content.lastIndexOf(MARKER);
+    if (start >= 0) {
+        const payloadStart = start + MARKER.length;
+        let payloadEnd = payloadStart;
+        while (payloadEnd < content.length && ALPHABET.includes(content[payloadEnd])) payloadEnd++;
+        return decodeBytes(content.slice(payloadStart, payloadEnd));
+    }
+
+    const legacyStart = content.lastIndexOf(LEGACY_MARKER);
+    if (legacyStart >= 0) return decodeLegacyBytes(content.slice(legacyStart + LEGACY_MARKER.length));
+    throw new Error("No hidden message");
+}
+
+async function deriveKey(password: string, salt: Uint8Array, usage: KeyUsage) {
+    const material = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(password),
+        "PBKDF2",
+        false,
+        ["deriveKey"]
+    );
+
+    return crypto.subtle.deriveKey(
+        { name: "PBKDF2", salt: salt as BufferSource, iterations: ITERATIONS, hash: "SHA-256" },
+        material,
+        { name: "AES-GCM", length: 256 },
+        false,
+        [usage]
+    );
+}
+
+function importKey(bytes: Uint8Array, usage: KeyUsage) {
+    return crypto.subtle.importKey("raw", bytes, "AES-GCM", false, [usage]);
+}
+
+export async function hideMessage(publicMessage: string, hiddenMessage: string, password: string | null) {
+    const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+    const saltOrKey = crypto.getRandomValues(new Uint8Array(password === null ? OPEN_KEY_BYTES : SALT_BYTES));
+    const key = password === null
+        ? await importKey(saltOrKey, "encrypt")
+        : await deriveKey(password, saltOrKey, "encrypt");
+    const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv, additionalData: AAD },
+        key,
+        new TextEncoder().encode(hiddenMessage)
+    ));
+
+    const packet = new Uint8Array(1 + saltOrKey.length + iv.length + ciphertext.length);
+    packet[0] = password === null ? 2 : 1;
+    packet.set(saltOrKey, 1);
+    packet.set(iv, 1 + saltOrKey.length);
+    packet.set(ciphertext, 1 + saltOrKey.length + iv.length);
+    const firstWhitespace = publicMessage.search(/\s/);
+    const characters = [...publicMessage];
+    const insertionPoint = firstWhitespace >= 0 && firstWhitespace < publicMessage.length - 1
+        ? firstWhitespace + 1
+        : characters.length > 1
+            ? characters[0].length
+            : 0;
+
+    return publicMessage.slice(0, insertionPoint)
+        + MARKER + encodeBytes(packet)
+        + publicMessage.slice(insertionPoint);
+}
+
+export function hasHiddenMessage(content: string) {
+    try {
+        const packet = getPacket(content);
+        return packet[0] === 1
+            ? packet.length >= 1 + SALT_BYTES + IV_BYTES + 16
+            : packet[0] === 2 && packet.length >= 1 + OPEN_KEY_BYTES + IV_BYTES + 16;
+    } catch {
+        return false;
+    }
+}
+
+export function requiresPassword(content: string) {
+    const packet = getPacket(content);
+    if (packet[0] === 1) return true;
+    if (packet[0] === 2) return false;
+    throw new Error("Invalid hidden message");
+}
+
+export async function revealMessage(content: string, password = "") {
+    const packet = getPacket(content);
+    const keyBytes = packet[0] === 1 ? SALT_BYTES : packet[0] === 2 ? OPEN_KEY_BYTES : 0;
+    if (!keyBytes || packet.length < 1 + keyBytes + IV_BYTES + 16)
+        throw new Error("Invalid hidden message");
+
+    const saltOrKey = packet.slice(1, 1 + keyBytes);
+    const iv = packet.slice(1 + keyBytes, 1 + keyBytes + IV_BYTES);
+    const ciphertext = packet.slice(1 + keyBytes + IV_BYTES);
+    const key = packet[0] === 1
+        ? await deriveKey(password, saltOrKey, "decrypt")
+        : await importKey(saltOrKey, "decrypt");
+
+    try {
+        return new TextDecoder("utf-8", { fatal: true }).decode(await crypto.subtle.decrypt(
+            { name: "AES-GCM", iv, additionalData: AAD },
+            key,
+            ciphertext
+        ));
+    } catch {
+        throw new Error("Wrong password or damaged message");
+    }
+}
+
+export async function selfTest() {
+    const visible = "Hey everyone!";
+    const secret = "I'm hiding this message! 🔒";
+    const content = await hideMessage(visible, secret, "Password1234");
+    const rendered = [...content].filter(char => !ALPHABET.includes(char) && !MARKER.includes(char)).join("");
+    if (rendered !== visible || !hasHiddenMessage(content)) throw new Error("Encoding failed");
+    if (await revealMessage(content, "Password1234") !== secret) throw new Error("Decryption failed");
+
+    try {
+        await revealMessage(content, "wrong");
+        throw new Error("Wrong password was accepted");
+    } catch (error) {
+        if ((error as Error).message === "Wrong password was accepted") throw error;
+    }
+
+    const openContent = await hideMessage(visible, secret, null);
+    if (requiresPassword(openContent) || await revealMessage(openContent) !== secret)
+        throw new Error("No-password mode failed");
+}

--- a/src/plugins/hiddenMessages/index.tsx
+++ b/src/plugins/hiddenMessages/index.tsx
@@ -1,0 +1,303 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
+import { Flex } from "@components/Flex";
+import { FormSwitch } from "@components/FormSwitch";
+import { HeadingSecondary } from "@components/Heading";
+import { sendMessage } from "@utils/discord";
+import definePlugin, { IconComponent } from "@utils/types";
+import type { RenderModalProps } from "@vencord/discord-types";
+import {
+    ChannelStore,
+    FluxDispatcher,
+    MessageActions,
+    Modal,
+    openModal,
+    PendingReplyStore,
+    showToast,
+    TextArea,
+    TextInput,
+    Toasts,
+    useEffect,
+    useState
+} from "@webpack/common";
+
+import { hasHiddenMessage, hideMessage, requiresPassword, revealMessage, selfTest } from "./crypto";
+
+// ponytail: session tombstones match Vencord's temporary logger; persist them if logger persistence is added.
+const revokedMessages = new Set<string>();
+const activeUnlocks = new Map<string, () => void>();
+
+function revokeMessage(messageId: string) {
+    revokedMessages.add(messageId);
+    activeUnlocks.get(messageId)?.();
+    activeUnlocks.delete(messageId);
+}
+const LockIcon: IconComponent = ({ height = 20, width = 20, className }) => (
+    <svg
+        aria-hidden="true"
+        className={className}
+        fill="currentColor"
+        height={height}
+        viewBox="0 0 24 24"
+        width={width}
+    >
+        <path d="M17 8h-1V6a4 4 0 0 0-8 0v2H7a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-9a2 2 0 0 0-2-2Zm-7-2a2 2 0 1 1 4 0v2h-4v-2Zm3 10.73V18h-2v-1.27a2 2 0 1 1 2 0Z" />
+    </svg>
+);
+
+function UnlockModal({ content, initialRevealed = "", messageId, modalProps }: {
+    content: string;
+    initialRevealed?: string;
+    messageId: string;
+    modalProps: RenderModalProps;
+}) {
+    const [password, setPassword] = useState("");
+    const [revealed, setRevealed] = useState(initialRevealed);
+    const [error, setError] = useState("");
+    const [busy, setBusy] = useState(false);
+
+    useEffect(() => {
+        const close = () => {
+            setRevealed("");
+            modalProps.onClose();
+        };
+        activeUnlocks.set(messageId, close);
+        return () => {
+            if (activeUnlocks.get(messageId) === close) activeUnlocks.delete(messageId);
+        };
+    }, [messageId, modalProps.onClose]);
+
+    async function unlock() {
+        if (revokedMessages.has(messageId)) return modalProps.onClose();
+        setBusy(true);
+        setError("");
+        try {
+            const plaintext = await revealMessage(content, password);
+            if (revokedMessages.has(messageId)) return modalProps.onClose();
+            setRevealed(plaintext);
+        } catch (e) {
+            setRevealed("");
+            setError((e as Error).message);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    return (
+        <Modal
+            {...modalProps}
+            title={revealed ? "Hidden Message Unlocked" : "Unlock Hidden Message"}
+            subtitle="The password is checked locally and is never stored or sent."
+            actions={[
+                { text: "Close", variant: "secondary", onClick: modalProps.onClose },
+                ...revealed ? [] : [{
+                    text: busy ? "Unlocking…" : "Unlock",
+                    variant: "primary" as const,
+                    disabled: !password || busy,
+                    onClick: unlock
+                }]
+            ]}
+        >
+            <Flex flexDirection="column" gap={12}>
+                {!revealed && (
+                    <section>
+                        <HeadingSecondary>Password</HeadingSecondary>
+                        <TextInput
+                            autoFocus
+                            type="password"
+                            value={password}
+                            onChange={setPassword}
+                            onKeyDown={e => e.key === "Enter" && password && !busy && unlock()}
+                            placeholder="Enter password"
+                        />
+                    </section>
+                )}
+                {error && <div style={{ color: "var(--text-danger)" }}>{error}</div>}
+                {revealed && (
+                    <div style={{
+                        background: "var(--background-secondary)",
+                        border: "1px solid var(--border-subtle)",
+                        borderRadius: 8,
+                        color: "var(--text-normal)",
+                        padding: 14,
+                        whiteSpace: "pre-wrap",
+                        wordBreak: "break-word"
+                    }}>
+                        {revealed}
+                    </div>
+                )}
+            </Flex>
+        </Modal>
+    );
+}
+
+async function openUnlockModal(content: string, messageId: string) {
+    if (revokedMessages.has(messageId)) return;
+
+    if (!requiresPassword(content)) {
+        try {
+            const revealed = await revealMessage(content);
+            if (revokedMessages.has(messageId)) return;
+            openModal(modalProps => (
+                <UnlockModal content={content} initialRevealed={revealed} messageId={messageId} modalProps={modalProps} />
+            ));
+        } catch {
+            showToast("Hidden message is damaged", Toasts.Type.FAILURE);
+        }
+        return;
+    }
+
+    openModal(modalProps => <UnlockModal content={content} messageId={messageId} modalProps={modalProps} />);
+}
+
+function ComposeModal({ channelId, modalProps }: { channelId: string; modalProps: RenderModalProps; }) {
+    const [publicMessage, setPublicMessage] = useState("");
+    const [hiddenMessage, setHiddenMessage] = useState("");
+    const [password, setPassword] = useState("");
+    const [noPassword, setNoPassword] = useState(false);
+    const [error, setError] = useState("");
+    const [busy, setBusy] = useState(false);
+
+    async function send() {
+        setBusy(true);
+        setError("");
+        try {
+            const content = await hideMessage(publicMessage, hiddenMessage, noPassword ? null : password);
+            if (content.length > 2000)
+                throw new Error(`Encrypted message is ${content.length - 2000} characters over Discord's limit.`);
+
+            await sendMessage(
+                channelId,
+                { content },
+                false,
+                MessageActions.getSendMessageOptionsForReply(PendingReplyStore.getPendingReply(channelId))
+            );
+            FluxDispatcher.dispatch({ type: "DELETE_PENDING_REPLY", channelId });
+            modalProps.onClose();
+            showToast("Encrypted hidden message sent", Toasts.Type.SUCCESS);
+        } catch (e) {
+            setError((e as Error).message || "Could not send hidden message");
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    return (
+        <Modal
+            {...modalProps}
+            title="Send Hidden Message"
+            subtitle={noPassword ? "Everyone sees the public message. Plugin users can unlock the hidden message instantly." : "Everyone sees the public message. Plugin users need your password to unlock it."}
+            actions={[
+                { text: "Cancel", variant: "secondary", onClick: modalProps.onClose },
+                {
+                    text: busy ? "Encrypting…" : "Send",
+                    variant: "primary",
+                    disabled: !publicMessage.trim() || !hiddenMessage.trim() || (!noPassword && !password) || busy,
+                    onClick: send
+                }
+            ]}
+        >
+            <Flex flexDirection="column" gap={14}>
+                <section>
+                    <HeadingSecondary>Message everyone will see</HeadingSecondary>
+                    <TextArea
+                        autoFocus
+                        autosize
+                        maxLength={1900}
+                        value={publicMessage}
+                        onChange={setPublicMessage}
+                        placeholder="Hey everyone!"
+                    />
+                </section>
+                <section>
+                    <HeadingSecondary>Hidden message</HeadingSecondary>
+                    <TextArea
+                        autosize
+                        value={hiddenMessage}
+                        onChange={setHiddenMessage}
+                        placeholder="I'm hiding this message!"
+                    />
+                </section>
+                <FormSwitch
+                    title="No Password Mode"
+                    description="Anyone with HiddenMessages can unlock it instantly."
+                    value={noPassword}
+                    onChange={setNoPassword}
+                />
+                {!noPassword && (
+                    <section>
+                        <HeadingSecondary>Password</HeadingSecondary>
+                        <TextInput
+                            type="password"
+                            value={password}
+                            onChange={setPassword}
+                            placeholder="Use a long, unique password"
+                        />
+                    </section>
+                )}
+                {error && <div style={{ color: "var(--text-danger)" }}>{error}</div>}
+                <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+                    AES-256-GCM · {noPassword ? "embedded random key" : "PBKDF2-SHA-256"} · random nonce
+                </div>
+            </Flex>
+        </Modal>
+    );
+}
+
+const ComposeButton: ChatBarButtonFactory = ({ isAnyChat, channel }) => {
+    if (!isAnyChat) return null;
+    return (
+        <ChatBarButton
+            tooltip="Send Hidden Message"
+            onClick={() => openModal(modalProps => <ComposeModal channelId={channel.id} modalProps={modalProps} />)}
+            buttonProps={{ "aria-haspopup": "dialog" }}
+        >
+            <LockIcon />
+        </ChatBarButton>
+    );
+};
+
+export default definePlugin({
+    name: "HiddenMessages",
+    description: "Encrypt hidden text inside an otherwise normal Discord message. Credits: Marmo1133.",
+    authors: [{ name: "MermoTEC", id: 839177393913856051 }],
+    tags: ["Chat", "Privacy"],
+    dependencies: ["MessagePopoverAPI", "ChatInputButtonAPI"],
+
+    chatBarButton: {
+        icon: LockIcon,
+        render: ComposeButton
+    },
+
+    messagePopoverButton: {
+        icon: LockIcon,
+        render(message) {
+            if (revokedMessages.has(message.id) || !hasHiddenMessage(message.content)) return null;
+            const channel = ChannelStore.getChannel(message.channel_id);
+            if (!channel) return null;
+            return {
+                label: "Unlock Hidden Message",
+                icon: LockIcon,
+                message,
+                channel,
+                onClick: () => openUnlockModal(message.content, message.id)
+            };
+        }
+    },
+
+    flux: {
+        MESSAGE_DELETE({ id }: { id: string; }) {
+            revokeMessage(id);
+        },
+        MESSAGE_DELETE_BULK({ ids }: { ids: string[]; }) {
+            ids.forEach(revokeMessage);
+        }
+    },
+
+    selfTest
+});


### PR DESCRIPTION
## HiddenMessages plugin

Adds optional encrypted hidden messages inside normal Discord messages.

### Features
- Composer lock button for creating hidden messages.
- AES-256-GCM encryption with password protection.
- Optional “No Password Mode” for plugin users.
- Lock icon appears in the message hover toolbar when hidden content exists.
- Unlock modal for viewing hidden content.
- Invisible Unicode payload embedded in the visible message.
- Credits included for Marmo1133.

### Testing
- Verified password mode and incorrect-password rejection.
- Verified no-password mode.
- Verified visible messages remain readable for users without the plugin.