### PR TITLE
fix edge case where Discord installs can go corrupt

### DIFF
--- a/src/main/persistAfterDiscordUpdates.ts
+++ b/src/main/persistAfterDiscordUpdates.ts
@@ -54,7 +54,7 @@ function patchLatest() {
         const newAppAsar = join(resources, "app.asar");
         const newAppAsarBackup = join(resources, "_app.asar");
 
-        if (!existsSync(oldVencordAsar) || !existsSync(newAppAsar)) return;
+        if (!existsSync(oldVencordAsar) || !existsSync(newAppAsar) || existsSync(newAppAsarBackup)) return;
 
         console.info(`[Vencord] Detected Host Update (${currentVersion} -> ${latestVersion}). Repatching...`);
 


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

The `persistAfterDiscordUpdates` sometimes causes the Discord installation to be corrupted and unusable on Linux unless Discord is deleted from `~/.config/discord`.

Sometimes after downloading a new update, Discord's updater/launcher will still open the old version (who knows why), which causes the patchLatest function  to be trigger and rename the `app.asar` to `_app.asar` even though `app.asar` has already been overwritten, contains Vencord's launcher, causing Discord to completely break unless reinstalled.

This has been happening to some users recently using Linux (you can check in the support channel) as I experienced this issue too, and I originally thought it was discord being discord but it's actually because of Vencord.

<img width="1094" height="287" alt="image" src="https://github.com/user-attachments/assets/58b7ef4b-655c-4ee2-9b80-8aedb8b54efd" />

i tried my best to explain the issue

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
