### PR TITLE
add plugin to Enable Screenshare on Unavailable countries (Brazil)

### DIFF
--- a/src/plugins/enableUnavailableScreenshare/README.md
+++ b/src/plugins/enableUnavailableScreenshare/README.md
@@ -1,0 +1,5 @@
+# EnableUnavailableScreenshare
+
+Enables `videoEnabled` in Discord's screen sharing configuration variations for users affected by the regional restriction in Brazil.
+
+The plugin changes the `videoEnabled` value from `false` to `true` in variations 1 and 2. It does not change server-side configuration or enforcement.

--- a/src/plugins/enableUnavailableScreenshare/index.ts
+++ b/src/plugins/enableUnavailableScreenshare/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "EnableUnavailableScreenshare",
+    description: "Enables screen sharing variations for users affected by the regional restriction in Brazil",
+    tags: ["Voice"],
+    authors: [Devs.Cicholas_],
+
+    patches: [
+        {
+            find: "variations:{1:{videoEnabled:!1},2:{videoEnabled:!1}}",
+            replacement: {
+                match: /(variations:\{1:\{videoEnabled:)!1(\},2:\{videoEnabled:)!1(?=\}\})/,
+                replace: "$1!0$2!0"
+            }
+        }
+    ]
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -655,8 +655,8 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         id: 383365021415243776n
     },
     paige: {
-         name: "paige",
-         id: 1375697625864601650n
+        name: "paige",
+        id: 1375697625864601650n
     },
     jax: {
         name: "jax",
@@ -669,7 +669,11 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Davri: {
         name: "Davri",
         id: 457579346282938368n
-    }
+    },
+    Cicholas_: {
+        name: "Cicholas_",
+        id: 268108896294535168n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Describe your Changes

Recently [Brazilian Government had inquired Discord ](https://discord.com/blog/a-letter-to-the-discord-community-in-brazil)to disable screensharing and camera. Basically what discord did was the creation of a custom configuration that is loaded internally, probably by a Feature Flag system.

My plugin basically overrides this `videoEnabled` flag with `true`.

## Screenshots (if applicable)

<img width="600" alt="HP-4_QeXoAA4jcd" src="https://github.com/user-attachments/assets/af3f40db-6180-429c-9e7a-a4ac6735313c" />

## Known Limitation

For some reason Camera sharing is enabled, it starts to buffer and shows that you are currently sending your camer, but it won't load for another users.

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
