### PR TITLE
ImageZoom: Fix magnifier showing a broken image for some plugins

### DIFF
--- a/src/plugins/imageZoom/components/Magnifier.tsx
+++ b/src/plugins/imageZoom/components/Magnifier.tsx
@@ -153,6 +153,10 @@ export const Magnifier = ErrorBoundary.wrap<MagnifierProps>(({ instance, size: i
     const imageSrc = useMemo(() => {
         try {
             const imageUrl = new URL(instance.props.src);
+
+            if (imageUrl.protocol !== "http:" && imageUrl.protocol !== "https:")
+                return instance.props.src;
+
             if (imageUrl.pathname.startsWith("/attachments/"))
                 imageUrl.hostname = "cdn.discordapp.com";
 


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
Also do not use AI in communication, it makes me ill

🫡
-->

## Describe your Changes
While building a private userplugin that swaps attachments to blob URLs, I noticed ImageZoom broke and couldn´t zoom in... This was due to `searchParams.set` adding a query that blob/data URLs can´t carry, I noticed that PreviewMessage also renders message attachments from blob, so it's affected (tested) by the same thing (it already appends # to those URLs specifically to stop Discord adding query params)... 
This fixes edge cases like ¨blob:¨, ¨data:¨ or anything else by returning `instance.props.src` **unmodified**.

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
