### PR TITLE
Allow gist.githubusercontent.com as an asset source

### DIFF
--- a/src/main/csp/index.ts
+++ b/src/main/csp/index.ts
@@ -28,6 +28,7 @@ export const CspPolicies: PolicyMap = {
     "*.github.io": ImageAndCssSrc, // GitHub pages, used by most themes
     "github.com": ImageAndCssSrc, // GitHub content (stuff uploaded to markdown forms), used by most themes
     "raw.githubusercontent.com": ImageAndCssSrc, // GitHub raw, used by some themes
+    "gist.githubusercontent.com": ImageAndCssSrc, // GitHub Gist raw, used by some themes
     "*.gitlab.io": ImageAndCssSrc, // GitLab pages, used by some themes
     "gitlab.com": ImageAndCssSrc, // GitLab raw, used by some themes
     "*.codeberg.page": ImageAndCssSrc, // Codeberg pages, used by some themes


### PR DESCRIPTION
## Describe your Changes
This PR makes support for themes hosted as GitHub Gists more obvious. It technically doesn't unlock anything new, since it seems that any `gist.githubusercontent.com/*` link can be rewritten to `raw.githubusercontent.com/gist/*`, but the former is what the `Raw` button provides.

## Checklist before submitting
- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [X] This pull request was written by me, and not an AI agent
