### PR TITLE
fix(expressionCloner): Better handing of fakeNitro emojis

### DIFF
--- a/src/plugins/expressionCloner/index.tsx
+++ b/src/plugins/expressionCloner/index.tsx
@@ -372,7 +372,7 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
     const menuItem = (() => {
         switch (favoriteableType) {
             case "emoji":
-                const match: string = props.message.content.match(RegExp(`<a?:(\\w+)(?:~\\d+)?:${favoriteableId}>|https://cdn\\.discordapp\\.com/emojis/${favoriteableId}\\..*(?=\\))`));
+                const match: string = props.message.content.match(RegExp(`<a?:(\\w+)(?:~\\d+)?:${favoriteableId}>|https://cdn\\.discordapp\\.com/emojis/${favoriteableId}\\.[\\w?&=%]*`));
                 const reaction = props.message.reactions.find(reaction => reaction.emoji.id === favoriteableId);
                 if (!match && !reaction) return;
 

--- a/src/plugins/expressionCloner/index.tsx
+++ b/src/plugins/expressionCloner/index.tsx
@@ -372,10 +372,18 @@ const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) =
     const menuItem = (() => {
         switch (favoriteableType) {
             case "emoji":
-                const match = props.message.content.match(RegExp(`<a?:(\\w+)(?:~\\d+)?:${favoriteableId}>|https://cdn\\.discordapp\\.com/emojis/${favoriteableId}\\.`));
+                const match: string = props.message.content.match(RegExp(`<a?:(\\w+)(?:~\\d+)?:${favoriteableId}>|https://cdn\\.discordapp\\.com/emojis/${favoriteableId}\\..*(?=\\))`));
                 const reaction = props.message.reactions.find(reaction => reaction.emoji.id === favoriteableId);
                 if (!match && !reaction) return;
-                const name = (match && match[1]) ?? reaction?.emoji.name ?? "FakeNitroEmoji";
+
+                let url: URL | null = null;
+                try {
+                    url = new URL(match[0]);
+                } catch { }
+                const fakeNitroName = match[0].startsWith("https") ?
+                    EmojiStore.getCustomEmojiById(favoriteableId)?.name ?? url?.searchParams.get("name") ?? undefined :
+                    undefined;
+                const name = match[1] ?? fakeNitroName ?? reaction?.emoji.name ?? "FakeNitroEmoji";
 
                 return buildMenuItem("Emoji", () => ({
                     id: favoriteableId,
@@ -417,7 +425,7 @@ export default definePlugin({
     description: "Allows you to clone Emotes & Stickers to your own server (right click them)",
     tags: ["Emotes", "Servers"],
     searchTerms: ["StickerCloner", "EmoteCloner", "EmojiCloner"],
-    authors: [Devs.Ven, Devs.Nuckyz],
+    authors: [Devs.Ven, Devs.Nuckyz, Devs.scattagain],
     contextMenus: {
         "message": messageContextMenuPatch,
         "expression-picker": expressionPickerPatch

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -651,8 +651,8 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         id: 383365021415243776n
     },
     paige: {
-         name: "paige",
-         id: 1375697625864601650n
+        name: "paige",
+        id: 1375697625864601650n
     },
     jax: {
         name: "jax",
@@ -661,7 +661,11 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     yuna0x0: {
         name: "yuna0x0",
         id: 213656926414831616n
-    }
+    },
+    scattagain: {
+        name: "Amelia",
+        id: 1098234477626544180n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -651,8 +651,8 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         id: 383365021415243776n
     },
     paige: {
-        name: "paige",
-        id: 1375697625864601650n
+         name: "paige",
+         id: 1375697625864601650n
     },
     jax: {
         name: "jax",


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
Also do not use AI in communication, it makes me ill
-->

## Describe your Changes
A small change that makes expressionCloner atleast attempt to get the name of fakeNitro emojis, the logic should be equivalent to how fakeNitro does it for the emoji popup.

## Screenshots (if applicable)

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
