### PR TITLE
ClearURLs: Rewrite parts to more closely match reference implementation

### DIFF
--- a/src/plugins/clearURLs/README.md
+++ b/src/plugins/clearURLs/README.md
@@ -8,4 +8,4 @@ Uses data from the [ClearURLs browser extension](https://clearurls.xyz/).
 
 **Before:** `https://www.amazon.com/dp/exampleProduct/ref=sxin_0_pb?__mk_de_DE=ÅMÅŽÕÑ&keywords=tea&pd_rd_i=exampleProduct&pd_rd_r=8d39e4cd-1e4f-43db-b6e7-72e969a84aa5&pd_rd_w=1pcKM&pd_rd_wg=hYrNl&pf_rd_p=50bbfd25-5ef7-41a2-68d6-74d854b30e30&pf_rd_r=0GMWD0YYKA7XFGX55ADP&qid=1517757263&rnid=2914120011`
 
-**After:** `https://www.amazon.com/dp/exampleProduct/`
+**After:** `https://www.amazon.com/dp/exampleProduct`

--- a/src/plugins/clearURLs/index.ts
+++ b/src/plugins/clearURLs/index.ts
@@ -80,8 +80,8 @@ export default definePlugin({
         for (const [name, provider] of Object.entries(res.providers)) {
             const urlPattern = new RegExp(provider.urlPattern, "i");
 
-            const rules = provider.rules?.map(rule => new RegExp(rule, "i"));
-            const rawRules = provider.rawRules?.map(rule => new RegExp(rule, "i"));
+            const rules = provider.rules?.map(rule => new RegExp("^(?:" + rule + ")$", "i")); // Disallow substring matches
+            const rawRules = provider.rawRules?.map(rule => new RegExp(rule, "gi"));
             const exceptions = provider.exceptions?.map(ex => new RegExp(ex, "i"));
 
             this.rules.push({
@@ -95,20 +95,31 @@ export default definePlugin({
     },
 
     replacer(match: string) {
-        // Parse URL without throwing errors
+        let href = match, url: URL;
+
+        // Verify input is actually a valid URL
         try {
-            var url = new URL(match);
-        } catch (error) {
-            // Don't modify anything if we can't parse the URL
+            url = new URL(href);
+        } catch (e) {
             return match;
         }
 
-        // Cheap way to check if there are any search params
-        if (url.searchParams.entries().next().done) return match;
-
         // Check rules for each provider that matches
-        this.rules.forEach(({ urlPattern, exceptions, rawRules, rules }) => {
-            if (!urlPattern.test(url.href) || exceptions?.some(ex => ex.test(url.href))) return;
+        for (const { urlPattern, exceptions, rawRules, rules } of this.rules) {
+            if (!urlPattern.test(href) || exceptions?.some(ex => ex.test(href)))
+                continue;
+
+            const pHref = href;
+
+            rawRules?.forEach(rawRule => href = href.replace(rawRule, ""));
+
+            try {
+                url = new URL(href);
+            } catch (e) {
+                // If something goes wrong, restore string representation and continue
+                href = pHref;
+                continue;
+            }
 
             const toDelete: string[] = [];
 
@@ -124,15 +135,11 @@ export default definePlugin({
             // Delete matched params from list
             toDelete.forEach(param => url.searchParams.delete(param));
 
-            // Match and remove any raw rules
-            let cleanedUrl = url.href;
-            rawRules?.forEach(rawRule => {
-                cleanedUrl = cleanedUrl.replace(rawRule, "");
-            });
-            url = new URL(cleanedUrl);
-        });
+            // Update string representation of URL
+            href = url.href;
+        }
 
-        return url.toString();
+        return href;
     },
 
     cleanMessage(msg: MessageObject) {


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

several changes that either make this impl more similar to that of the ClearURLs browser addon, or add additional safety:
* wrapping parameter rules in `^$` to disallow substring matches (fixes erroneous matches such as `https://example.com/?utmaaa`), as well as a non-capturing group (not in the browser addon impl but guards against a malformed rule with a naked alternation being added in the future due to human error)
* add `g` to rawRules
* remove the early return for no search params (because that negates the whole point of raw rules) and apply raw rules before regular rules
* add a try/catch in each iteration of the loop to guard against malformed raw rules (once again, due to potential future human error)

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
