### PR TITLE
TenorGifSearch: add provider toggle (Tenor/Klipy)

### DIFF
--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import { isNonNullish } from "@utils/guards";
-import definePlugin from "@utils/types";
+import definePlugin, { OptionType } from "@utils/types";
 import { FluxDispatcher, LocaleStore } from "@webpack/common";
 
 // API key is taken from the GBoard app on iOS
@@ -126,10 +127,22 @@ async function fetchCategories(): Promise<TrendingCategories | null> {
 
 }
 
+const settings = definePluginSettings({
+    provider: {
+        type: OptionType.SELECT,
+        description: "Which GIF provider to use",
+        options: [
+            { label: "Tenor", value: "tenor", default: true },
+            { label: "Klipy (Discord's default)", value: "klipy" }
+        ]
+    }
+});
+
 export default definePlugin({
     name: "TenorGifSearch",
     description: "Restore Tenor GIF search",
     authors: [Devs.Lunascape],
+    settings,
 
     patches: [
         {
@@ -187,6 +200,10 @@ export default definePlugin({
             }
         }
     ],
+
+    isTenor() {
+        return settings.store.provider === "tenor";
+    },
 
     async start() {
         cachedCategories = await fetchCategories() ?? cachedCategories;

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import "./styles.css";
+
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
 import { isNonNullish } from "@utils/guards";
 import definePlugin, { OptionType } from "@utils/types";
-import { FluxDispatcher, LocaleStore } from "@webpack/common";
+import { FluxDispatcher, LocaleStore, Select } from "@webpack/common";
+
+const cl = classNameFactory("vc-tenorgifsearch-");
 
 // API key is taken from the GBoard app on iOS
 const TENOR_KEY = "3Z0688EVWYKH";
@@ -130,6 +135,7 @@ async function fetchCategories(): Promise<TrendingCategories | null> {
 const settings = definePluginSettings({
     provider: {
         type: OptionType.SELECT,
+        displayName: "Default Provider",
         description: "Which GIF provider to use",
         options: [
             { label: "Tenor", value: "tenor", default: true },
@@ -137,6 +143,32 @@ const settings = definePluginSettings({
         ]
     }
 });
+
+const providerOptions = [
+    { label: "Tenor", value: "tenor" },
+    { label: "Klipy", value: "klipy" }
+];
+
+function ProviderToggle({ instance }: { instance: { forceUpdate(): void; }; }) {
+    const { provider } = settings.use(["provider"]);
+
+    return (
+        <Select
+            className={cl("provider-select")}
+            options={providerOptions}
+            isSelected={v => v === provider}
+            select={v => {
+                if (v === settings.store.provider) return;
+                settings.store.provider = v;
+                // The search bar / header content is owned by Discord's own component,
+                // so it won't pick up the setting change on its own - force it to re-render.
+                instance.forceUpdate();
+            }}
+            serialize={v => v}
+            closeOnSelect={true}
+        />
+    );
+}
 
 export default definePlugin({
     name: "TenorGifSearch",
@@ -147,41 +179,48 @@ export default definePlugin({
     patches: [
         {
             find: "renderHeaderContent()",
-            replacement: {
-                match: /placeholder:(\i),"aria-label":(\i)/,
-                replace: 'placeholder:$1?.replace(/Giphy|Klipy/gi,"Tenor"),"aria-label":$2?.replace(/Giphy|Klipy/gi,"Tenor")'
-            }
+            replacement: [
+                {
+                    match: /placeholder:(\i),"aria-label":(\i)/,
+                    replace: 'placeholder:$self.isTenor()?$1?.replace(/Giphy|Klipy/gi,"Tenor"):$1,"aria-label":$self.isTenor()?$2?.replace(/Giphy|Klipy/gi,"Tenor"):$2'
+                },
+                {
+                    // Render the provider toggle to the left of the search bar / header content
+                    match: /children:\[(\i),this\.renderHeaderContent\(\)\]/,
+                    replace: "children:[$1,$self.renderProviderToggle(this),this.renderHeaderContent()]"
+                }
+            ]
         },
         {
             find: '"GIF_PICKER_TRENDING_FETCH_SUCCESS",trendingCategories:',
             replacement: [
                 {
                     match: /let \i=Date\.now\(\);\i\([^)]+\),\i\.\i\.get\(\{url:\i\.\i\.GIFS_SEARCH,query:\{q:(\i),/,
-                    replace: "return $self.handleSearchFetch($1);$&"
+                    replace: "if($self.isTenor())return $self.handleSearchFetch($1);$&"
                 },
                 {
                     match: /""!==(\i)&&null!=\1&&\i\.\i\.get\(\{url:\i\.\i\.GIFS_SUGGEST,/,
-                    replace: "return $self.handleSuggestionsFetch($1);$&"
+                    replace: "if($self.isTenor())return $self.handleSuggestionsFetch($1);$&"
                 },
                 {
                     match: /\i\.\i\.get\(\{url:\i\.\i\.GIFS_TRENDING,/,
-                    replace: "return $self.handleTrendingFetch();$&"
+                    replace: "if($self.isTenor())return $self.handleTrendingFetch();$&"
                 },
                 {
                     match: /let \i=Date\.now\(\);\i\([^)]+\),\i\.\i\.get\(\{url:\i\.\i\.GIFS_TRENDING_GIFS,/,
-                    replace: "return $self.handleTrendingGifsFetch();$&"
+                    replace: "if($self.isTenor())return $self.handleTrendingGifsFetch();$&"
                 },
                 {
                     match: /\i\.\i\.post\(\{url:\i\.\i\.GIFS_SELECT,body:\{id:(\i),q:(\i)\}/,
-                    replace: "$self.handleGifSelect($1,$2)&&false&&$&"
+                    replace: "($self.isTenor()?($self.handleGifSelect($1,$2),false):true)&&$&"
                 }
             ]
         },
         {
             find: '"IntegrationQueryStore"',
             replacement: {
-                match: /(?<=search\((\i),(\i)\)\{)null==\i\.getResults\(\1,\2\)&&/,
-                replace: "return $self.tenorIntegrationSearch($1,$2);null==void 0&&"
+                match: /(?<=search\((\i),(\i)\)\{)null==(\i)\.getResults\(\1,\2\)&&/,
+                replace: "if($self.isTenor())return $self.tenorIntegrationSearch($1,$2);null==$3.getResults($1,$2)&&"
             }
         },
         // Add back tenor command
@@ -189,20 +228,24 @@ export default definePlugin({
             find: 'commandId:"-16"',
             replacement: {
                 match: /commandId:"-16"}/,
-                replace: '$&,TENOR:{type:"GIF",command:"tenor",title:"Tenor",commandId:"-9"}'
+                replace: '$&,...($self.isTenor()?{TENOR:{type:"GIF",command:"tenor",title:"Tenor",commandId:"-9"}}:{})'
             }
         },
         {
             find: "#{intl::COMMAND_GIPHY_DESCRIPTION}",
             replacement: {
                 match: /(\i)===\i\.\i\.GIF\.title/,
-                replace: '$&||$1==="Tenor"'
+                replace: '$&||($self.isTenor()&&$1==="Tenor")'
             }
         }
     ],
 
     isTenor() {
         return settings.store.provider === "tenor";
+    },
+
+    renderProviderToggle(instance: { forceUpdate(): void; }) {
+        return <ProviderToggle instance={instance} />;
     },
 
     async start() {

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -149,24 +149,64 @@ const providerOptions = [
     { label: "Klipy", value: "klipy" }
 ];
 
-function ProviderToggle({ instance }: { instance: { forceUpdate(): void; }; }) {
+interface PickerInstance {
+    forceUpdate(): void;
+    handleClearQuery(): void;
+    handleChangeQuery(query: string): void;
+    props: { query: string; };
+}
+
+// Immediately re-applying a query right after clearing it didn't force a refetch - possibly
+// an internal debounce/dedup gate tied to timing (the intercepted search code stamps
+// Date.now()), or just that props.query hasn't actually propagated down as empty yet by
+// the time we re-set it. Rather than guess a fixed delay for either, poll for the actual
+// observable effect of the clear (props.query genuinely becoming empty) and fire the
+// requery the moment that's true - with a safety-net cutoff in case it never happens.
+const REQUERY_MAX_WAIT_MS = 500;
+
+function waitForQueryClear(instance: PickerInstance, onCleared: () => void) {
+    const deadline = Date.now() + REQUERY_MAX_WAIT_MS;
+
+    const check = () => {
+        if (instance.props.query === "" || Date.now() >= deadline) {
+            onCleared();
+        } else {
+            requestAnimationFrame(check);
+        }
+    };
+
+    requestAnimationFrame(check);
+}
+
+function ProviderToggle({ instance }: { instance: PickerInstance; }) {
     const { provider } = settings.use(["provider"]);
 
+    const onSelect = (v: string) => {
+        if (v === settings.store.provider) return;
+        settings.store.provider = v;
+        // The search bar / results grid are owned by Discord's own component, so they
+        // won't pick up the setting change on their own.
+        const { query } = instance.props;
+        instance.handleClearQuery();
+        if (query) {
+            waitForQueryClear(instance, () => instance.handleChangeQuery(query));
+        }
+        instance.forceUpdate();
+    };
+
     return (
-        <Select
-            className={cl("provider-select")}
-            options={providerOptions}
-            isSelected={v => v === provider}
-            select={v => {
-                if (v === settings.store.provider) return;
-                settings.store.provider = v;
-                // The search bar / header content is owned by Discord's own component,
-                // so it won't pick up the setting change on its own - force it to re-render.
-                instance.forceUpdate();
-            }}
-            serialize={v => v}
-            closeOnSelect={true}
-        />
+        // Discord's Select doesn't visibly respect width overrides passed via className,
+        // so clip it to size instead of fighting its internal styling - this doesn't
+        // depend on knowing anything about its internal DOM structure.
+        <div className={cl("provider-select-clip")}>
+            <Select
+                options={providerOptions}
+                isSelected={v => v === provider}
+                select={onSelect}
+                serialize={v => v}
+                closeOnSelect={true}
+            />
+        </div>
     );
 }
 
@@ -244,7 +284,7 @@ export default definePlugin({
         return settings.store.provider === "tenor";
     },
 
-    renderProviderToggle(instance: { forceUpdate(): void; }) {
+    renderProviderToggle(instance: PickerInstance) {
         return <ProviderToggle instance={instance} />;
     },
 

--- a/src/plugins/tenorGifSearch/index.tsx
+++ b/src/plugins/tenorGifSearch/index.tsx
@@ -156,14 +156,9 @@ interface PickerInstance {
     props: { query: string; };
 }
 
-// Immediately re-applying a query right after clearing it didn't force a refetch - possibly
-// an internal debounce/dedup gate tied to timing (the intercepted search code stamps
-// Date.now()), or just that props.query hasn't actually propagated down as empty yet by
-// the time we re-set it. Rather than guess a fixed delay for either, poll for the actual
-// observable effect of the clear (props.query genuinely becoming empty) and fire the
-// requery the moment that's true - with a safety-net cutoff in case it never happens.
 const REQUERY_MAX_WAIT_MS = 500;
 
+// Polls until the picker's query has actually cleared, then calls onCleared().
 function waitForQueryClear(instance: PickerInstance, onCleared: () => void) {
     const deadline = Date.now() + REQUERY_MAX_WAIT_MS;
 
@@ -184,8 +179,8 @@ function ProviderToggle({ instance }: { instance: PickerInstance; }) {
     const onSelect = (v: string) => {
         if (v === settings.store.provider) return;
         settings.store.provider = v;
-        // The search bar / results grid are owned by Discord's own component, so they
-        // won't pick up the setting change on their own.
+
+        // Reload the picker under the new provider.
         const { query } = instance.props;
         instance.handleClearQuery();
         if (query) {
@@ -195,9 +190,7 @@ function ProviderToggle({ instance }: { instance: PickerInstance; }) {
     };
 
     return (
-        // Discord's Select doesn't visibly respect width overrides passed via className,
-        // so clip it to size instead of fighting its internal styling - this doesn't
-        // depend on knowing anything about its internal DOM structure.
+        // Fixed-width clip; Discord's Select ignores plain width overrides.
         <div className={cl("provider-select-clip")}>
             <Select
                 options={providerOptions}

--- a/src/plugins/tenorGifSearch/styles.css
+++ b/src/plugins/tenorGifSearch/styles.css
@@ -1,6 +1,6 @@
-.vc-tenorgifsearch-provider-select {
-    width: 45px;
-    min-width: 0;
+.vc-tenorgifsearch-provider-select-clip {
+    width: 105px;
+    overflow: hidden;
     flex: 0 0 auto;
     margin-right: 8px;
 }

--- a/src/plugins/tenorGifSearch/styles.css
+++ b/src/plugins/tenorGifSearch/styles.css
@@ -1,0 +1,6 @@
+.vc-tenorgifsearch-provider-select {
+    width: 45px;
+    min-width: 0;
+    flex: 0 0 auto;
+    margin-right: 8px;
+}


### PR DESCRIPTION
  - **TenorGifSearch: add provider setting (WIP)**
  - **TenorGifSearch: gate provider behind isTenor(), add inline picker toggle**
  - **TenorGifSearch: clip provider dropdown width, reload results on provider switch**
  - **cleaned code readbility**
  
  <!--
  We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
  -->
  
  ## Describe your Changes
  Added a setting for default GIF provider and a dropdown toggle next to the search bar.
  Switching provider after querying will immidiately show the same query with the other provider.
  This was tested on Windows and Linux, works fine on Windows but on Linux, the tenor GIFs did not have a preview. This issue existed prior to my changes.
  
  ## Checklist before submitting
  - [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
  - [x] This pull request was written by me, and not an AI agent
