### PR TITLE
LoadLazyChunks: cache isWorkerAsset

### DIFF
--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -30,9 +30,28 @@ function getWebpackChunkMap() {
     return chunksMap as Record<PropertyKey, string> | null;
 }
 
+const workerAssetCache: Map<string, boolean> = new Map();
+const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
+
 export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");
     const queue = pLimit(50);
+
+    async function isWorkerAsset(url: string): Promise<boolean> {
+        if (workerAssetCache.has(url)) {
+            return workerAssetCache.get(url)!;
+        }
+        const iwa = await queue(() => {
+            return fetch(url)
+                .then(r => r.text())
+                .then(t => WORKER_ASSET_REGEX.test(t));
+        });
+
+        workerAssetCache.set(url, iwa);
+
+        return iwa;
+    }
+
 
     try {
         LazyChunkLoaderLogger.log("Loading all chunks...");
@@ -93,13 +112,7 @@ export async function loadLazyChunks() {
 
                     if (wreq.u(id) == null || wreq.u(id) === "undefined.js") continue;
 
-                    const isWorkerAsset = await queue(() =>
-                        fetch(wreq.p + wreq.u(id))
-                            .then(r => r.text())
-                            .then(t => /importScripts\(|self\.postMessage/.test(t))
-                    );
-
-                    if (isWorkerAsset) {
+                    if (await isWorkerAsset(wreq.p + wreq.u(id))) {
                         invalidChunks.add(id);
                         invalidChunkGroup = true;
                         continue;
@@ -198,12 +211,10 @@ export async function loadLazyChunks() {
         });
 
         await Promise.all(chunksLeft.map(async id => queue(async () => {
-            const isWorkerAsset = await fetch(wreq.p + wreq.u(id))
-                .then(r => r.text())
-                .then(t => /importScripts\(|self\.postMessage/.test(t));
+            const isWorkerFile = await isWorkerAsset(wreq.p + wreq.u(id));
 
             // Loads the chunk. Currently this only happens with the language packs which are loaded differently
-            if (!isWorkerAsset) {
+            if (!isWorkerFile) {
                 await wreq.e(id);
             }
         })));

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -30,41 +30,30 @@ function getWebpackChunkMap() {
     return chunksMap as Record<PropertyKey, string> | null;
 }
 
-const workerAssetCache: Map<string, boolean> = new Map();
-const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
-
 export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");
     const queue = pLimit(50);
-    const pendingWorkerAssetChecks: Map<string, Promise<boolean>> = new Map();
+    const workerAssetCache = new Map<string, Promise<boolean>>();
+    const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
 
     async function isWorkerAsset(url: string, useQueue: boolean = true): Promise<boolean> {
         if (workerAssetCache.has(url)) {
             return workerAssetCache.get(url)!;
         }
 
-        if (pendingWorkerAssetChecks.has(url)) {
-            return await pendingWorkerAssetChecks.get(url)!;
-        }
-
-        const qFunc = () => {
+        const doFetch = () => {
             return fetch(url)
                 .then(r => r.text())
                 .then(t => WORKER_ASSET_REGEX.test(t));
         };
 
-        const iwap = (useQueue ? queue(qFunc) : qFunc());
+        const res = useQueue
+            ? queue(doFetch)
+            : doFetch();
 
-        pendingWorkerAssetChecks.set(url, iwap);
-
-        const iwa = await iwap;
-
-        workerAssetCache.set(url, iwa);
-        pendingWorkerAssetChecks.delete(url);
-
-        return iwa;
+        workerAssetCache.set(url, res);
+        return res;
     }
-
 
     try {
         LazyChunkLoaderLogger.log("Loading all chunks...");

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -47,7 +47,7 @@ export async function loadLazyChunks() {
             return await pendingWorkerAssetChecks.get(url)!;
         }
 
-        let qFunc = () => {
+        const qFunc = () => {
             return fetch(url)
                 .then(r => r.text())
                 .then(t => WORKER_ASSET_REGEX.test(t));

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -36,10 +36,15 @@ const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
 export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");
     const queue = pLimit(50);
+    const pendingWorkerAssetChecks: Map<string, Promise<boolean>> = new Map();
 
     async function isWorkerAsset(url: string, useQueue: boolean = true): Promise<boolean> {
         if (workerAssetCache.has(url)) {
             return workerAssetCache.get(url)!;
+        }
+
+        if (pendingWorkerAssetChecks.has(url)) {
+            return await pendingWorkerAssetChecks.get(url)!;
         }
 
         let qFunc = () => {
@@ -48,9 +53,14 @@ export async function loadLazyChunks() {
                 .then(t => WORKER_ASSET_REGEX.test(t));
         };
 
-        const iwa = await (useQueue ? queue(qFunc) : qFunc());
+        const iwap = (useQueue ? queue(qFunc) : qFunc());
+
+        pendingWorkerAssetChecks.set(url, iwap);
+
+        const iwa = await iwap;
 
         workerAssetCache.set(url, iwa);
+        pendingWorkerAssetChecks.delete(url);
 
         return iwa;
     }

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -14,7 +14,7 @@ import pLimit from "p-limit";
 
 function getWebpackChunkMap() {
     const sym = Symbol();
-    let chunksMap: unknown;
+    let chunksMap: unknown = null;
 
     Object.defineProperty(Object.prototype, sym, {
         get() {

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -29,14 +29,17 @@ function getWebpackChunkMap() {
 
     return chunksMap as Record<PropertyKey, string> | null;
 }
-let didLoadChunks = false;
+
+let chunksAlreadyLoaded = false;
 
 export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");
-    if (didLoadChunks) {
-        LazyChunkLoaderLogger.log("Already loaded lazy chunks");
+
+    if (chunksAlreadyLoaded) {
+        LazyChunkLoaderLogger.log("Lazy chunks have already been loaded");
         return;
     }
+
     const queue = pLimit(50);
     const workerAssetCache = new Map<string, Promise<boolean>>();
     const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
@@ -68,12 +71,12 @@ export async function loadLazyChunks() {
         const invalidChunks = new Set<PropertyKey>();
         const deferredRequires = new Set<PropertyKey>();
 
-        const { promise: chunksSearchingDone, resolve: chunksSearchingResolve } = Promise.withResolvers<void>();
+        const { promise: chunkSearchingDone, resolve: chunkSearchingDoneResolve } = Promise.withResolvers<void>();
 
-        // True if resolved, false otherwise
-        const chunksSearchPromises = [] as Array<() => boolean>;
+        // True if searching promise for that chunk is resolved, false otherwise
+        let chunkSearchResolvedGetters = [] as Array<() => boolean>;
 
-        // This regex loads all language packs which makes webpack finds testing extremely slow, so for now, we prioritize using the one which doesnt include those
+        // This regex loads all language packs which makes webpack finds testing extremely slow, so for now, we prioritize using the one which doesn't include those
         const CompleteLazyChunkRegex = canonicalizeMatch(/(?:(?:Promise\.all\(\[)?((?:\i\.e\("?[^)]+?"?\),?)+?)(?:\]\))?)\.then\(\i(?:\.\i)?\.bind\(\i,"?([^)]+?)"?(?:,[^)]+?)?\)\)/g);
         const PartialLazyChunkRegex = canonicalizeMatch(/(?:(?:Promise\.all\(\[)?((?:\i\.e\("?[^)]+?"?\),?)+?)(?:\]\))?)\.then\(\i\.bind\(\i,"?([^)]+?)"?\)\)/g);
 
@@ -83,7 +86,7 @@ export async function loadLazyChunks() {
             // Workaround to avoid loading the CSS debugging chunk which turns the app pink
             // const hasCssDebuggingLoad = foundCssDebuggingLoad ? false : (foundCssDebuggingLoad = factoryCode.includes(".cssDebuggingEnabled&&"));
 
-            // Disabled for now since this causes lots of chunks concatenated into the same module get marked as invalid, and thus not loaded.
+            // Disabled for now since this causes lots of chunks concatenated into the same module to get marked as invalid, and thus not loaded.
             const hasCssDebuggingLoad = foundCssDebuggingLoad = false;
 
             const lazyChunks = factoryCode.matchAll(hasCssDebuggingLoad ? CompleteLazyChunkRegex : PartialLazyChunkRegex);
@@ -161,34 +164,27 @@ export async function loadLazyChunks() {
                 }
             }
 
-            // setImmediate to only check if all chunks were loaded after this function resolves
-            // We check if all chunks were loaded every time a factory is loaded
-            // If we are still looking for chunks in the other factories, the array will have that factory's chunk search promise not resolved
-            // But, if all chunk search promises are resolved, this means we found every lazy chunk loaded by Discord code and manually loaded them
+
+            // Filter out resolved chunk search promises. If the array length is 0 that means all the pending searches and loadings are done
+            // and our regex has finished scanning all modules. Once this happens, the artificial "natural" loading of chunks has been completed
+            // and we can continue with the rest of the code.
+            // setImmediate here is needed so the filtering also includes the promises created from searching the modules loaded by the current invokation.
+            // Otherwise, it could resolve before the async code being put at the end of the event loop has a chance to run and add the promise to the array.
+            // The async code mentioned is the invokation of the current function from the factoryListener.
             setTimeout(() => {
-                let allResolved = true;
-
-                for (let i = 0; i < chunksSearchPromises.length; i++) {
-                    const isResolved = chunksSearchPromises[i]();
-
-                    if (isResolved) {
-                        // Remove finished promises to avoid having to iterate through a huge array everytime
-                        chunksSearchPromises.splice(i--, 1);
-                    } else {
-                        allResolved = false;
-                    }
+                chunkSearchResolvedGetters = chunkSearchResolvedGetters.filter(isResolvedGetter => !isResolvedGetter());
+                if (chunkSearchResolvedGetters.length === 0) {
+                    chunkSearchingDoneResolve();
                 }
-
-                if (allResolved) chunksSearchingResolve();
             }, 0);
         }
 
         function factoryListener(factory: AnyModuleFactory | ModuleFactory) {
             let isResolved = false;
             searchAndLoadLazyChunks(String(factory))
-                .finally(() => { isResolved = true; });
+                .finally(() => isResolved = true);
 
-            chunksSearchPromises.push(() => isResolved);
+            chunkSearchResolvedGetters.push(() => isResolved);
         }
 
         Webpack.factoryListeners.add(factoryListener);
@@ -196,7 +192,7 @@ export async function loadLazyChunks() {
             factoryListener(wreq.m[moduleId]);
         }
 
-        await chunksSearchingDone;
+        await chunkSearchingDone;
         Webpack.factoryListeners.delete(factoryListener);
 
         // Require deferred entry points
@@ -227,7 +223,7 @@ export async function loadLazyChunks() {
         })));
 
         LazyChunkLoaderLogger.log("Finished loading all chunks!");
-        didLoadChunks = true;
+        chunksAlreadyLoaded = true;
     } catch (e) {
         LazyChunkLoaderLogger.log("A fatal error occurred:", e);
     }

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -29,12 +29,18 @@ function getWebpackChunkMap() {
 
     return chunksMap as Record<PropertyKey, string> | null;
 }
-const workerAssetCache = new Map<string, Promise<boolean>>();
-const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
+let didLoadChunks = false;
 
 export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");
+    if (didLoadChunks) {
+        LazyChunkLoaderLogger.log("Already loaded lazy chunks");
+        return;
+    }
     const queue = pLimit(50);
+    const workerAssetCache = new Map<string, Promise<boolean>>();
+    const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
+
 
     async function isWorkerAsset(url: string, useQueue: boolean = true): Promise<boolean> {
         if (workerAssetCache.has(url)) {
@@ -222,6 +228,7 @@ export async function loadLazyChunks() {
         })));
 
         LazyChunkLoaderLogger.log("Finished loading all chunks!");
+        didLoadChunks = true;
     } catch (e) {
         LazyChunkLoaderLogger.log("A fatal error occurred:", e);
     }

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -213,10 +213,9 @@ export async function loadLazyChunks() {
         });
 
         await Promise.all(chunksLeft.map(async id => queue(async () => {
-            // we will deadlock if we use the queue inside a queue func
+            // We will deadlock if we use the queue inside a queue func
             const isWorkerFile = await isWorkerAsset(wreq.p + wreq.u(id), false);
 
-            // Loads the chunk. Currently this only happens with the language packs which are loaded differently
             if (!isWorkerFile) {
                 await wreq.e(id);
             }

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -29,12 +29,12 @@ function getWebpackChunkMap() {
 
     return chunksMap as Record<PropertyKey, string> | null;
 }
+const workerAssetCache = new Map<string, Promise<boolean>>();
+const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
 
 export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");
     const queue = pLimit(50);
-    const workerAssetCache = new Map<string, Promise<boolean>>();
-    const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
 
     async function isWorkerAsset(url: string, useQueue: boolean = true): Promise<boolean> {
         if (workerAssetCache.has(url)) {

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -186,8 +186,7 @@ export async function loadLazyChunks() {
         function factoryListener(factory: AnyModuleFactory | ModuleFactory) {
             let isResolved = false;
             searchAndLoadLazyChunks(String(factory))
-                .then(() => isResolved = true)
-                .catch(() => isResolved = true);
+                .finally(() => { isResolved = true; });
 
             chunksSearchPromises.push(() => isResolved);
         }

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -44,7 +44,6 @@ export async function loadLazyChunks() {
     const workerAssetCache = new Map<string, Promise<boolean>>();
     const WORKER_ASSET_REGEX = /importScripts\(|self\.postMessage/;
 
-
     async function isWorkerAsset(url: string, useQueue: boolean = true): Promise<boolean> {
         if (workerAssetCache.has(url)) {
             return workerAssetCache.get(url)!;

--- a/src/debug/loadLazyChunks.ts
+++ b/src/debug/loadLazyChunks.ts
@@ -37,15 +37,18 @@ export async function loadLazyChunks() {
     const LazyChunkLoaderLogger = new Logger("LazyChunkLoader");
     const queue = pLimit(50);
 
-    async function isWorkerAsset(url: string): Promise<boolean> {
+    async function isWorkerAsset(url: string, useQueue: boolean = true): Promise<boolean> {
         if (workerAssetCache.has(url)) {
             return workerAssetCache.get(url)!;
         }
-        const iwa = await queue(() => {
+
+        let qFunc = () => {
             return fetch(url)
                 .then(r => r.text())
                 .then(t => WORKER_ASSET_REGEX.test(t));
-        });
+        };
+
+        const iwa = await (useQueue ? queue(qFunc) : qFunc());
 
         workerAssetCache.set(url, iwa);
 
@@ -211,7 +214,8 @@ export async function loadLazyChunks() {
         });
 
         await Promise.all(chunksLeft.map(async id => queue(async () => {
-            const isWorkerFile = await isWorkerAsset(wreq.p + wreq.u(id));
+            // we will deadlock if we use the queue inside a queue func
+            const isWorkerFile = await isWorkerAsset(wreq.p + wreq.u(id), false);
 
             // Loads the chunk. Currently this only happens with the language packs which are loaded differently
             if (!isWorkerFile) {

--- a/src/debug/runReporter.ts
+++ b/src/debug/runReporter.ts
@@ -17,7 +17,7 @@ async function runReporter() {
     try {
         ReporterLogger.log("Starting test...");
 
-        const { promise: loadLazyChunksDone, resolve: loadLazyChunksResolve } = Promise.withResolvers<void>();
+        const { promise: loadLazyChunksDone, resolve: loadLazyChunksDoneResolve } = Promise.withResolvers<void>();
 
         // The main patch for starting the reporter chunk loading
         addPatch({
@@ -28,11 +28,10 @@ async function runReporter() {
             }
         }, "Vencord Reporter");
 
+        // initReporter is called in the patched entry point of Discord
         // @ts-expect-error
         Vencord.Webpack._initReporter = function () {
-            // initReporter is called in the patched entry point of Discord
-            // setImmediate to only start searching for lazy chunks after Discord initialized the app
-            setTimeout(() => loadLazyChunks().then(loadLazyChunksResolve), 0);
+            loadLazyChunks().then(loadLazyChunksDoneResolve);
         };
 
         await loadLazyChunksDone;


### PR DESCRIPTION
isWorkerAsset accounted for 2/3 of **all** requests while running reporter

by caching it we don't send those requests, lifting preasure on the queue, making the reporter faster and use less resources

35k requests -> 11k requests

## before
<img width="373" height="32" alt="image" src="https://github.com/user-attachments/assets/347b240c-fa10-4884-95c8-fd48ba7b88bc" />

<img width="1916" height="599" alt="image" src="https://github.com/user-attachments/assets/3101124d-56f5-41e3-ab9a-0faadd49c8fb" />

## After

<img width="347" height="27" alt="image" src="https://github.com/user-attachments/assets/e6437388-ba11-4467-b1f8-66cae8beeab1" />

<img width="1922" height="421" alt="image" src="https://github.com/user-attachments/assets/8deaa9cb-680f-4afa-a875-22e4bd7d6f48" />
