### PR TITLE
Add Context Pins plugin

### DIFF
--- a/src/plugins/contextPins/components/ContextPinsModal.tsx
+++ b/src/plugins/contextPins/components/ContextPinsModal.tsx
@@ -1,0 +1,342 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Button, TextButton } from "@components/Button";
+import {
+    getPins,
+    getStorageError,
+    getStorageState,
+    makePinKey,
+    type StoredPin,
+    subscribe,
+} from "@plugins/contextPins/storage";
+import { copyWithToast } from "@utils/discord";
+import type { RenderModalProps } from "@vencord/discord-types";
+import {
+    ChannelStore,
+    Forms,
+    MessageActions,
+    MessageStore,
+    PermissionsBits,
+    PermissionStore,
+    ScrollerThin,
+    SearchableSelect,
+    Select,
+    Text,
+    TextInput,
+    Timestamp,
+    useEffect,
+    useMemo,
+    useReducer,
+    useState,
+} from "@webpack/common";
+
+interface Props {
+    modalProps: RenderModalProps;
+    onEdit(pin: StoredPin): void;
+    onDelete(pin: StoredPin): void;
+}
+
+interface FilterOption {
+    label: string;
+    value: string;
+}
+
+type SortOrder = "newest" | "oldest";
+
+type Availability = {
+    label: string;
+    canOpen: boolean;
+};
+
+function makeFilterOptions(pins: StoredPin[], field: "tags" | "guildName" | "channelName" | "authorName"): FilterOption[] {
+    const values = new Set<string>();
+    for (const pin of pins) {
+        if (field === "tags") {
+            pin.tags.forEach(tag => values.add(tag));
+        } else {
+            const value = pin[field];
+            if (value) values.add(value);
+        }
+    }
+
+    return [
+        { label: "All", value: "" },
+        ...Array.from(values)
+            .sort((a, b) => a.localeCompare(b))
+            .map(value => ({ label: value, value })),
+    ];
+}
+
+function getAvailability(pin: StoredPin): Availability {
+    const channel = ChannelStore.getChannel(pin.channelId);
+    if (!channel) return { label: "Channel unavailable", canOpen: false };
+    if (!channel.isPrivate() && !PermissionStore.can(PermissionsBits.VIEW_CHANNEL, channel)) {
+        return { label: "Channel unavailable", canOpen: false };
+    }
+
+    const message = MessageStore.getMessage(pin.channelId, pin.messageId);
+    if (message?.deleted) return { label: "Original message deleted", canOpen: false };
+    if (message) return { label: "Original message available", canOpen: true };
+
+    return { label: "Original message not currently loaded", canOpen: true };
+}
+
+function searchableText(pin: StoredPin) {
+    return [
+        pin.content,
+        pin.note,
+        pin.authorName,
+        pin.channelName,
+        pin.guildName,
+        ...pin.tags,
+    ].filter(Boolean).join(" ").toLocaleLowerCase();
+}
+
+function PinRow({ pin, onEdit, onDelete, onClose }: {
+    pin: StoredPin;
+    onEdit(pin: StoredPin): void;
+    onDelete(pin: StoredPin): void;
+    onClose(): void;
+}) {
+    const availability = getAvailability(pin);
+    const indicators = [
+        pin.attachmentCount && `${pin.attachmentCount} attachment${pin.attachmentCount === 1 ? "" : "s"}`,
+        pin.embedCount && `${pin.embedCount} embed${pin.embedCount === 1 ? "" : "s"}`,
+        pin.stickerCount && `${pin.stickerCount} sticker${pin.stickerCount === 1 ? "" : "s"}`,
+    ].filter(Boolean);
+
+    function openOriginal() {
+        if (!availability.canOpen) return;
+        onClose();
+        MessageActions.jumpToMessage({
+            channelId: pin.channelId,
+            messageId: pin.messageId,
+            flash: true,
+            jumpType: "INSTANT",
+        });
+    }
+
+    function copyMessageLink() {
+        const guildId = pin.guildId ?? "@me";
+        copyWithToast(
+            `https://discord.com/channels/${guildId}/${pin.channelId}/${pin.messageId}`,
+            "Message link copied."
+        );
+    }
+
+    return (
+        <article className="vc-context-pins-row" role="listitem">
+            <div className="vc-context-pins-row-header">
+                <Text variant="text-sm/semibold">{pin.authorName}</Text>
+                <span className="vc-context-pins-row-location">
+                    {pin.guildName ? `${pin.guildName} · ` : ""}{pin.channelName}
+                </span>
+                <Timestamp timestamp={new Date(pin.messageTimestamp)} />
+            </div>
+            <div className="vc-context-pins-row-content">
+                {pin.content || <span className="vc-context-pins-muted">No text content</span>}
+            </div>
+            {pin.note && <div className="vc-context-pins-row-note">{pin.note}</div>}
+            <div className="vc-context-pins-row-meta">
+                <span className={availability.canOpen ? "" : "vc-context-pins-unavailable"}>{availability.label}</span>
+                {indicators.length > 0 && <span>{indicators.join(" · ")}</span>}
+                {pin.tags.length > 0 && (
+                    <div className="vc-context-pins-tags" aria-label="Tags">
+                        {pin.tags.map(tag => <span className="vc-context-pins-tag" key={tag}>{tag}</span>)}
+                    </div>
+                )}
+            </div>
+            <div className="vc-context-pins-row-actions">
+                <Button variant="secondary" size="small" onClick={openOriginal} disabled={!availability.canOpen}>
+                    Open original
+                </Button>
+                <TextButton variant="secondary" onClick={copyMessageLink}>Copy link</TextButton>
+                <TextButton variant="primary" onClick={() => onEdit(pin)}>Edit</TextButton>
+                <TextButton variant="danger" onClick={() => onDelete(pin)}>Delete</TextButton>
+            </div>
+        </article>
+    );
+}
+
+export default function ContextPinsModal({ modalProps, onEdit, onDelete }: Props) {
+    const [, refresh] = useReducer(value => value + 1, 0);
+    const [query, setQuery] = useState("");
+    const [tag, setTag] = useState("");
+    const [guild, setGuild] = useState("");
+    const [channel, setChannel] = useState("");
+    const [author, setAuthor] = useState("");
+    const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
+    const storageState = getStorageState();
+    const pins = getPins();
+
+    useEffect(() => subscribe(refresh), []);
+
+    const filterOptions = useMemo(() => ({
+        tags: makeFilterOptions(pins, "tags"),
+        guilds: makeFilterOptions(pins, "guildName"),
+        channels: makeFilterOptions(pins, "channelName"),
+        authors: makeFilterOptions(pins, "authorName"),
+    }), [pins]);
+
+    const hasActiveSearchOrFilters = Boolean(query.trim() || tag || guild || channel || author);
+
+    function clearSearchAndFilters() {
+        setQuery("");
+        setTag("");
+        setGuild("");
+        setChannel("");
+        setAuthor("");
+    }
+
+    const filteredPins = useMemo(() => {
+        const normalizedQuery = query.trim().toLocaleLowerCase();
+        return [...pins]
+            .sort((a, b) => sortOrder === "newest" ? b.createdAt - a.createdAt : a.createdAt - b.createdAt)
+            .filter(pin => {
+                if (normalizedQuery && !searchableText(pin).includes(normalizedQuery)) return false;
+                if (tag && !pin.tags.some(value => value.toLocaleLowerCase() === tag.toLocaleLowerCase())) return false;
+                if (guild && pin.guildName !== guild) return false;
+                if (channel && pin.channelName !== channel) return false;
+                if (author && pin.authorName !== author) return false;
+                return true;
+            });
+    }, [author, channel, guild, pins, query, sortOrder, tag]);
+
+    const storageError = getStorageError();
+    const resultSummary = hasActiveSearchOrFilters
+        ? `Showing ${filteredPins.length} of ${pins.length} ${pins.length === 1 ? "pin" : "pins"}`
+        : `${pins.length} ${pins.length === 1 ? "pin" : "pins"}`;
+
+    return (
+        <div className="vc-context-pins-modal-content">
+            {storageState === "loading" && (
+                <div className="vc-context-pins-state" role="status">Loading your Context Pins...</div>
+            )}
+            {storageState === "error" && (
+                <div className="vc-context-pins-state vc-context-pins-state-error" role="alert">
+                    {storageError?.message || "Context Pins storage is unavailable."}
+                </div>
+            )}
+            {storageState === "ready" && (
+                <>
+                    <div className="vc-context-pins-controls">
+                        <label className="vc-context-pins-search">
+                            <Forms.FormTitle tag="h5">Search</Forms.FormTitle>
+                            <TextInput
+                                value={query}
+                                onChange={setQuery}
+                                placeholder="Search your pins"
+                                aria-label="Search Context Pins"
+                            />
+                        </label>
+                        <div className="vc-context-pins-filters">
+                            <div className="vc-context-pins-filter">
+                                <Forms.FormTitle tag="h5">Tag</Forms.FormTitle>
+                                <SearchableSelect
+                                    options={filterOptions.tags}
+                                    value={tag}
+                                    onChange={setTag}
+                                    closeOnSelect={true}
+                                    placeholder="All"
+                                    maxVisibleItems={6}
+                                />
+                            </div>
+                            <div className="vc-context-pins-filter">
+                                <Forms.FormTitle tag="h5">Server</Forms.FormTitle>
+                                <SearchableSelect
+                                    options={filterOptions.guilds}
+                                    value={guild}
+                                    onChange={setGuild}
+                                    closeOnSelect={true}
+                                    placeholder="All"
+                                    maxVisibleItems={6}
+                                />
+                            </div>
+                            <div className="vc-context-pins-filter">
+                                <Forms.FormTitle tag="h5">Channel</Forms.FormTitle>
+                                <SearchableSelect
+                                    options={filterOptions.channels}
+                                    value={channel}
+                                    onChange={setChannel}
+                                    closeOnSelect={true}
+                                    placeholder="All"
+                                    maxVisibleItems={6}
+                                />
+                            </div>
+                            <div className="vc-context-pins-filter">
+                                <Forms.FormTitle tag="h5">Author</Forms.FormTitle>
+                                <SearchableSelect
+                                    options={filterOptions.authors}
+                                    value={author}
+                                    onChange={setAuthor}
+                                    closeOnSelect={true}
+                                    placeholder="All"
+                                    maxVisibleItems={6}
+                                />
+                            </div>
+                        </div>
+                        <div className="vc-context-pins-toolbar">
+                            <span className="vc-context-pins-result-count" aria-live="polite" aria-atomic="true">
+                                {resultSummary}
+                            </span>
+                            <div className="vc-context-pins-toolbar-actions">
+                                <div className="vc-context-pins-sort">
+                                    <Forms.FormTitle tag="h5">Sort by</Forms.FormTitle>
+                                    <Select
+                                        options={[
+                                            { label: "Newest saved", value: "newest", default: true },
+                                            { label: "Oldest saved", value: "oldest" },
+                                        ]}
+                                        select={value => setSortOrder(value as SortOrder)}
+                                        isSelected={value => value === sortOrder}
+                                        serialize={String}
+                                        closeOnSelect={true}
+                                        placeholder="Sort pins"
+                                    />
+                                </div>
+                                <TextButton
+                                    className="vc-context-pins-clear"
+                                    variant="secondary"
+                                    onClick={clearSearchAndFilters}
+                                    disabled={!hasActiveSearchOrFilters}
+                                >
+                                    Clear search and filters
+                                </TextButton>
+                            </div>
+                        </div>
+                    </div>
+
+                    {!pins.length ? (
+                        <div className="vc-context-pins-state">
+                            <Text variant="heading-md/semibold">No Context Pins yet</Text>
+                            <span>Save a message from its context menu to find it here.</span>
+                        </div>
+                    ) : !filteredPins.length ? (
+                        <div className="vc-context-pins-state">
+                            <Text variant="heading-md/semibold">No matching pins</Text>
+                            <span>Try changing your search or filters.</span>
+                        </div>
+                    ) : (
+                        <ScrollerThin className="vc-context-pins-list" orientation="auto">
+                            <div role="list">
+                                {filteredPins.map(pin => (
+                                    <PinRow
+                                        key={makePinKey(pin.channelId, pin.messageId)}
+                                        pin={pin}
+                                        onEdit={onEdit}
+                                        onDelete={onDelete}
+                                        onClose={modalProps.onClose}
+                                    />
+                                ))}
+                            </div>
+                        </ScrollerThin>
+                    )}
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/plugins/contextPins/components/PinEditorModal.tsx
+++ b/src/plugins/contextPins/components/PinEditorModal.tsx
@@ -1,0 +1,150 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import {
+    ContextPinsConflictError,
+    MAX_NOTE_LENGTH,
+    normalizeNote,
+    normalizeTags,
+    type PinKey,
+    type PinSnapshot,
+    type StoredPin,
+    upsertPin,
+} from "@plugins/contextPins/storage";
+import type { RenderModalProps } from "@vencord/discord-types";
+import { Forms, Modal, Text, TextArea, TextInput, Timestamp, Toasts, useState } from "@webpack/common";
+
+export interface PinEditorTarget {
+    key: PinKey;
+    snapshot: PinSnapshot;
+    note: string;
+    tags: string[];
+    expectedRevision: number | null;
+}
+
+interface Props {
+    modalProps: RenderModalProps;
+    target: PinEditorTarget;
+    onSaved?(pin: StoredPin): void;
+}
+
+function SnapshotPreview({ snapshot }: { snapshot: PinSnapshot; }) {
+    const indicators = [
+        snapshot.attachmentCount && `${snapshot.attachmentCount} attachment${snapshot.attachmentCount === 1 ? "" : "s"}`,
+        snapshot.embedCount && `${snapshot.embedCount} embed${snapshot.embedCount === 1 ? "" : "s"}`,
+        snapshot.stickerCount && `${snapshot.stickerCount} sticker${snapshot.stickerCount === 1 ? "" : "s"}`,
+    ].filter(Boolean);
+
+    return (
+        <div className="vc-context-pins-editor-preview">
+            <div className="vc-context-pins-editor-author">{snapshot.authorName}</div>
+            <div className="vc-context-pins-editor-location">
+                {snapshot.guildName ? `${snapshot.guildName} · ` : ""}{snapshot.channelName}
+                <span> · </span>
+                <Timestamp timestamp={new Date(snapshot.messageTimestamp)} />
+            </div>
+            <div className="vc-context-pins-editor-content">
+                {snapshot.content || <span className="vc-context-pins-muted">No text content</span>}
+            </div>
+            {indicators.length > 0 && (
+                <div className="vc-context-pins-editor-indicators">{indicators.join(" · ")}</div>
+            )}
+        </div>
+    );
+}
+
+export default function PinEditorModal({ modalProps, target, onSaved }: Props) {
+    const isEdit = target.expectedRevision !== null;
+    const [note, setNote] = useState(target.note);
+    const [tagsInput, setTagsInput] = useState(target.tags.join(", "));
+    const [saving, setSaving] = useState(false);
+    const [notice, setNotice] = useState<string>();
+
+    const noteResult = normalizeNote(note);
+    const tagsResult = normalizeTags(tagsInput);
+    const validationNotice = noteResult.error || tagsResult.error;
+
+    async function save() {
+        if (validationNotice || saving) return;
+
+        setSaving(true);
+        setNotice(undefined);
+        try {
+            const pin = await upsertPin({
+                key: target.key,
+                snapshot: target.snapshot,
+                note: noteResult.note,
+                tags: tagsResult.tags,
+            }, target.expectedRevision);
+
+            onSaved?.(pin);
+            Toasts.show({
+                message: isEdit ? "Context Pin updated." : "Message saved to Context Pins.",
+                type: Toasts.Type.SUCCESS,
+                id: Toasts.genId(),
+            });
+            modalProps.onClose();
+        } catch (error) {
+            if (error instanceof ContextPinsConflictError) {
+                setNotice(error.message);
+            } else {
+                setNotice("Context Pins could not save this change. Check the console for details.");
+            }
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    return (
+        <Modal
+            {...modalProps}
+            title={isEdit ? "Edit Context Pin" : "Save to Context Pins"}
+            subtitle="This message is stored locally on this Discord installation."
+            actions={[
+                {
+                    text: "Cancel",
+                    variant: "secondary",
+                    onClick: modalProps.onClose,
+                    disabled: saving,
+                },
+                {
+                    text: isEdit ? "Save changes" : "Save",
+                    variant: "primary",
+                    onClick: () => void save(),
+                    disabled: Boolean(validationNotice) || saving,
+                    loading: saving,
+                },
+            ]}
+            notice={(notice || validationNotice) ? { message: notice || validationNotice!, type: "critical" } : undefined}
+        >
+            <div className="vc-context-pins-editor">
+                <Forms.FormTitle tag="h5">Message</Forms.FormTitle>
+                <SnapshotPreview snapshot={target.snapshot} />
+
+                <Forms.FormTitle tag="h5">Note</Forms.FormTitle>
+                <TextArea
+                    value={note}
+                    onChange={setNote}
+                    placeholder="Add a personal note (optional)"
+                    maxLength={MAX_NOTE_LENGTH}
+                    autosize
+                />
+                <div className="vc-context-pins-field-hint">{note.length}/{MAX_NOTE_LENGTH}</div>
+
+                <Forms.FormTitle tag="h5">Tags</Forms.FormTitle>
+                <TextInput
+                    value={tagsInput}
+                    onChange={setTagsInput}
+                    placeholder="reference, todo, important"
+                    aria-label="Context Pin tags"
+                />
+                <Text variant="text-xs/normal" className="vc-context-pins-field-hint">
+                    Separate tags with commas. Up to 20 tags, 32 characters each.
+                </Text>
+            </div>
+        </Modal>
+    );
+}

--- a/src/plugins/contextPins/index.tsx
+++ b/src/plugins/contextPins/index.tsx
@@ -1,0 +1,270 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { definePluginSettings } from "@api/Settings";
+import { Button } from "@components/Button";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { Devs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+import definePlugin, { OptionType } from "@utils/types";
+import type { Message, RenderModalProps } from "@vencord/discord-types";
+import {
+    ChannelStore,
+    closeModal,
+    ConfirmModal,
+    GuildStore,
+    Menu,
+    Modal,
+    openModal,
+    Toasts,
+} from "@webpack/common";
+
+import ContextPinsModal from "./components/ContextPinsModal";
+import PinEditorModal, { PinEditorTarget } from "./components/PinEditorModal";
+import {
+    ContextPinsConflictError,
+    ContextPinsStorageError,
+    deletePin,
+    getPin,
+    getStorageState,
+    makePinKey,
+    PinSnapshot,
+    startStorage,
+    stopStorage,
+    StoredPin,
+} from "./storage";
+
+const logger = new Logger("ContextPins");
+const activeModalKeys = new Set<string>();
+
+function showToast(message: string, type = Toasts.Type.SUCCESS) {
+    Toasts.show({ message, type, id: Toasts.genId() });
+}
+
+function getAuthorName(message: Message) {
+    return message.author.globalName || message.author.username || "Unknown user";
+}
+
+function getChannelName(message: Message) {
+    const channel = ChannelStore.getChannel(message.channel_id);
+    if (channel?.name) return channel.name;
+    if (channel?.isGroupDM()) return "Group DM";
+    if (channel?.isPrivate()) return "Direct Message";
+    return "Unknown channel";
+}
+
+function createSnapshot(message: Message): PinSnapshot {
+    const channel = ChannelStore.getChannel(message.channel_id);
+    const guildId = channel?.guild_id ?? null;
+
+    return {
+        messageId: message.id,
+        channelId: message.channel_id,
+        guildId,
+        content: message.content || "",
+        authorId: message.author.id,
+        authorName: getAuthorName(message),
+        channelName: getChannelName(message),
+        guildName: guildId ? GuildStore.getGuild(guildId)?.name ?? null : null,
+        messageTimestamp: message.timestamp.getTime(),
+        attachmentCount: message.attachments.length,
+        embedCount: message.embeds.length,
+        stickerCount: message.stickerItems.length,
+    };
+}
+
+function trackModal(render: (modalProps: RenderModalProps, onClose: () => void) => React.ReactNode) {
+    let modalKey = "";
+    modalKey = openModal(modalProps => {
+        const onClose = () => {
+            activeModalKeys.delete(modalKey);
+            modalProps.onClose();
+        };
+
+        return render(modalProps, onClose);
+    });
+    activeModalKeys.add(modalKey);
+    return modalKey;
+}
+
+function openManager() {
+    trackModal((modalProps, onClose) => (
+        <ErrorBoundary>
+            <Modal {...modalProps} onClose={onClose} title="Context Pins" size="xl">
+                <ContextPinsModal
+                    modalProps={{ ...modalProps, onClose }}
+                    onEdit={openEditorForPin}
+                    onDelete={openDeleteConfirmation}
+                />
+            </Modal>
+        </ErrorBoundary>
+    ));
+}
+
+function openEditor(target: PinEditorTarget) {
+    trackModal((modalProps, onClose) => (
+        <ErrorBoundary>
+            <PinEditorModal
+                modalProps={{ ...modalProps, onClose }}
+                target={target}
+            />
+        </ErrorBoundary>
+    ));
+}
+
+function openEditorForMessage(message: Message) {
+    if (getStorageState() !== "ready") {
+        showToast("Context Pins is still loading. Try again in a moment.", Toasts.Type.FAILURE);
+        return;
+    }
+
+    const key = makePinKey(message.channel_id, message.id);
+    const existing = getPin(key);
+    openEditor({
+        key,
+        snapshot: createSnapshot(message),
+        note: existing?.note ?? "",
+        tags: existing?.tags ?? [],
+        expectedRevision: existing?.revision ?? null,
+    });
+}
+
+function openEditorForPin(pin: StoredPin) {
+    openEditor({
+        key: makePinKey(pin.channelId, pin.messageId),
+        snapshot: pin,
+        note: pin.note,
+        tags: pin.tags,
+        expectedRevision: pin.revision,
+    });
+}
+
+function openDeleteConfirmation(pin: StoredPin) {
+    trackModal((modalProps, onClose) => (
+        <ErrorBoundary>
+            <ConfirmModal
+                {...modalProps}
+                onClose={onClose}
+                title="Remove Context Pin"
+                subtitle="This only removes the local pin. The Discord message will not be changed."
+                confirmText="Remove pin"
+                cancelText="Cancel"
+                onConfirm={async setError => {
+                    try {
+                        await deletePin(makePinKey(pin.channelId, pin.messageId), pin.revision);
+                        showToast("Context Pin removed.");
+                    } catch (error) {
+                        if (error instanceof ContextPinsConflictError) {
+                            setError(error.message);
+                        } else {
+                            logger.error("Failed to remove pin", error);
+                            setError("Context Pin could not be removed. Check the console for details.");
+                        }
+                        throw error;
+                    }
+                }}
+            />
+        </ErrorBoundary>
+    ));
+}
+
+const messageContextMenuPatch: NavContextMenuPatchCallback = (
+    children,
+    { message }: { message?: Message; }
+) => {
+    if (!message) return;
+
+    const storageState = getStorageState();
+    const ready = storageState === "ready";
+    const pin = ready ? getPin(makePinKey(message.channel_id, message.id)) : undefined;
+
+    children.push(
+        <Menu.MenuItem
+            id="vc-context-pins-menu"
+            label="Context Pins"
+        >
+            {storageState === "loading" && (
+                <Menu.MenuItem
+                    id="vc-context-pins-loading"
+                    label="Context Pins is loading..."
+                    disabled
+                />
+            )}
+            {storageState === "error" && (
+                <Menu.MenuItem
+                    id="vc-context-pins-error"
+                    label="Context Pins unavailable"
+                    disabled
+                />
+            )}
+            {ready && !pin && (
+                <Menu.MenuItem
+                    id="vc-context-pins-save"
+                    label="Save to Context Pins"
+                    action={() => openEditorForMessage(message)}
+                />
+            )}
+            {ready && pin && (
+                <>
+                    <Menu.MenuItem
+                        id="vc-context-pins-edit"
+                        label="Edit Context Pin"
+                        action={() => openEditorForMessage(message)}
+                    />
+                    <Menu.MenuItem
+                        id="vc-context-pins-remove"
+                        label="Remove from Context Pins"
+                        color="danger"
+                        action={() => openDeleteConfirmation(pin)}
+                    />
+                </>
+            )}
+            <Menu.MenuItem
+                id="vc-context-pins-manage"
+                label="Manage Context Pins"
+                action={openManager}
+            />
+        </Menu.MenuItem>
+    );
+};
+
+const settings = definePluginSettings({
+    managePins: {
+        type: OptionType.COMPONENT,
+        component: () => (
+            <Button onClick={openManager}>
+                Manage Context Pins
+            </Button>
+        ),
+    },
+});
+
+export default definePlugin({
+    name: "ContextPins",
+    description: "Saves Discord messages as local bookmarks with notes and tags",
+    tags: ["Chat", "Utility"],
+    authors: [Devs.rexy0345, Devs.reticla],
+    settings,
+
+    start() {
+        void startStorage().catch(error => {
+            if (!(error instanceof ContextPinsStorageError)) logger.error("Failed to initialize", error);
+        });
+    },
+
+    stop() {
+        for (const modalKey of activeModalKeys) closeModal(modalKey);
+        activeModalKeys.clear();
+        stopStorage();
+    },
+
+    contextMenus: {
+        message: messageContextMenuPatch,
+    },
+});

--- a/src/plugins/contextPins/storage.ts
+++ b/src/plugins/contextPins/storage.ts
@@ -1,0 +1,368 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import * as DataStore from "@api/DataStore";
+import { Logger } from "@utils/Logger";
+
+export const STORAGE_KEY = "ContextPins_store";
+export const STORAGE_VERSION = 1 as const;
+export const MAX_NOTE_LENGTH = 2000;
+export const MAX_TAGS = 20;
+export const MAX_TAG_LENGTH = 32;
+
+export type PinKey = string;
+export type StorageState = "loading" | "ready" | "error";
+
+export interface PinSnapshot {
+    messageId: string;
+    channelId: string;
+    guildId: string | null;
+    content: string;
+    authorId: string;
+    authorName: string;
+    channelName: string;
+    guildName: string | null;
+    messageTimestamp: number;
+    attachmentCount: number;
+    embedCount: number;
+    stickerCount: number;
+}
+
+export interface StoredPin extends PinSnapshot {
+    note: string;
+    tags: string[];
+    createdAt: number;
+    updatedAt: number;
+    revision: number;
+}
+
+export interface StoredContextPins {
+    version: typeof STORAGE_VERSION;
+    pins: Record<PinKey, StoredPin>;
+}
+
+export interface PinInput {
+    key: PinKey;
+    snapshot: PinSnapshot;
+    note: string;
+    tags: string[];
+}
+
+export class ContextPinsStorageError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ContextPinsStorageError";
+    }
+}
+
+export class ContextPinsConflictError extends ContextPinsStorageError {
+    constructor() {
+        super("This pin changed in another window. Close this editor and try again.");
+        this.name = "ContextPinsConflictError";
+    }
+}
+
+export class ContextPinsLifecycleError extends ContextPinsStorageError {
+    constructor() {
+        super("Context Pins is no longer active.");
+        this.name = "ContextPinsLifecycleError";
+    }
+}
+
+const logger = new Logger("ContextPins");
+const listeners = new Set<() => void>();
+const emptyDocument = (): StoredContextPins => ({ version: STORAGE_VERSION, pins: {} });
+
+let currentDocument = emptyDocument();
+let storageState: StorageState = "loading";
+let storageError: Error | null = null;
+let lifecycleGeneration = 0;
+let initialization: Promise<void> | null = null;
+
+export function makePinKey(channelId: string, messageId: string): PinKey {
+    return `${channelId}:${messageId}`;
+}
+
+export function normalizeTags(input: string): { tags: string[]; error?: string; } {
+    const tags: string[] = [];
+    const seen = new Set<string>();
+
+    for (const rawTag of input.split(",")) {
+        const tag = rawTag.trim().replace(/\s+/g, " ");
+        if (!tag) continue;
+
+        if (tag.length > MAX_TAG_LENGTH) {
+            return { tags: [], error: `Tags must be ${MAX_TAG_LENGTH} characters or fewer.` };
+        }
+
+        const normalized = tag.toLocaleLowerCase();
+        if (seen.has(normalized)) continue;
+        seen.add(normalized);
+        tags.push(tag);
+    }
+
+    if (tags.length > MAX_TAGS) {
+        return { tags: [], error: `You can add up to ${MAX_TAGS} tags.` };
+    }
+
+    return { tags };
+}
+
+export function normalizeNote(input: string): { note: string; error?: string; } {
+    const note = input.replace(/[ \t]+$/gm, "").trim();
+    if (note.length > MAX_NOTE_LENGTH) {
+        return { note: "", error: `Notes must be ${MAX_NOTE_LENGTH} characters or fewer.` };
+    }
+
+    return { note };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSnowflake(value: unknown): value is string;
+function isSnowflake(value: unknown, nullable: true): value is string | null;
+function isSnowflake(value: unknown, nullable = false): value is string | null {
+    if (nullable && value === null) return true;
+    return typeof value === "string" && /^\d+$/.test(value);
+}
+
+function isFinitePositive(value: unknown): value is number {
+    return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function isFiniteCount(value: unknown): value is number {
+    return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function parsePin(value: unknown): StoredPin {
+    if (!isRecord(value)) throw new ContextPinsStorageError("A stored pin is not an object.");
+
+    const {
+        messageId,
+        channelId,
+        guildId,
+        content,
+        authorId,
+        authorName,
+        channelName,
+        guildName,
+        messageTimestamp,
+        attachmentCount,
+        embedCount,
+        stickerCount,
+        note,
+        tags: rawTags,
+        createdAt,
+        updatedAt,
+        revision,
+    } = value;
+
+    if (
+        !isSnowflake(messageId) ||
+        !isSnowflake(channelId) ||
+        !isSnowflake(authorId) ||
+        !isSnowflake(guildId, true) ||
+        typeof content !== "string" ||
+        typeof authorName !== "string" ||
+        typeof channelName !== "string" ||
+        (guildName !== null && typeof guildName !== "string") ||
+        !isFinitePositive(messageTimestamp) ||
+        !isFiniteCount(attachmentCount) ||
+        !isFiniteCount(embedCount) ||
+        !isFiniteCount(stickerCount) ||
+        typeof note !== "string" ||
+        note.length > MAX_NOTE_LENGTH ||
+        !Array.isArray(rawTags) ||
+        rawTags.length > MAX_TAGS ||
+        rawTags.some(tag => typeof tag !== "string" || !tag.trim() || tag.length > MAX_TAG_LENGTH) ||
+        !isFinitePositive(createdAt) ||
+        !isFinitePositive(updatedAt) ||
+        !isFinitePositive(revision)
+    ) {
+        throw new ContextPinsStorageError("A stored pin contains invalid data.");
+    }
+
+    const tags = normalizeTags(rawTags.join(","));
+    if (tags.error || tags.tags.length !== rawTags.length) {
+        throw new ContextPinsStorageError("A stored pin contains invalid tags.");
+    }
+
+    return {
+        messageId,
+        channelId,
+        guildId,
+        content,
+        authorId,
+        authorName,
+        channelName,
+        guildName,
+        messageTimestamp,
+        attachmentCount,
+        embedCount,
+        stickerCount,
+        note,
+        tags: tags.tags,
+        createdAt,
+        updatedAt,
+        revision,
+    };
+}
+
+export function parseDocument(value: unknown): StoredContextPins {
+    if (value === undefined) return emptyDocument();
+    if (!isRecord(value) || value.version !== STORAGE_VERSION || !isRecord(value.pins)) {
+        throw new ContextPinsStorageError("Context Pins storage uses an unsupported schema version.");
+    }
+
+    const pins: Record<PinKey, StoredPin> = {};
+    for (const [key, valueForKey] of Object.entries(value.pins)) {
+        const pin = parsePin(valueForKey);
+        if (key !== makePinKey(pin.channelId, pin.messageId)) {
+            throw new ContextPinsStorageError("A stored pin has an invalid key.");
+        }
+        pins[key] = pin;
+    }
+
+    return { version: STORAGE_VERSION, pins };
+}
+
+function emit() {
+    listeners.forEach(listener => listener());
+}
+
+function requireActive(requestGeneration: number) {
+    if (requestGeneration !== lifecycleGeneration) throw new ContextPinsLifecycleError();
+}
+
+function isStorageReady() {
+    return storageState === "ready";
+}
+
+async function waitUntilReady(requestGeneration: number) {
+    requireActive(requestGeneration);
+    if (isStorageReady()) return;
+    if (initialization) await initialization;
+    requireActive(requestGeneration);
+    if (isStorageReady()) return;
+    throw storageError ?? new ContextPinsStorageError("Context Pins storage is unavailable.");
+}
+
+export function startStorage() {
+    const requestGeneration = ++lifecycleGeneration;
+    currentDocument = emptyDocument();
+    storageState = "loading";
+    storageError = null;
+    emit();
+
+    initialization = DataStore.get<unknown>(STORAGE_KEY)
+        .then(value => {
+            requireActive(requestGeneration);
+            currentDocument = parseDocument(value);
+            storageState = "ready";
+            emit();
+        })
+        .catch(error => {
+            if (requestGeneration !== lifecycleGeneration) return;
+
+            storageState = "error";
+            storageError = error instanceof Error ? error : new ContextPinsStorageError("Failed to load Context Pins storage.");
+            logger.error("Failed to load storage", error);
+            emit();
+            throw storageError;
+        });
+
+    return initialization;
+}
+
+export function stopStorage() {
+    lifecycleGeneration++;
+    initialization = null;
+    currentDocument = emptyDocument();
+    storageState = "loading";
+    storageError = null;
+    listeners.clear();
+}
+
+export function getStorageState() {
+    return storageState;
+}
+
+export function getStorageError() {
+    return storageError;
+}
+
+export function subscribe(listener: () => void) {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+export function getPins() {
+    return Object.values(currentDocument.pins);
+}
+
+export function getPin(key: PinKey) {
+    return currentDocument.pins[key];
+}
+
+export async function upsertPin(input: PinInput, expectedRevision: number | null) {
+    const requestGeneration = lifecycleGeneration;
+    await waitUntilReady(requestGeneration);
+
+    let nextDocument: StoredContextPins | undefined;
+    let nextPin: StoredPin | undefined;
+    await DataStore.update<unknown>(STORAGE_KEY, oldValue => {
+        requireActive(requestGeneration);
+        const document = parseDocument(oldValue);
+        const existing = document.pins[input.key];
+
+        if (expectedRevision === null ? existing : existing?.revision !== expectedRevision) {
+            throw new ContextPinsConflictError();
+        }
+
+        const now = Date.now();
+        nextPin = {
+            ...input.snapshot,
+            note: input.note,
+            tags: [...input.tags],
+            createdAt: existing?.createdAt ?? now,
+            updatedAt: now,
+            revision: (existing?.revision ?? 0) + 1,
+        };
+        document.pins[input.key] = nextPin;
+        nextDocument = document;
+        return document;
+    });
+
+    requireActive(requestGeneration);
+    currentDocument = nextDocument!;
+    emit();
+    return nextPin!;
+}
+
+export async function deletePin(key: PinKey, expectedRevision: number) {
+    const requestGeneration = lifecycleGeneration;
+    await waitUntilReady(requestGeneration);
+
+    let nextDocument: StoredContextPins | undefined;
+    await DataStore.update<unknown>(STORAGE_KEY, oldValue => {
+        requireActive(requestGeneration);
+        const document = parseDocument(oldValue);
+        const existing = document.pins[key];
+        if (!existing || existing.revision !== expectedRevision) throw new ContextPinsConflictError();
+
+        delete document.pins[key];
+        nextDocument = document;
+        return document;
+    });
+
+    requireActive(requestGeneration);
+    currentDocument = nextDocument!;
+    emit();
+}

--- a/src/plugins/contextPins/style.css
+++ b/src/plugins/contextPins/style.css
@@ -1,0 +1,233 @@
+.vc-context-pins-modal-content {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    min-height: min(360px, 60vh);
+    color: var(--text-default);
+}
+
+.vc-context-pins-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--background-modifier-accent);
+}
+
+.vc-context-pins-search {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.vc-context-pins-filters {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.vc-context-pins-filter,
+.vc-context-pins-sort {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+}
+
+.vc-context-pins-toolbar {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.vc-context-pins-result-count {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.vc-context-pins-toolbar-actions {
+    display: flex;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.vc-context-pins-sort {
+    min-width: 180px;
+}
+
+.vc-context-pins-clear {
+    align-self: flex-end;
+}
+
+.vc-context-pins-list {
+    min-height: min(240px, 35vh);
+    max-height: min(520px, 55vh);
+    padding-inline-end: 4px;
+}
+
+.vc-context-pins-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px;
+    margin-bottom: 8px;
+    border: 1px solid var(--background-modifier-accent);
+    border-radius: 8px;
+    background: var(--background-secondary);
+}
+
+.vc-context-pins-row:last-child {
+    margin-bottom: 0;
+}
+
+.vc-context-pins-row-header {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.vc-context-pins-row-location,
+.vc-context-pins-row-header time,
+.vc-context-pins-editor-location {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.vc-context-pins-row-content {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    line-height: 1.45;
+}
+
+.vc-context-pins-row-note {
+    padding: 8px 10px;
+    border-inline-start: 3px solid var(--text-brand);
+    background: var(--background-tertiary);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.vc-context-pins-row-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.vc-context-pins-unavailable {
+    color: var(--text-feedback-critical);
+}
+
+.vc-context-pins-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.vc-context-pins-tag {
+    padding: 2px 7px;
+    border-radius: 10px;
+    background: var(--background-modifier-accent);
+    color: var(--text-default);
+}
+
+.vc-context-pins-row-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 4px;
+}
+
+.vc-context-pins-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 220px;
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.vc-context-pins-state-error {
+    color: var(--text-feedback-critical);
+}
+
+.vc-context-pins-muted,
+.vc-context-pins-field-hint {
+    color: var(--text-muted);
+}
+
+.vc-context-pins-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.vc-context-pins-editor-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px;
+    margin-bottom: 8px;
+    border: 1px solid var(--background-modifier-accent);
+    border-radius: 8px;
+    background: var(--background-secondary);
+}
+
+.vc-context-pins-editor-author {
+    color: var(--header-primary);
+    font-weight: 600;
+}
+
+.vc-context-pins-editor-content {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    line-height: 1.45;
+}
+
+.vc-context-pins-editor-indicators {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+@media (width <= 700px) {
+    .vc-context-pins-filters {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .vc-context-pins-toolbar-actions {
+        flex: 1 1 100%;
+        justify-content: space-between;
+    }
+}
+
+@media (width <= 480px) {
+    .vc-context-pins-filters {
+        grid-template-columns: 1fr;
+    }
+
+    .vc-context-pins-toolbar-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .vc-context-pins-sort {
+        width: 100%;
+    }
+
+    .vc-context-pins-clear {
+        align-self: flex-start;
+    }
+
+    .vc-context-pins-row {
+        padding: 12px;
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -657,6 +657,14 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     yuna0x0: {
         name: "yuna0x0",
         id: 213656926414831616n
+    },
+    rexy0345: {
+        name: "rexy0345",
+        id: 1523489275155583056n
+    },
+    reticla: {
+        name: "reticla",
+        id: 531201797893914645n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->
## About us

Me and my friend Reticla made this plugin because we didn’t like how the Discord pin system works, so we decided to create this plugin to fix it

## Summary
The Context Pins plugin is a plugin that lets users save Discord messages as local bookmarks with optional notes and tags
It is useful when you want to keep a message saved just for yourself instead of pinning it for everyone in the group

## Features
Users can manage their saved messages by editing, deleting, searching, filtering, and sorting them. Each pin also lets them copy the Discord link or jump directly to the original message

## Privacy
Everything is stored locally using Vencord DataStore. The plugin does not use external services, telemetry, accounts, or API keys

## Checklist before submitting
- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [X] This pull request was written by me, and not an AI agent


<img width="626" height="303" alt="Captura de ecrã 2026-08-04 032749" src="https://github.com/user-attachments/assets/3c3ad187-0b2f-49b8-8af5-e9f812e875a1" />

<img width="502" height="609" alt="Captura de ecrã 2026-08-04 032807" src="https://github.com/user-attachments/assets/8cc1b80f-ef8a-486b-9d68-c9129b954d4a" />

<img width="658" height="309" alt="Captura de ecrã 2026-08-04 032817" src="https://github.com/user-attachments/assets/8f09c823-303d-4f51-8916-a796992bce37" />

<img width="961" height="614" alt="Captura de ecrã 2026-08-04 032824" src="https://github.com/user-attachments/assets/bb82b1aa-226f-4c1b-8575-8d91cdff0636" />



