### PR TITLE
ReplaceGoogleSearch: add Kagi

### DIFF
--- a/src/plugins/replaceGoogleSearch/index.tsx
+++ b/src/plugins/replaceGoogleSearch/index.tsx
@@ -21,7 +21,8 @@ const DefaultEngines = {
     GitHub: "https://github.com/search?q=",
     Reddit: "https://www.reddit.com/search?q=",
     Wikipedia: "https://wikipedia.org/w/index.php?search=",
-    Startpage: "https://www.startpage.com/sp/search?query="
+    Startpage: "https://www.startpage.com/sp/search?query=",
+    Kagi: "https://kagi.com/search?q="
 } as const;
 
 const enum ReplacementEngineValue {


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
Added [Kagi](https://www.kagi.com/) as an option for [ReplaceGoogleSearch](https://vencord.dev/plugins/ReplaceGoogleSearch) plugin.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
