### PR TITLE
Add ActivityTimeline Plugin

### DIFF
--- a/src/plugins/activityTimeline/TimelineModal.tsx
+++ b/src/plugins/activityTimeline/TimelineModal.tsx
@@ -1,0 +1,379 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import { classNameFactory } from "@utils/css";
+import type { Channel, RenderModalProps } from "@vencord/discord-types";
+import {
+    Avatar,
+    ChannelRouter,
+    ChannelStore,
+    ConfirmModal,
+    FluxDispatcher,
+    Forms,
+    GuildStore,
+    ListScrollerThin,
+    MessageActions,
+    Modal,
+    openModal,
+    PermissionsBits,
+    PermissionStore,
+    Select,
+    SelectedChannelStore,
+    showToast,
+    Timestamp,
+    Toasts,
+    useEffect,
+    useMemo,
+    UserStore,
+    useState
+} from "@webpack/common";
+
+import { createTimelineMessageNavigator } from "./navigation";
+import {
+    MAX_TIMELINE_EVENTS,
+    type PresenceStatus,
+    type TimelineEvent,
+    type TimelineEventType,
+    timelineStore } from "./store";
+
+const cl = classNameFactory("vc-activity-timeline-");
+
+const timelineMessageNavigator = createTimelineMessageNavigator({
+    getChannel: channelId => ChannelStore.getChannel(channelId),
+    canViewChannel: channel => Boolean(channel.guild_id && PermissionStore.can(PermissionsBits.VIEW_CHANNEL, channel)),
+    getSelectedChannelId: () => SelectedChannelStore.getChannelId(),
+    subscribe: callback => FluxDispatcher.subscribe("CHANNEL_SELECT", callback),
+    unsubscribe: callback => FluxDispatcher.unsubscribe("CHANNEL_SELECT", callback),
+    wait: callback => FluxDispatcher.wait(callback),
+    transitionToChannel: channelId => ChannelRouter.transitionToChannel(channelId),
+    transitionToThread: channel => ChannelRouter.transitionToThread(channel as Channel),
+    jumpToMessage: jump => MessageActions.jumpToMessage(jump),
+    notify: message => showToast(message, Toasts.Type.FAILURE),
+    setTimeout: (callback, delay) => setTimeout(callback, delay),
+    clearTimeout: timeout => clearTimeout(timeout as number)
+});
+
+export function cancelPendingTimelineMessageNavigation() {
+    timelineMessageNavigator.cancel();
+}
+
+type FilterType = "all" | TimelineEventType;
+type FilterValue = "all" | string;
+
+const typeOptions: { label: string; value: FilterType; }[] = [
+    { label: "All events", value: "all" },
+    { label: "Messages", value: "message" },
+    { label: "Presence", value: "presence" },
+    { label: "Voice", value: "voice" }
+];
+
+const statusLabels: Record<PresenceStatus, string> = {
+    online: "Online",
+    idle: "Idle",
+    dnd: "Do Not Disturb",
+    invisible: "Invisible",
+    offline: "Offline"
+};
+
+function displayUserName(userId: string) {
+    const user = UserStore.getUser(userId);
+    return user?.globalName || user?.username || userId;
+}
+
+function canViewGuildChannel(channel: Channel | undefined) {
+    return Boolean(channel?.guild_id && PermissionStore.can(PermissionsBits.VIEW_CHANNEL, channel));
+}
+
+function channelName(channelId: string | undefined) {
+    if (!channelId) return "unknown channel";
+    const channel = ChannelStore.getChannel(channelId);
+    if (!canViewGuildChannel(channel)) return "inaccessible channel";
+    return channel?.name ? `#${channel.name}` : channelId;
+}
+
+function guildName(guildId: string) {
+    return GuildStore.getGuild(guildId)?.name || "inaccessible server";
+}
+
+function eventUsesGuild(event: TimelineEvent, guildId: string) {
+    return event.type !== "presence" && event.guildId === guildId;
+}
+
+function eventUsesChannel(event: TimelineEvent, channelId: string) {
+    return event.type === "message"
+        ? event.channelId === channelId
+        : event.type === "voice"
+            ? event.fromChannelId === channelId || event.toChannelId === channelId
+            : false;
+}
+
+function eventTypeLabel(type: TimelineEventType) {
+    return type === "message" ? "Message" : type === "presence" ? "Presence" : "Voice";
+}
+
+function EventRow({ event, modalProps }: { event: TimelineEvent; modalProps: RenderModalProps; }) {
+    let title: string;
+    let details: string;
+    let disabledReason: string | undefined;
+
+    if (event.type === "message") {
+        const channel = ChannelStore.getChannel(event.channelId);
+        title = "Message received";
+        details = `${guildName(event.guildId)} · ${channelName(event.channelId)}`;
+        if (event.deletedAt) {
+            disabledReason = "Message deleted";
+        } else if (!canViewGuildChannel(channel)) {
+            disabledReason = "Channel inaccessible";
+        }
+    } else if (event.type === "presence") {
+        title = `${statusLabels[event.previousStatus]} → ${statusLabels[event.currentStatus]}`;
+        details = "Presence change observed";
+    } else {
+        title = event.action === "join" ? "Joined voice" : event.action === "leave" ? "Left voice" : "Moved in voice";
+        const from = channelName(event.fromChannelId);
+        const to = channelName(event.toChannelId);
+        details = event.action === "join"
+            ? `${guildName(event.guildId)} · ${to}`
+            : event.action === "leave"
+                ? `${guildName(event.guildId)} · ${from}`
+                : `${guildName(event.guildId)} · ${from} → ${to}`;
+    }
+
+    const jump = () => {
+        if (event.type !== "message" || disabledReason) return;
+        timelineMessageNavigator.navigate({
+            guildId: event.guildId,
+            channelId: event.channelId,
+            messageId: event.messageId,
+            deletedAt: event.deletedAt,
+            onClose: modalProps.onClose
+        });
+    };
+
+    return (
+        <div className={cl("event")}>
+            <div className={cl("eventHeader")}>
+                <span className={cl("eventType")}>{eventTypeLabel(event.type)}</span>
+                <Timestamp timestamp={new Date(event.timestamp)} isInline={false} />
+            </div>
+            <div className={cl("eventTitle")}>{title}</div>
+            <div className={cl("eventDetails")}>{details}</div>
+            {event.type === "message" && (
+                <button className={cl("jump")} type="button" disabled={Boolean(disabledReason)} onClick={jump}>
+                    {disabledReason || "Jump to message"}
+                </button>
+            )}
+        </div>
+    );
+}
+
+function FilterSelect<T extends FilterValue>({
+    label,
+    value,
+    options,
+    onChange
+}: {
+    label: string;
+    value: T;
+    options: { label: string; value: T; }[];
+    onChange(value: T): void;
+}) {
+    return (
+        <div className={cl("filter")}>
+            <Forms.FormText>{label}</Forms.FormText>
+            <Select
+                options={options}
+                isSelected={option => option === value}
+                select={option => onChange(option as T)}
+                serialize={option => String(option)}
+                closeOnSelect={true}
+                maxVisibleItems={6}
+            />
+        </div>
+    );
+}
+
+export function ActivityTimelineModal({
+    modalProps,
+    initialTargetUserId,
+    onStart,
+    onClear,
+    onStop,
+    onRetry
+}: {
+    modalProps: RenderModalProps;
+    initialTargetUserId?: string;
+    onStart(userId: string): void;
+    onClear(userId: string): void;
+    onStop(): void;
+    onRetry(): void;
+}) {
+    const [, setVersion] = useState(0);
+    const [filterUser, setFilterUser] = useState<string | undefined>(initialTargetUserId);
+    const [filterType, setFilterType] = useState<FilterType>("all");
+    const [filterGuild, setFilterGuild] = useState<FilterValue>("all");
+    const [filterChannel, setFilterChannel] = useState<FilterValue>("all");
+
+    useEffect(() => timelineStore.subscribe(() => setVersion(version => version + 1)), []);
+
+    const snapshot = timelineStore.getSnapshot();
+    const sessionById = useMemo(() => new Map(snapshot.sessions.map(session => [session.id, session])), [snapshot.sessions]);
+    const userIds = useMemo(() => {
+        const ids = new Set<string>();
+        const lastActivity = new Map<string, number>();
+        for (const session of snapshot.sessions) ids.add(session.targetUserId);
+        if (initialTargetUserId) ids.add(initialTargetUserId);
+        if (snapshot.target) ids.add(snapshot.target.userId);
+        const ownId = UserStore.getCurrentUser()?.id;
+        if (ownId) ids.add(ownId);
+        for (const session of snapshot.sessions)
+            lastActivity.set(session.targetUserId, Math.max(lastActivity.get(session.targetUserId) || 0, session.startedAt));
+        for (const event of snapshot.events) {
+            const userId = sessionById.get(event.sessionId)?.targetUserId;
+            if (userId) lastActivity.set(userId, Math.max(lastActivity.get(userId) || 0, event.timestamp));
+        }
+        return Array.from(ids).sort((left, right) => (lastActivity.get(right) || 0) - (lastActivity.get(left) || 0));
+    }, [initialTargetUserId, sessionById, snapshot.events, snapshot.sessions, snapshot.target]);
+
+    useEffect(() => {
+        if (!filterUser || !userIds.includes(filterUser))
+            setFilterUser(initialTargetUserId && userIds.includes(initialTargetUserId) ? initialTargetUserId : snapshot.target?.userId || userIds[0]);
+    }, [filterUser, initialTargetUserId, snapshot.target, userIds]);
+
+    const selectedEvents = useMemo(() => snapshot.events.filter(event => sessionById.get(event.sessionId)?.targetUserId === filterUser), [filterUser, sessionById, snapshot.events]);
+    const userOptions = userIds.map(userId => ({ label: displayUserName(userId), value: userId }));
+    const guildOptions = useMemo(() => {
+        const guildIds = new Set(selectedEvents.filter(event => event.type !== "presence").map(event => event.guildId));
+        return [{ label: "All servers", value: "all" }, ...Array.from(guildIds, guildId => ({ label: guildName(guildId), value: guildId }))];
+    }, [selectedEvents]);
+    const channelOptions = useMemo(() => {
+        const channelIds = new Set(selectedEvents
+            .filter(event => event.type !== "presence")
+            .filter(event => filterGuild === "all" || eventUsesGuild(event, filterGuild))
+            .flatMap(event => event.type === "message" ? [event.channelId] : [event.fromChannelId, event.toChannelId].filter((id): id is string => Boolean(id))));
+        return [{ label: "All channels", value: "all" }, ...Array.from(channelIds, channelId => ({ label: channelName(channelId), value: channelId }))];
+    }, [filterGuild, selectedEvents]);
+
+    useEffect(() => {
+        if (filterGuild !== "all" && !guildOptions.some(option => option.value === filterGuild)) setFilterGuild("all");
+    }, [filterGuild, guildOptions]);
+    useEffect(() => {
+        if (filterChannel !== "all" && !channelOptions.some(option => option.value === filterChannel)) setFilterChannel("all");
+    }, [channelOptions, filterChannel]);
+
+    const visibleEvents = useMemo(() => [...selectedEvents]
+        .reverse()
+        .filter(event => filterType === "all" || event.type === filterType)
+        .filter(event => filterGuild === "all" || eventUsesGuild(event, filterGuild))
+        .filter(event => filterChannel === "all" || eventUsesChannel(event, filterChannel)),
+    [filterChannel, filterGuild, filterType, selectedEvents]);
+
+    const selectedUserId = filterUser;
+    const selectedName = selectedUserId ? displayUserName(selectedUserId) : "No user selected";
+    const selectedActive = snapshot.target?.userId === selectedUserId;
+    const activeOther = Boolean(snapshot.target && !selectedActive);
+    const selectedSession = snapshot.sessions.find(session => session.id === snapshot.activeSessionId && session.targetUserId === selectedUserId)
+        || [...snapshot.sessions].reverse().find(session => session.targetUserId === selectedUserId);
+    const startText = selectedActive
+        ? "Tracking active"
+        : activeOther
+            ? `Switch tracking to ${selectedName}`
+            : "Start Activity Timeline";
+    const canStart = snapshot.hydrationState === "ready" && !snapshot.storageError && Boolean(selectedUserId) && !selectedActive;
+
+    const confirmClear = () => {
+        if (!selectedUserId) return;
+        openModal(props => (
+            <ConfirmModal
+                {...props}
+                title="Clear Activity Timeline history?"
+                subtitle={`This removes the saved history for ${selectedName}. Other users' history will remain.`}
+                confirmText="Clear history"
+                cancelText="Keep history"
+                onConfirm={() => onClear(selectedUserId)}
+            />
+        ));
+    };
+
+    const selectedHistoryCount = selectedEvents.length;
+
+    return (
+        <Modal
+            {...modalProps}
+            title="Activity Timeline"
+            actions={[
+                {
+                    text: startText,
+                    variant: "primary",
+                    disabled: !canStart,
+                    onClick: () => selectedUserId && onStart(selectedUserId)
+                },
+                {
+                    text: "Clear History",
+                    variant: "primary",
+                    disabled: selectedHistoryCount === 0,
+                    onClick: confirmClear
+                },
+                {
+                    text: "Stop Activity Timeline",
+                    variant: "critical-primary",
+                    disabled: !snapshot.target,
+                    onClick: onStop
+                },
+                ...(snapshot.storageError ? [{
+                    text: "Retry loading history",
+                    variant: "primary" as const,
+                    onClick: onRetry
+                }] : [])
+            ]}
+        >
+            <div className={cl("modal")}>
+                <div className={cl("summary")}>
+                    <div className={cl("targetHeader")}>
+                        {selectedUserId && UserStore.getUser(selectedUserId) && (
+                            <Avatar
+                                src={UserStore.getUser(selectedUserId)!.getAvatarURL(undefined, 40, false)}
+                                size="SIZE_40"
+                                className={cl("avatar")}
+                            />
+                        )}
+                        <div className={cl("target")}>{selectedName}</div>
+                        {selectedActive && <span className={cl("activeBadge")}>Tracking</span>}
+                    </div>
+                    {snapshot.hydrationState === "loading" && <Forms.FormText>Loading saved history...</Forms.FormText>}
+                    {snapshot.storageError && <div className={cl("notice", "error")}>{snapshot.storageError}</div>}
+                    {snapshot.capacityReached && <div className={cl("notice")}>The 20,000-event limit was reached. Tracking is stopped; clear or wait for expiry to start again.</div>}
+                    {snapshot.hydrationState === "ready" && !snapshot.storageError && <Forms.FormText>
+                        {selectedSession ? `Started ${new Date(selectedSession.startedAt).toLocaleString()}` : "No tracking session for this user"} · {selectedHistoryCount}/{MAX_TIMELINE_EVENTS} events · History retained for 72 hours
+                    </Forms.FormText>}
+                </div>
+
+                <div className={cl("filters")}>
+                    <FilterSelect label="User" value={filterUser || "all"} options={userOptions.length ? userOptions : [{ label: "No users", value: "all" }]} onChange={value => setFilterUser(value === "all" ? undefined : value)} />
+                    <FilterSelect label="Type" value={filterType} options={typeOptions} onChange={value => setFilterType(value as FilterType)} />
+                    <FilterSelect label="Server" value={filterGuild} options={guildOptions} onChange={setFilterGuild} />
+                    <FilterSelect label="Channel" value={filterChannel} options={channelOptions} onChange={setFilterChannel} />
+                </div>
+
+                {visibleEvents.length > 0 ? (
+                    <ListScrollerThin className={cl("scroller")} sections={[visibleEvents.length]} sectionHeight={0} rowHeight={112} renderSection={() => null} renderRow={item => (
+                        <EventRow key={visibleEvents[item.row].id} event={visibleEvents[item.row]} modalProps={modalProps} />
+                    )} />
+                ) : (
+                    <div className={cl("empty")}>
+                        {snapshot.hydrationState === "loading"
+                            ? "Loading Activity Timeline history..."
+                            : selectedHistoryCount > 0 ? "No events match these filters." : "No events have been observed for this user."
+                        }
+                    </div>
+                )}
+            </div>
+        </Modal>
+    );
+}
+
+export const WrappedActivityTimelineModal = ErrorBoundary.wrap(ActivityTimelineModal, { noop: true });

--- a/src/plugins/activityTimeline/index.tsx
+++ b/src/plugins/activityTimeline/index.tsx
@@ -1,0 +1,480 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import type { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { Devs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+import definePlugin from "@utils/types";
+import type { Message, OnlineStatus, User } from "@vencord/discord-types";
+import {
+    ChannelStore,
+    ConfirmModal,
+    Menu,
+    openModal,
+    PermissionsBits,
+    PermissionStore,
+    PresenceStore,
+    showToast,
+    Toasts,
+    UserStore,
+    VoiceStateStore
+} from "@webpack/common";
+
+import { flushHistoryWrite, loadHistory, queueHistoryWrite, writeHistoryNow } from "./persistence";
+import {
+    type PresenceStatus,
+    type TimelineMode,
+    timelineStore } from "./store";
+import { cancelPendingTimelineMessageNavigation, WrappedActivityTimelineModal } from "./TimelineModal";
+
+const logger = new Logger("ActivityTimeline");
+
+interface VoiceStateUpdate {
+    userId?: string;
+    guildId?: string;
+    channelId?: string | null;
+    oldChannelId?: string | null;
+}
+
+let presenceListener: (() => void) | undefined;
+let lastPresence: PresenceStatus | null = null;
+let voiceBaselines = new Map<string, string | undefined>();
+let connectionReady = true;
+let hydratedAccountId: string | undefined;
+let hydrationPromise: Promise<void> | undefined;
+
+function currentUserId() {
+    return UserStore.getCurrentUser()?.id;
+}
+
+function normalizePresenceStatus(status: OnlineStatus | undefined): PresenceStatus | null {
+    if (!status) return null;
+    if (status === "online" || status === "idle" || status === "dnd" || status === "invisible" || status === "offline") return status;
+    if (status === "streaming") return "online";
+    return "offline";
+}
+
+function readPresence(userId: string) {
+    try {
+        return normalizePresenceStatus(PresenceStore.getStatus(userId));
+    } catch (error) {
+        logger.error("Could not read presence", error);
+        return null;
+    }
+}
+
+function canViewGuildChannel(channelId: string | undefined) {
+    if (!channelId) return false;
+
+    const channel = ChannelStore.getChannel(channelId);
+    return Boolean(channel?.guild_id && PermissionStore.can(PermissionsBits.VIEW_CHANNEL, channel));
+}
+
+function readVoiceBaselines(userId: string) {
+    const baselines = new Map<string, string | undefined>();
+
+    try {
+        const allStates = VoiceStateStore.getAllVoiceStates();
+        for (const [guildId, states] of Object.entries(allStates)) {
+            const state = states[userId];
+            baselines.set(guildId, state?.channelId || undefined);
+        }
+    } catch (error) {
+        logger.error("Could not read voice baselines", error);
+    }
+
+    return baselines;
+}
+
+function rebaseline() {
+    const { target } = timelineStore.getSnapshot();
+    if (!target) return;
+
+    lastPresence = readPresence(target.userId);
+    voiceBaselines = readVoiceBaselines(target.userId);
+    connectionReady = true;
+}
+
+function persistHistory(force = false) {
+    if (!hydratedAccountId || timelineStore.getSnapshot().hydrationState !== "ready") return Promise.resolve();
+    const state = timelineStore.getPersistedState();
+    const handleSaveError = (error: unknown) => {
+        logger.error("Could not save Activity Timeline history", error);
+        timelineStore.setStorageError("Activity Timeline history could not be saved.");
+    };
+    return (force ? writeHistoryNow(hydratedAccountId, state) : queueHistoryWrite(hydratedAccountId, state, handleSaveError)).catch(handleSaveError);
+}
+
+async function hydrateForCurrentAccount() {
+    const accountId = currentUserId();
+    if (!accountId) return;
+    if (hydratedAccountId === accountId && timelineStore.getSnapshot().hydrationState === "ready") return;
+
+    if (hydratedAccountId && timelineStore.getSnapshot().hydrationState === "ready") {
+        timelineStore.stop();
+        await writeHistoryNow(hydratedAccountId, timelineStore.getPersistedState());
+    } else if (hydratedAccountId) {
+        timelineStore.stop();
+    }
+
+    hydratedAccountId = accountId;
+    try {
+        const loaded = await loadHistory(accountId);
+        timelineStore.hydrate(loaded.state);
+        if (loaded.unsupported) {
+            timelineStore.setStorageError("This Activity Timeline history was created by a newer version and was not changed.");
+        } else if (loaded.recovered) {
+            showToast("Some Activity Timeline history was discarded because it was invalid.", Toasts.Type.FAILURE);
+            await writeHistoryNow(accountId, timelineStore.getPersistedState());
+        } else {
+            await writeHistoryNow(accountId, timelineStore.getPersistedState());
+        }
+    } catch (error) {
+        logger.error("Could not load Activity Timeline history", error);
+        timelineStore.setStorageError("Activity Timeline history could not be loaded. Try again later.");
+    }
+}
+
+function ensureHydrated() {
+    if (!hydrationPromise) hydrationPromise = hydrateForCurrentAccount().finally(() => hydrationPromise = undefined);
+    return hydrationPromise;
+}
+
+function openActivityTimelineModal(initialTargetUserId?: string) {
+    void ensureHydrated();
+    openModal(props => (
+        <WrappedActivityTimelineModal
+            modalProps={props}
+            initialTargetUserId={initialTargetUserId}
+            onStart={startTrackingFromModal}
+            onClear={clearTrackingHistory}
+            onStop={stopTracking}
+            onRetry={retryHydration}
+        />
+    ));
+}
+
+function startTracking(userId: string, mode: TimelineMode) {
+    const sessionId = timelineStore.start({
+        userId,
+        mode,
+        startedAt: Date.now()
+    });
+    if (sessionId === null) {
+        showToast("Activity Timeline is still loading or its history is unavailable.", Toasts.Type.FAILURE);
+        return false;
+    }
+
+    lastPresence = readPresence(userId);
+    voiceBaselines = readVoiceBaselines(userId);
+    connectionReady = true;
+
+    const user = UserStore.getUser(userId);
+    const name = user?.globalName || user?.username || userId;
+    showToast(`Activity Timeline started for ${name}`, Toasts.Type.SUCCESS);
+    void persistHistory(true);
+    return true;
+}
+
+function stopTracking() {
+    cancelPendingTimelineMessageNavigation();
+    const wasActive = Boolean(timelineStore.getSnapshot().target);
+    timelineStore.stop();
+    lastPresence = null;
+    voiceBaselines = new Map();
+    if (wasActive) {
+        showToast("Activity Timeline stopped", Toasts.Type.SUCCESS);
+        void persistHistory(true);
+    }
+}
+
+function startTrackingFromModal(userId: string) {
+    const mode: TimelineMode = userId === currentUserId() ? "self" : "selected";
+    const snapshot = timelineStore.getSnapshot();
+    if (snapshot.target?.userId === userId) return;
+    if (snapshot.target) {
+        const user = UserStore.getUser(userId);
+        const name = user?.globalName || user?.username || userId;
+        openModal(props => (
+            <ConfirmModal
+                {...props}
+                title="Switch Activity Timeline target?"
+                subtitle={`Stop tracking the current target and start collecting new events for ${name}? Existing history will be kept.`}
+                confirmText="Switch target"
+                cancelText="Keep current target"
+                onConfirm={() => startTracking(userId, mode)}
+            />
+        ));
+        return;
+    }
+    startTracking(userId, mode);
+}
+
+function clearTrackingHistory(userId: string) {
+    timelineStore.clearForUser(userId);
+    void persistHistory(true);
+    showToast("Activity Timeline history cleared", Toasts.Type.SUCCESS);
+}
+
+function retryHydration() {
+    hydrationPromise = undefined;
+    void ensureHydrated();
+}
+
+function addTimelineEvent(event: Parameters<typeof timelineStore.addEvent>[0]) {
+    const added = timelineStore.addEvent(event);
+    if (added) {
+        void persistHistory();
+    } else if (timelineStore.getSnapshot().capacityReached) {
+        showToast("Activity Timeline stopped after reaching 20,000 events", Toasts.Type.FAILURE);
+        void persistHistory(true);
+    }
+}
+
+function handlePresenceChange() {
+    const { target } = timelineStore.getSnapshot();
+    if (!target || !connectionReady) return;
+
+    const current = readPresence(target.userId);
+    if (!current || !lastPresence || current === lastPresence) {
+        lastPresence = current;
+        return;
+    }
+
+    const previous = lastPresence;
+    lastPresence = current;
+    addTimelineEvent({
+        type: "presence",
+        timestamp: Date.now(),
+        previousStatus: previous,
+        currentStatus: current
+    });
+}
+
+function handleMessageCreate(event: { message?: Message; optimistic?: boolean; }) {
+    if (event.optimistic) return;
+
+    const { target } = timelineStore.getSnapshot();
+    const { message } = event;
+    if (!target || !message || message.author?.id !== target.userId) return;
+
+    const channel = ChannelStore.getChannel(message.channel_id);
+    if (!channel?.guild_id || !PermissionStore.can(PermissionsBits.VIEW_CHANNEL, channel)) return;
+
+    addTimelineEvent({
+        type: "message",
+        timestamp: Date.now(),
+        guildId: channel.guild_id,
+        channelId: message.channel_id,
+        messageId: message.id
+    });
+}
+
+function getVoiceGuildId(state: VoiceStateUpdate, event: { guildId?: string; }) {
+    if (state.guildId || event.guildId) return state.guildId || event.guildId;
+
+    const channelId = state.channelId || state.oldChannelId;
+    return channelId ? ChannelStore.getChannel(channelId)?.guild_id : undefined;
+}
+
+function handleVoiceStateUpdates(event: { guildId?: string; voiceStates?: VoiceStateUpdate[]; }) {
+    const { target } = timelineStore.getSnapshot();
+    if (!target || !connectionReady) return;
+
+    for (const state of event.voiceStates ?? []) {
+        if (state.userId !== target.userId) continue;
+
+        const guildId = getVoiceGuildId(state, event);
+        if (!guildId) continue;
+
+        const previousBaseline = voiceBaselines.get(guildId);
+        const reportedOld = state.oldChannelId || undefined;
+        const nextChannel = state.channelId || undefined;
+
+        // Discord can replay a VOICE_STATE_UPDATES entry while resuming. The
+        // baseline is the last state we accepted, so an unchanged destination
+        // is a duplicate rather than a new movement.
+        if (nextChannel === previousBaseline) continue;
+
+        const fromChannel = target.mode === "self" && reportedOld === nextChannel
+            ? previousBaseline
+            : reportedOld ?? previousBaseline;
+
+        voiceBaselines.set(guildId, nextChannel);
+        if (fromChannel === nextChannel) continue;
+
+        const fromVisible = canViewGuildChannel(fromChannel);
+        const toVisible = canViewGuildChannel(nextChannel);
+        if (!fromVisible && !toVisible) continue;
+
+        const action = !fromVisible && toVisible
+            ? "join"
+            : fromVisible && !toVisible
+                ? "leave"
+                : "move";
+
+        addTimelineEvent({
+            type: "voice",
+            timestamp: Date.now(),
+            guildId,
+            action,
+            fromChannelId: fromVisible ? fromChannel : undefined,
+            toChannelId: toVisible ? nextChannel : undefined
+        });
+    }
+}
+
+function handleMessageDelete(event: { channelId?: string; id?: string; }) {
+    if (event.channelId && event.id)
+        timelineStore.markMessageDeleted(event.channelId, event.id);
+    void persistHistory();
+}
+
+function handleMessageDeleteBulk(event: { channelId?: string; ids?: string[]; }) {
+    if (!event.channelId) return;
+    for (const id of event.ids ?? []) timelineStore.markMessageDeleted(event.channelId, id);
+    void persistHistory();
+}
+
+const patchUserContextMenu: NavContextMenuPatchCallback = (children, props) => {
+    const { user } = props as { user?: User; };
+    if (!user) return;
+
+    const snapshot = timelineStore.getSnapshot();
+    const isCurrentTarget = snapshot.target?.userId === user.id;
+
+    children.push(
+        <Menu.MenuItem
+            id="vc-activity-timeline-user"
+            label="Open Activity Timeline"
+            action={() => openActivityTimelineModal(user.id)}
+        />
+    );
+
+    if (isCurrentTarget) {
+        children.push(
+            <Menu.MenuItem
+                id="vc-activity-timeline-stop-user"
+                label="Stop Activity Timeline"
+                color="danger"
+                action={stopTracking}
+            />
+        );
+    }
+};
+
+export default definePlugin({
+    name: "ActivityTimeline",
+    authors: [Devs.reticla, Devs.rexy0345],
+    description: "Keeps a local 72-hour timeline of messages, presence changes, and voice activity for one selected user or yourself",
+    tags: ["Utility", "Privacy"],
+    contextMenus: {
+        "user-context": patchUserContextMenu
+    },
+
+    toolboxActions() {
+        const snapshot = timelineStore.getSnapshot();
+        if (!snapshot.target) {
+            return [
+                <Menu.MenuItem
+                    id="vc-activity-timeline-open"
+                    key="vc-activity-timeline-open"
+                    label="Open Activity Timeline"
+                    action={() => openActivityTimelineModal()}
+                />
+            ];
+        }
+
+        const user = UserStore.getUser(snapshot.target.userId);
+        const name = user?.globalName || user?.username || snapshot.target.userId;
+
+        return [
+            <Menu.MenuItem
+                id="vc-activity-timeline-open-active"
+                key="vc-activity-timeline-open-active"
+                label={`Open Activity Timeline (${name})`}
+                action={() => openActivityTimelineModal()}
+            />,
+            <Menu.MenuItem
+                id="vc-activity-timeline-stop"
+                key="vc-activity-timeline-stop"
+                label="Stop Activity Timeline"
+                color="danger"
+                action={stopTracking}
+            />
+        ];
+    },
+
+    start() {
+        void ensureHydrated();
+        presenceListener = () => {
+            try {
+                handlePresenceChange();
+            } catch (error) {
+                logger.error("Could not record presence activity", error);
+            }
+        };
+        PresenceStore.addChangeListener(presenceListener);
+    },
+
+    stop() {
+        if (presenceListener) PresenceStore.removeChangeListener(presenceListener);
+        presenceListener = undefined;
+        stopTracking();
+        void flushHistoryWrite().catch(error => logger.error("Could not flush Activity Timeline history", error));
+        connectionReady = false;
+    },
+
+    flux: {
+        MESSAGE_CREATE(event: { message?: Message; optimistic?: boolean; }) {
+            try {
+                handleMessageCreate(event);
+            } catch (error) {
+                logger.error("Could not record message activity", error);
+            }
+        },
+
+        MESSAGE_DELETE(event: { channelId?: string; id?: string; }) {
+            handleMessageDelete(event);
+        },
+
+        MESSAGE_DELETE_BULK(event: { channelId?: string; ids?: string[]; }) {
+            handleMessageDeleteBulk(event);
+        },
+
+        VOICE_STATE_UPDATES(event: { guildId?: string; voiceStates?: VoiceStateUpdate[]; }) {
+            try {
+                handleVoiceStateUpdates(event);
+            } catch (error) {
+                logger.error("Could not record voice activity", error);
+            }
+        },
+
+        CHANNEL_DELETE(event: { channel?: { id?: string; }; id?: string; }) {
+            const channelId = event.channel?.id || event.id;
+            if (channelId) timelineStore.removeChannel(channelId);
+        },
+
+        GUILD_DELETE(event: { guild?: { id?: string; }; guildId?: string; }) {
+            const guildId = event.guild?.id || event.guildId;
+            if (guildId) timelineStore.removeGuild(guildId);
+        },
+
+        CONNECTION_CLOSED() {
+            connectionReady = false;
+        },
+
+        CONNECTION_OPEN() {
+            rebaseline();
+        },
+
+        CONNECTION_RESUMED() {
+            rebaseline();
+        }
+    }
+});

--- a/src/plugins/activityTimeline/navigation.test.ts
+++ b/src/plugins/activityTimeline/navigation.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    createTimelineMessageNavigator,
+    type TimelineNavigationChannel,
+    type TimelineNavigationDependencies
+} from "./navigation";
+
+function makeHarness(selectedChannelId: string | null = "current", autoSelect = true) {
+    let selected = selectedChannelId;
+    let listener: ((event: { channelId?: string | null; }) => void) | undefined;
+    let timerCallback: (() => void) | undefined;
+    const channels = new Map<string, TimelineNavigationChannel>();
+    const jumps: unknown[] = [];
+    const transitions: string[] = [];
+    const threadTransitions: string[] = [];
+    const notices: string[] = [];
+    let closed = 0;
+    let unsubscribed = 0;
+
+    const deps: TimelineNavigationDependencies = {
+        getChannel: channelId => channels.get(channelId),
+        canViewChannel: () => true,
+        getSelectedChannelId: () => selected,
+        subscribe: callback => {
+            listener = callback;
+        },
+        unsubscribe: callback => {
+            if (listener === callback) listener = undefined;
+            unsubscribed++;
+        },
+        wait: callback => callback(),
+        transitionToChannel: channelId => {
+            transitions.push(channelId);
+            if (autoSelect) {
+                selected = channelId;
+                listener?.({ channelId });
+            }
+        },
+        transitionToThread: channel => {
+            threadTransitions.push(channel.id);
+            if (autoSelect) {
+                selected = channel.id;
+                listener?.({ channelId: channel.id });
+            }
+        },
+        jumpToMessage: jump => jumps.push(jump),
+        notify: message => notices.push(message),
+        setTimeout: callback => {
+            timerCallback = callback;
+            return callback;
+        },
+        clearTimeout: timeout => {
+            if (timerCallback === timeout) timerCallback = undefined;
+        }
+    };
+
+    const channel = (id: string, guildId = "guild", options: { thread?: boolean; forumPost?: boolean; } = {}) => {
+        const value: TimelineNavigationChannel = {
+            id,
+            guild_id: guildId,
+            isThread: () => options.thread === true,
+            isForumPost: () => options.forumPost === true
+        };
+        channels.set(id, value);
+        return value;
+    };
+
+    return {
+        deps,
+        channel,
+        jumps,
+        transitions,
+        threadTransitions,
+        notices,
+        get closed() {
+            return closed;
+        },
+        close() {
+            closed++;
+        },
+        emit(channelId: string) {
+            selected = channelId;
+            listener?.({ channelId });
+        },
+        fireTimeout() {
+            timerCallback?.();
+        },
+        get unsubscribed() {
+            return unsubscribed;
+        }
+    };
+}
+
+function request(harness: ReturnType<typeof makeHarness>, channelId = "target") {
+    return {
+        guildId: "guild",
+        channelId,
+        messageId: "message",
+        onClose: harness.close
+    };
+}
+
+test("jumps in the current channel without routing", () => {
+    const harness = makeHarness("target");
+    harness.channel("target");
+    const navigator = createTimelineMessageNavigator(harness.deps);
+
+    assert.equal(navigator.navigate(request(harness)), true);
+    assert.equal(harness.closed, 1);
+    assert.deepEqual(harness.transitions, []);
+    assert.equal(harness.jumps.length, 1);
+    assert.equal((harness.jumps[0] as { jumpType: string; }).jumpType, "INSTANT");
+});
+
+test("routes to another server before jumping", () => {
+    const harness = makeHarness("current");
+    harness.channel("target", "other-guild");
+    const navigator = createTimelineMessageNavigator(harness.deps);
+
+    assert.equal(navigator.navigate({ ...request(harness), guildId: "other-guild" }), true);
+    assert.deepEqual(harness.transitions, ["target"]);
+    assert.equal(harness.jumps.length, 1);
+    assert.equal(harness.closed, 1);
+});
+
+test("ignores another channel selection until the requested channel is selected", () => {
+    const harness = makeHarness("current", false);
+    harness.channel("target");
+    const navigator = createTimelineMessageNavigator(harness.deps);
+
+    navigator.navigate(request(harness));
+    harness.emit("unrelated");
+    assert.equal(harness.jumps.length, 0);
+    harness.emit("target");
+    assert.equal(harness.jumps.length, 1);
+});
+
+test("uses thread navigation for threads and forum posts", () => {
+    const threadHarness = makeHarness("current");
+    threadHarness.channel("thread", "guild", { thread: true });
+    createTimelineMessageNavigator(threadHarness.deps).navigate({ ...request(threadHarness, "thread") });
+    assert.deepEqual(threadHarness.threadTransitions, ["thread"]);
+
+    const forumHarness = makeHarness("current");
+    forumHarness.channel("post", "guild", { forumPost: true });
+    createTimelineMessageNavigator(forumHarness.deps).navigate({ ...request(forumHarness, "post") });
+    assert.deepEqual(forumHarness.threadTransitions, ["post"]);
+});
+
+test("rejects deleted, inaccessible, missing, or mismatched channels before closing", () => {
+    const harness = makeHarness("current");
+    harness.channel("target");
+    const navigator = createTimelineMessageNavigator({ ...harness.deps, canViewChannel: () => false });
+    assert.equal(navigator.navigate(request(harness)), false);
+    assert.equal(harness.closed, 0);
+    assert.equal(harness.jumps.length, 0);
+
+    const deleted = createTimelineMessageNavigator(harness.deps);
+    assert.equal(deleted.navigate({ ...request(harness), deletedAt: 1 }), false);
+    assert.equal(deleted.navigate({ ...request(harness), guildId: "wrong" }), false);
+    assert.equal(deleted.navigate({ ...request(harness, "missing") }), false);
+    assert.equal(harness.closed, 0);
+});
+
+test("timeout cleans the listener and reports a failed route", () => {
+    const harness = makeHarness("current", false);
+    harness.channel("target");
+    const navigator = createTimelineMessageNavigator(harness.deps);
+
+    assert.equal(navigator.navigate(request(harness)), true);
+    harness.fireTimeout();
+    assert.equal(harness.jumps.length, 0);
+    assert.equal(harness.unsubscribed, 1);
+    assert.match(harness.notices[0], /did not open/i);
+});
+
+test("a new request and explicit cancellation clean up a pending route", () => {
+    const harness = makeHarness("current", false);
+    harness.channel("first");
+    harness.channel("second");
+    const navigator = createTimelineMessageNavigator(harness.deps);
+
+    navigator.navigate(request(harness, "first"));
+    navigator.navigate(request(harness, "second"));
+    navigator.cancel();
+    harness.emit("second");
+    assert.equal(harness.jumps.length, 0);
+    assert.equal(harness.unsubscribed, 2);
+});

--- a/src/plugins/activityTimeline/navigation.ts
+++ b/src/plugins/activityTimeline/navigation.ts
@@ -1,0 +1,133 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export const MESSAGE_NAVIGATION_TIMEOUT_MS = 5_000;
+
+export interface TimelineNavigationChannel {
+    id: string;
+    guild_id?: string | null;
+    isThread?(): boolean;
+    isForumPost?(): boolean;
+}
+
+export interface TimelineMessageNavigationRequest {
+    guildId: string;
+    channelId: string;
+    messageId: string;
+    deletedAt?: number;
+    onClose(): void;
+}
+
+export interface TimelineMessageJump {
+    channelId: string;
+    messageId: string;
+    flash: boolean;
+    jumpType: "INSTANT";
+}
+
+export interface TimelineNavigationDependencies {
+    getChannel(channelId: string): TimelineNavigationChannel | undefined;
+    canViewChannel(channel: TimelineNavigationChannel): boolean;
+    getSelectedChannelId(): string | null;
+    subscribe(callback: (event: { channelId?: string | null; }) => void): void;
+    unsubscribe(callback: (event: { channelId?: string | null; }) => void): void;
+    wait(callback: () => void): void;
+    transitionToChannel(channelId: string): void;
+    transitionToThread(channel: TimelineNavigationChannel): void;
+    jumpToMessage(jump: TimelineMessageJump): void;
+    notify(message: string): void;
+    setTimeout(callback: () => void, delay: number): unknown;
+    clearTimeout(timeout: unknown): void;
+}
+
+function isThread(channel: TimelineNavigationChannel) {
+    return channel.isThread?.() === true || channel.isForumPost?.() === true;
+}
+
+export function createTimelineMessageNavigator(deps: TimelineNavigationDependencies) {
+    let cancelPending: (() => void) | undefined;
+
+    const cancel = () => {
+        cancelPending?.();
+        cancelPending = undefined;
+    };
+
+    const navigate = (request: TimelineMessageNavigationRequest) => {
+        cancel();
+
+        const channel = deps.getChannel(request.channelId);
+        if (request.deletedAt) {
+            deps.notify("This message was deleted");
+            return false;
+        }
+        if (!channel || channel.guild_id !== request.guildId) {
+            deps.notify("This channel is no longer available");
+            return false;
+        }
+        if (!deps.canViewChannel(channel)) {
+            deps.notify("This channel is no longer accessible");
+            return false;
+        }
+
+        request.onClose();
+
+        let settled = false;
+        const cleanup = () => {
+            if (settled) return;
+            settled = true;
+            deps.unsubscribe(onChannelSelect);
+            if (timeout !== undefined) deps.clearTimeout(timeout);
+            if (cancelPending === cleanup) cancelPending = undefined;
+        };
+
+        const jump = () => {
+            if (deps.getSelectedChannelId() !== request.channelId || settled) return;
+
+            cleanup();
+            try {
+                deps.jumpToMessage({
+                    channelId: request.channelId,
+                    messageId: request.messageId,
+                    flash: true,
+                    jumpType: "INSTANT"
+                });
+            } catch {
+                deps.notify("Could not open this message");
+            }
+        };
+
+        const waitForSelectedChannel = () => deps.wait(jump);
+        const onChannelSelect = (event: { channelId?: string | null; }) => {
+            if (event.channelId !== request.channelId) return;
+            waitForSelectedChannel();
+        };
+
+        cancelPending = cleanup;
+        const timeout = deps.setTimeout(() => {
+            cleanup();
+            deps.notify("Discord did not open the target channel in time");
+        }, MESSAGE_NAVIGATION_TIMEOUT_MS);
+
+        if (deps.getSelectedChannelId() === request.channelId) {
+            waitForSelectedChannel();
+            return true;
+        }
+
+        deps.subscribe(onChannelSelect);
+        try {
+            if (isThread(channel)) deps.transitionToThread(channel);
+            else deps.transitionToChannel(request.channelId);
+        } catch {
+            cleanup();
+            deps.notify("Could not open the target channel");
+            return false;
+        }
+
+        return true;
+    };
+
+    return { navigate, cancel };
+}

--- a/src/plugins/activityTimeline/persistence.ts
+++ b/src/plugins/activityTimeline/persistence.ts
@@ -1,0 +1,58 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import * as DataStore from "@api/DataStore";
+
+import { type PersistedTimelineStateV1, validatePersistedState } from "./store";
+
+export const HISTORY_KEY_PREFIX = "activity-timeline-history:";
+const WRITE_DELAY_MS = 250;
+
+export function historyKey(userId: string) {
+    return `${HISTORY_KEY_PREFIX}${userId}`;
+}
+
+export async function loadHistory(userId: string) {
+    const raw = await DataStore.get<unknown>(historyKey(userId));
+    return validatePersistedState(raw);
+}
+
+let writeChain = Promise.resolve();
+let pendingWrite: { userId: string; state: PersistedTimelineStateV1; onError?: (error: unknown) => void; } | undefined;
+let writeTimer: ReturnType<typeof setTimeout> | undefined;
+
+function enqueueWrite(userId: string, state: PersistedTimelineStateV1) {
+    writeChain = writeChain.catch(() => undefined).then(() => DataStore.set(historyKey(userId), state));
+    return writeChain;
+}
+
+function flushPending() {
+    if (writeTimer) clearTimeout(writeTimer);
+    writeTimer = undefined;
+    const pending = pendingWrite;
+    pendingWrite = undefined;
+    const write = pending ? enqueueWrite(pending.userId, pending.state) : writeChain;
+    return pending?.onError ? write.catch(error => {
+        pending.onError?.(error);
+        throw error;
+    }) : write;
+}
+
+export function queueHistoryWrite(userId: string, state: PersistedTimelineStateV1, onError?: (error: unknown) => void) {
+    pendingWrite = { userId, state, onError };
+    if (!writeTimer)
+        writeTimer = setTimeout(() => void flushPending().catch(() => undefined), WRITE_DELAY_MS);
+    return writeChain;
+}
+
+export function flushHistoryWrite() {
+    return flushPending();
+}
+
+export async function writeHistoryNow(userId: string, state: PersistedTimelineStateV1) {
+    await flushPending();
+    await enqueueWrite(userId, state);
+}

--- a/src/plugins/activityTimeline/store.test.ts
+++ b/src/plugins/activityTimeline/store.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    createTimelineStore,
+    MAX_TIMELINE_EVENTS,
+    TIMELINE_RETENTION_MS,
+    validatePersistedState
+} from "./store";
+
+const now = 1_000_000_000;
+
+function message(channelId: string, messageId: string, timestamp = now) {
+    return {
+        type: "message" as const,
+        timestamp,
+        guildId: "guild",
+        channelId,
+        messageId
+    };
+}
+
+function readyStore() {
+    const store = createTimelineStore();
+    store.hydrate({ version: 1, sessions: [], events: [] }, now);
+    return store;
+}
+
+function startStore(userId = "user") {
+    const store = readyStore();
+    assert.ok(store.start({ userId, mode: "self", startedAt: now }));
+    return store;
+}
+
+test("hydration closes interrupted sessions and never resumes tracking", () => {
+    const store = createTimelineStore();
+    store.hydrate({
+        version: 1,
+        sessions: [{ id: 3, targetUserId: "user", mode: "self", startedAt: now - 100, endedAt: null }],
+        events: [{ ...message("channel", "message", now - 20), id: 7, sessionId: 3 }]
+    }, now);
+
+    const snapshot = store.getSnapshot();
+    assert.equal(snapshot.activeSessionId, null);
+    assert.equal(snapshot.target, null);
+    assert.equal(snapshot.sessions[0].endedAt, now - 20);
+});
+
+test("starting a target creates a session without deleting previous history", () => {
+    const store = startStore("first");
+    store.addEvent(message("channel", "first"));
+    store.stop(now + 1);
+    assert.ok(store.start({ userId: "second", mode: "selected", startedAt: now + 2 }));
+    store.addEvent(message("channel", "second", now + 2));
+
+    assert.deepEqual(store.getSnapshot().events.filter(event => event.type === "message").map(event => event.messageId), ["first", "second"]);
+    assert.equal(store.getSnapshot().sessions.length, 2);
+    assert.equal(store.getSnapshot().target?.userId, "second");
+});
+
+test("stop preserves the selected user's history", () => {
+    const store = startStore();
+    store.addEvent(message("channel", "message"));
+    assert.equal(store.stop(now + 1), true);
+    assert.equal(store.getSnapshot().target, null);
+    assert.equal(store.getSnapshot().events.length, 1);
+    assert.equal(store.addEvent(message("channel", "later", now + 2)), false);
+});
+
+test("messages are deduplicated, and deleted messages remain marked", () => {
+    const store = startStore();
+    assert.equal(store.addEvent(message("channel", "message")), true);
+    assert.equal(store.addEvent(message("channel", "message")), false);
+    store.markMessageDeleted("channel", "message", now + 1);
+    const event = store.getSnapshot().events[0];
+    assert.equal(event.type, "message");
+    assert.equal(event.deletedAt, now + 1);
+});
+
+test("history expires only after 72 hours and orphan sessions are removed", () => {
+    const store = createTimelineStore();
+    store.hydrate({
+        version: 1,
+        sessions: [
+            { id: 1, targetUserId: "old", mode: "selected", startedAt: now - TIMELINE_RETENTION_MS - 2, endedAt: now - TIMELINE_RETENTION_MS - 1 },
+            { id: 2, targetUserId: "fresh", mode: "selected", startedAt: now - TIMELINE_RETENTION_MS, endedAt: null }
+        ],
+        events: [
+            { ...message("channel", "old", now - TIMELINE_RETENTION_MS - 1), id: 1, sessionId: 1 },
+            { ...message("channel", "fresh", now - TIMELINE_RETENTION_MS), id: 2, sessionId: 2 }
+        ]
+    }, now);
+
+    assert.deepEqual(store.getSnapshot().events.filter(event => event.type === "message").map(event => event.messageId), ["fresh"]);
+    assert.deepEqual(store.getSnapshot().sessions.map(session => session.targetUserId), ["fresh"]);
+});
+
+test("clear removes only the selected user and keeps an active target running", () => {
+    const store = startStore("first");
+    store.addEvent(message("channel", "first"));
+    store.stop(now + 1);
+    store.start({ userId: "second", mode: "selected", startedAt: now + 2 });
+    store.addEvent(message("channel", "second", now + 2));
+
+    store.clearForUser("first", now + 3);
+    assert.deepEqual(store.getSnapshot().events.filter(event => event.type === "message").map(event => event.messageId), ["second"]);
+    store.clearForUser("second", now + 4);
+    assert.equal(store.getSnapshot().target?.userId, "second");
+    assert.equal(store.getSnapshot().events.length, 0);
+    assert.equal(store.addEvent(message("channel", "after-clear", now + 5)), true);
+});
+
+test("the 20,001st event stops tracking without evicting valid history", () => {
+    const store = startStore();
+    for (let index = 0; index < MAX_TIMELINE_EVENTS; index++)
+        assert.equal(store.addEvent(message("channel", String(index), now + index)), true);
+
+    assert.equal(store.getSnapshot().events.length, MAX_TIMELINE_EVENTS);
+    assert.equal(store.addEvent(message("channel", "overflow", now + MAX_TIMELINE_EVENTS)), false);
+    assert.equal(store.getSnapshot().capacityReached, true);
+    assert.equal(store.getSnapshot().target, null);
+    assert.equal(store.getSnapshot().events.length, MAX_TIMELINE_EVENTS);
+});
+
+test("invalid records are salvaged and unknown versions are never treated as v1", () => {
+    const recovered = validatePersistedState({
+        version: 1,
+        sessions: [{ id: 1, targetUserId: "user", mode: "self", startedAt: now, endedAt: null }, { bad: true }],
+        events: [{ id: 2, sessionId: 1, type: "presence", timestamp: now, previousStatus: "offline", currentStatus: "online" }, { bad: true }]
+    });
+    assert.equal(recovered.recovered, true);
+    assert.equal(recovered.unsupported, false);
+    assert.equal(recovered.state.sessions.length, 1);
+    assert.equal(recovered.state.events.length, 1);
+
+    const unknown = validatePersistedState({ version: 99, sessions: [], events: [] });
+    assert.equal(unknown.unsupported, true);
+});

--- a/src/plugins/activityTimeline/store.ts
+++ b/src/plugins/activityTimeline/store.ts
@@ -1,0 +1,356 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export const MAX_TIMELINE_EVENTS = 20_000;
+export const TIMELINE_RETENTION_MS = 72 * 60 * 60 * 1000;
+
+export type TimelineMode = "self" | "selected";
+export type TimelineEventType = "message" | "presence" | "voice";
+export type PresenceStatus = "online" | "idle" | "dnd" | "invisible" | "offline";
+export type HydrationState = "loading" | "ready" | "error";
+
+export interface TimelineTarget {
+    userId: string;
+    mode: TimelineMode;
+    startedAt: number;
+}
+
+export interface TimelineSessionRecord {
+    id: number;
+    targetUserId: string;
+    mode: TimelineMode;
+    startedAt: number;
+    endedAt: number | null;
+}
+
+export type TimelineEventInput =
+    | {
+        type: "message";
+        timestamp: number;
+        guildId: string;
+        channelId: string;
+        messageId: string;
+      }
+    | {
+        type: "presence";
+        timestamp: number;
+        previousStatus: PresenceStatus;
+        currentStatus: PresenceStatus;
+      }
+    | {
+        type: "voice";
+        timestamp: number;
+        guildId: string;
+        action: "join" | "leave" | "move";
+        fromChannelId?: string;
+        toChannelId?: string;
+      };
+
+export type TimelineEvent = TimelineEventInput & {
+    id: number;
+    sessionId: number;
+    deletedAt?: number;
+};
+
+export type PersistedTimelineEvent = TimelineEvent;
+
+export interface PersistedTimelineStateV1 {
+    version: 1;
+    sessions: TimelineSessionRecord[];
+    events: PersistedTimelineEvent[];
+}
+
+export interface TimelineSnapshot {
+    target: TimelineTarget | null;
+    events: readonly TimelineEvent[];
+    sessions: readonly TimelineSessionRecord[];
+    activeSessionId: number | null;
+    hydrationState: HydrationState;
+    storageError: string | null;
+    capacityReached: boolean;
+}
+
+type Listener = () => void;
+
+function messageKey(channelId: string, messageId: string) {
+    return `${channelId}:${messageId}`;
+}
+
+function isPresenceStatus(value: unknown): value is PresenceStatus {
+    return value === "online" || value === "idle" || value === "dnd" || value === "invisible" || value === "offline";
+}
+
+function isFiniteTimestamp(value: unknown): value is number {
+    return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isString(value: unknown): value is string {
+    return typeof value === "string" && value.length > 0;
+}
+
+function isMode(value: unknown): value is TimelineMode {
+    return value === "self" || value === "selected";
+}
+
+function isSession(value: unknown): value is TimelineSessionRecord {
+    if (!value || typeof value !== "object") return false;
+    const session = value as Partial<TimelineSessionRecord>;
+    return typeof session.id === "number" && Number.isSafeInteger(session.id) && session.id > 0
+        && isString(session.targetUserId)
+        && isMode(session.mode)
+        && isFiniteTimestamp(session.startedAt)
+        && (session.endedAt === null || isFiniteTimestamp(session.endedAt));
+}
+
+function isEvent(value: unknown): value is PersistedTimelineEvent {
+    if (!value || typeof value !== "object") return false;
+    const event = value as Partial<TimelineEvent>;
+    if (typeof event.id !== "number" || !Number.isSafeInteger(event.id) || event.id <= 0 || typeof event.sessionId !== "number" || !Number.isSafeInteger(event.sessionId) || event.sessionId <= 0 || !isFiniteTimestamp(event.timestamp)) return false;
+
+    if (event.type === "message") {
+        return isString(event.guildId) && isString(event.channelId) && isString(event.messageId)
+            && (event.deletedAt === undefined || isFiniteTimestamp(event.deletedAt));
+    }
+    if (event.type === "presence")
+        return isPresenceStatus(event.previousStatus) && isPresenceStatus(event.currentStatus);
+    if (event.type === "voice") {
+        return isString(event.guildId)
+            && (event.action === "join" || event.action === "leave" || event.action === "move")
+            && (event.fromChannelId === undefined || isString(event.fromChannelId))
+            && (event.toChannelId === undefined || isString(event.toChannelId));
+    }
+    return false;
+}
+
+export function validatePersistedState(value: unknown): { state: PersistedTimelineStateV1; recovered: boolean; unsupported: boolean; } {
+    if (value === undefined || value === null)
+        return { state: { version: 1, sessions: [], events: [] }, recovered: false, unsupported: false };
+
+    if (typeof value !== "object")
+        return { state: { version: 1, sessions: [], events: [] }, recovered: true, unsupported: false };
+
+    const { version } = value as { version?: unknown; };
+    if (version !== undefined && version !== 1)
+        return { state: { version: 1, sessions: [], events: [] }, recovered: false, unsupported: true };
+
+    const raw = value as Partial<PersistedTimelineStateV1>;
+    const sessions = Array.isArray(raw.sessions) ? raw.sessions.filter(isSession) : [];
+    const sessionIds = new Set(sessions.map(session => session.id));
+    const events = Array.isArray(raw.events)
+        ? raw.events.filter((event): event is PersistedTimelineEvent => isEvent(event) && sessionIds.has(event.sessionId))
+        : [];
+    const recovered = version === undefined || !Array.isArray(raw.sessions) || !Array.isArray(raw.events) || sessions.length !== raw.sessions.length || events.length !== raw.events.length;
+    return { state: { version: 1, sessions, events }, recovered, unsupported: false };
+}
+
+function latestEventTimestamp(events: readonly TimelineEvent[], sessionId: number, fallback: number) {
+    return events.reduce((latest, event) => event.sessionId === sessionId ? Math.max(latest, event.timestamp) : latest, fallback);
+}
+
+export interface TimelineStore {
+    getSnapshot(): TimelineSnapshot;
+    subscribe(listener: Listener): () => void;
+    hydrate(state: PersistedTimelineStateV1 | null, now?: number): void;
+    setStorageError(message: string | null): void;
+    start(target: TimelineTarget): number | null;
+    stop(now?: number): boolean;
+    clearForUser(userId: string, now?: number): void;
+    clear(now?: number): void;
+    addEvent(event: TimelineEventInput): boolean;
+    markMessageDeleted(channelId: string, messageId: string, deletedAt?: number): void;
+    removeMessage(channelId: string, messageId: string): void;
+    removeChannel(channelId: string): void;
+    removeGuild(guildId: string): void;
+    prune(now?: number): boolean;
+    getPersistedState(now?: number): PersistedTimelineStateV1;
+}
+
+export function createTimelineStore(): TimelineStore {
+    let snapshot: TimelineSnapshot = {
+        target: null,
+        events: [],
+        sessions: [],
+        activeSessionId: null,
+        hydrationState: "loading",
+        storageError: null,
+        capacityReached: false
+    };
+    let nextEventId = 1;
+    let nextSessionId = 1;
+    let seenMessages = new Set<string>();
+    const listeners = new Set<Listener>();
+
+    const notify = () => listeners.forEach(listener => listener());
+
+    const rebuildIndexes = () => {
+        nextEventId = Math.max(0, ...snapshot.events.map(event => event.id)) + 1;
+        nextSessionId = Math.max(0, ...snapshot.sessions.map(session => session.id)) + 1;
+        seenMessages = new Set(snapshot.events.filter((event): event is TimelineEvent & { type: "message"; } => event.type === "message").map(event => messageKey(event.channelId, event.messageId)));
+    };
+
+    const update = (changes: Partial<TimelineSnapshot>) => {
+        snapshot = { ...snapshot, ...changes };
+        notify();
+    };
+
+    const activeSession = () => snapshot.activeSessionId === null ? undefined : snapshot.sessions.find(session => session.id === snapshot.activeSessionId);
+
+    const prune = (now = Date.now()) => {
+        const cutoff = now - TIMELINE_RETENTION_MS;
+        const events = snapshot.events.filter(event => event.timestamp >= cutoff);
+        const eventSessionIds = new Set(events.map(event => event.sessionId));
+        const sessions = snapshot.sessions.filter(session => eventSessionIds.has(session.id) || session.id === snapshot.activeSessionId || session.startedAt >= cutoff);
+        const capacityReset = snapshot.capacityReached && events.length < MAX_TIMELINE_EVENTS;
+        const changed = events.length !== snapshot.events.length || sessions.length !== snapshot.sessions.length || capacityReset;
+        if (!changed) return false;
+        snapshot = { ...snapshot, events, sessions, capacityReached: capacityReset ? false : snapshot.capacityReached };
+        rebuildIndexes();
+        notify();
+        return true;
+    };
+
+    return {
+        getSnapshot() {
+            return snapshot;
+        },
+
+        subscribe(listener) {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+
+        hydrate(state, now = Date.now()) {
+            const validated = validatePersistedState(state);
+            const sessions = validated.state.sessions.map(session => ({ ...session }));
+            const events = validated.state.events.map(event => ({ ...event }));
+            for (const session of sessions) {
+                if (session.endedAt === null)
+                    session.endedAt = latestEventTimestamp(events, session.id, session.startedAt);
+            }
+            snapshot = {
+                target: null,
+                events,
+                sessions,
+                activeSessionId: null,
+                hydrationState: validated.unsupported ? "error" : "ready",
+                storageError: validated.unsupported ? "This Activity Timeline history was created by a newer version and was not changed." : null,
+                capacityReached: false
+            };
+            rebuildIndexes();
+            prune(now);
+            notify();
+        },
+
+        setStorageError(message) {
+            update({ hydrationState: message ? "error" : "ready", storageError: message });
+        },
+
+        start(target) {
+            if (snapshot.hydrationState !== "ready" || snapshot.storageError) return null;
+            const now = target.startedAt;
+            prune(now);
+            const previous = activeSession();
+            if (previous) previous.endedAt = now;
+            const session: TimelineSessionRecord = {
+                id: nextSessionId++,
+                targetUserId: target.userId,
+                mode: target.mode,
+                startedAt: target.startedAt,
+                endedAt: null
+            };
+            snapshot = {
+                ...snapshot,
+                target: { ...target },
+                sessions: [...snapshot.sessions, session],
+                activeSessionId: session.id,
+                capacityReached: false
+            };
+            notify();
+            return session.id;
+        },
+
+        stop(now = Date.now()) {
+            const session = activeSession();
+            if (!session) return false;
+            session.endedAt = now;
+            update({ target: null, activeSessionId: null, capacityReached: false });
+            return true;
+        },
+
+        clearForUser(userId, now = Date.now()) {
+            const active = activeSession();
+            const keepActive = active?.targetUserId === userId;
+            const sessionIds = new Set(snapshot.sessions.filter(session => session.targetUserId === userId).map(session => session.id));
+            const sessions = snapshot.sessions.filter(session => !sessionIds.has(session.id) || (keepActive && session.id === active?.id));
+            const events = snapshot.events.filter(event => !sessionIds.has(event.sessionId));
+            if (keepActive && active) {
+                active.startedAt = now;
+                active.endedAt = null;
+            }
+            snapshot = { ...snapshot, sessions, events, capacityReached: false };
+            rebuildIndexes();
+            notify();
+        },
+
+        clear(now = Date.now()) {
+            const userId = activeSession()?.targetUserId;
+            if (userId) this.clearForUser(userId, now);
+        },
+
+        addEvent(event) {
+            const session = activeSession();
+            if (!session || snapshot.hydrationState !== "ready" || snapshot.storageError) return false;
+            const now = event.timestamp;
+            prune(now);
+            if (snapshot.events.length >= MAX_TIMELINE_EVENTS) {
+                session.endedAt = now;
+                update({ target: null, activeSessionId: null, capacityReached: true });
+                return false;
+            }
+            if (event.type === "message") {
+                const key = messageKey(event.channelId, event.messageId);
+                if (seenMessages.has(key)) return false;
+                seenMessages.add(key);
+            }
+            const nextEvent = { ...event, id: nextEventId++, sessionId: session.id } as TimelineEvent;
+            update({ events: [...snapshot.events, nextEvent] });
+            return true;
+        },
+
+        markMessageDeleted(channelId, messageId, deletedAt = Date.now()) {
+            const events = snapshot.events.map(event => event.type === "message" && event.channelId === channelId && event.messageId === messageId
+                ? { ...event, deletedAt }
+                : event);
+            if (events.some((event, index) => event !== snapshot.events[index])) update({ events });
+        },
+
+        removeMessage(channelId, messageId) {
+            this.markMessageDeleted(channelId, messageId);
+        },
+
+        removeChannel() {
+            // Channel deletion is reflected by ChannelStore at render time. Keep the
+            // event until its retention deadline so the history remains auditable.
+        },
+
+        removeGuild() {
+            // Guild deletion is reflected by GuildStore at render time.
+        },
+
+        prune,
+
+        getPersistedState(now = Date.now()) {
+            prune(now);
+            return {
+                version: 1,
+                sessions: snapshot.sessions.map(session => ({ ...session })),
+                events: snapshot.events.map(event => ({ ...event }))
+            };
+        }
+    };
+}
+
+export const timelineStore = createTimelineStore();

--- a/src/plugins/activityTimeline/style.css
+++ b/src/plugins/activityTimeline/style.css
@@ -1,0 +1,138 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+.vc-activity-timeline-modal {
+    min-height: 520px;
+}
+
+.vc-activity-timeline-summary {
+    padding: 4px 0 16px;
+}
+
+.vc-activity-timeline-target {
+    color: var(--header-primary);
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.vc-activity-timeline-targetHeader {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+}
+
+.vc-activity-timeline-avatar {
+    flex: 0 0 auto;
+}
+
+.vc-activity-timeline-activeBadge {
+    background: var(--status-positive-background);
+    border-radius: 4px;
+    color: var(--status-positive-text);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 3px 6px;
+    text-transform: uppercase;
+}
+
+.vc-activity-timeline-notice {
+    background: var(--background-secondary-alt);
+    border-radius: 4px;
+    color: var(--text-normal);
+    margin-top: 8px;
+    padding: 8px;
+}
+
+.vc-activity-timeline-error {
+    color: var(--text-danger);
+}
+
+.vc-activity-timeline-filters {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.vc-activity-timeline-filter {
+    min-width: 0;
+}
+
+.vc-activity-timeline-filter > div:first-child {
+    margin-bottom: 6px;
+}
+
+.vc-activity-timeline-scroller {
+    min-height: 320px;
+    max-height: 420px;
+}
+
+.vc-activity-timeline-event {
+    border-top: 1px solid var(--background-modifier-accent);
+    padding: 12px 4px;
+}
+
+.vc-activity-timeline-eventHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.vc-activity-timeline-eventType {
+    color: var(--text-link);
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.vc-activity-timeline-eventTitle {
+    color: var(--header-primary);
+    font-size: 15px;
+    font-weight: 600;
+    margin-top: 4px;
+}
+
+.vc-activity-timeline-eventDetails {
+    color: var(--text-normal);
+    font-size: 13px;
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vc-activity-timeline-jump {
+    background: none;
+    border: 0;
+    color: var(--text-link);
+    cursor: pointer;
+    font-size: 12px;
+    margin-top: 6px;
+    padding: 0;
+}
+
+.vc-activity-timeline-jump:disabled {
+    color: var(--text-muted);
+    cursor: not-allowed;
+}
+
+.vc-activity-timeline-empty {
+    align-items: center;
+    color: var(--text-muted);
+    display: flex;
+    justify-content: center;
+    min-height: 320px;
+    padding: 24px;
+    text-align: center;
+}
+
+@media (width <= 700px) {
+    .vc-activity-timeline-filters {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Quick about us
Hello guys, me and rexy are cybersecurity students in Portugal and full-stack developers, and today we're proposing a new plugin called ActivityTimeline

We both developed this plugin together, and we are trying to create more plugins that the community and you, Vencord developers, might enjoy, we even created an organization called Vencord Plugin Team (all the plugins are private for now, we've fully developed 2, and are making another 2)

## Describe your Changes

Here's what it does:

- It adds an ActivityTimeline plugin for reviewing recent Discord activity, it tracks events on the servers and accessible channels that the client and the targeted user share, such as **"joined the call in X server" "left call in Y server"**
- The tracking starts ONLY after the user explicitly presses start
- It only supports ONE selected user at a time
- It **records new messages, presence changes, and voice channel events**
- Stores only event metadata such as IDs, presence status, voice actions and timestamps; message content is **never** persisted
- Keeps local history for 72 hours, with a 20,000-event limit
- It includes filters, permission checks, cleanup, and navigation to accessible messages
- It **excludes DMs, inaccessible channels, typing events, profiles and Rich presence**
- It includes unit tests for storage, retention, sessions, permissions and navigation

## Screenshots about the plugin

### Initial modal 
<img width="477" height="792" alt="image" src="https://github.com/user-attachments/assets/2ce1a2f6-ca53-453f-8096-de2781f98323" />

### After tracking is active and the targeted user has made an event
<img width="477" height="798" alt="image" src="https://github.com/user-attachments/assets/4cea2456-c5c7-42da-a6a2-4143f042cc6b" />

### Tracking a specific event type, server, and channel
<img width="474" height="792" alt="image" src="https://github.com/user-attachments/assets/aca5b2e6-cdef-46c8-8ee7-d953b65938c6" />

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
