### PR TITLE
WebPWA: fix popout & fullscreen styling

### DIFF
--- a/browser/monacoWin.html
+++ b/browser/monacoWin.html
@@ -7,7 +7,6 @@
             html,
             body,
             #container {
-                position: absolute;
                 left: 0;
                 top: 0;
                 width: 100%;
@@ -15,11 +14,34 @@
                 margin: 0;
                 padding: 0;
                 overflow: hidden;
+                background-color: #1e1e1e;
+            }
+
+            body {
+                display: flex;
+                flex-direction: column;
+            }
+
+            #title-bar {
+                display: none;
+            }
+
+            @media all and (display-mode: window-controls-overlay) {
+                #title-bar {
+                    display: flex;
+                    align-items: center;
+                    padding-left: 14px;
+                    font-family: Consolas, Courier New, monospace;
+                    line-height: 1;
+                    height: env(titlebar-area-height, 0px);
+                    app-region: drag;
+                }
             }
         </style>
     </head>
 
     <body>
+        <div id="title-bar">Vencord QuickCSS Editor</div>
         <div id="container"></div>
 
         <script>

--- a/browser/monacoWin.html
+++ b/browser/monacoWin.html
@@ -35,6 +35,7 @@
                     line-height: 1;
                     height: env(titlebar-area-height, 0px);
                     app-region: drag;
+                    color: white;
                 }
             }
         </style>

--- a/src/plugins/webPWA.browser/styles.css
+++ b/src/plugins/webPWA.browser/styles.css
@@ -13,6 +13,18 @@
     [class*="bar_"] [class*="trailing_"] {
         padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0px));
     }
+
+    /* popout windows like screenshare popout, these properties don't work outside WCO so this is safe */
+    [data-popout-root="true"] {
+        [class*="headerWrapper_"] {
+            app-region: drag;
+
+            /* position trailing toolbar elements alongside WCO */
+            [class*="toolbar_"] {
+                padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0px));
+            }
+        }
+    }
 }
 
 /* force hide trailing icons when standalone so there's no ugly pixel overflow */

--- a/src/plugins/webPWA.browser/styles.css
+++ b/src/plugins/webPWA.browser/styles.css
@@ -3,14 +3,14 @@
     color-scheme: only light;
 }
 
-@media all and not (display-mode: browser) {
+@media all and not ((display-mode: browser) or (display-mode: fullscreen)) {
     :root {
         /* force title bar to be same as WCO bar height, regardless of zoom, device pixel ratio or OS, is only set when WCO is defined, otherwise sets to 0 */
         --custom-app-top-bar-height: env(titlebar-area-height, 0px) !important;
     }
 
     /* position trailing titlebar elements alongside WCO */
-    [class*="bar_"] [class*="trailing_"] {
+    [data-fullscreen] > [class*="bar_"] [class*="trailing_"] {
         padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0px));
     }
 
@@ -29,7 +29,10 @@
 
 /* force hide trailing icons when standalone so there's no ugly pixel overflow */
 @media all and (display-mode: standalone) {
-    [class*="bar_"] [class*="trailing_"] {
-        display: none;
+    [data-fullscreen] > [class*="bar_"] {
+        [class*="trailing_"],
+        [class*="leading"] {
+            display: none;
+        }
     }
 }


### PR DESCRIPTION
## Describe your Changes
Fixes window controls overlay styling on popout windows, I couldn't get the WebRTC debug popout to play nicely, but that one is rarely ever used anyways.

The main goal is to create draggable regions, with some styling improvements if applicable [like moving the stream status badge to the left of WCO]

## Screenshots (if applicable)
WCO w/ changes, no WCO w/ changes, old WCO w/o changes, [no WCO w/ and w/o look and act the same]

Custom CSS
<img width="943" height="812" alt="image" src="https://github.com/user-attachments/assets/84494757-aba2-4f9d-aa6f-cfdcba8189de" />
<img width="943" height="812" alt="image" src="https://github.com/user-attachments/assets/27d5dea7-5e86-4aa8-b96b-79fa77e16ad2" />
<img width="1000" height="716" alt="image" src="https://github.com/user-attachments/assets/5a1ff4ab-3eaf-48d0-859a-cbc540aad006" />


Stream Popout
<img width="1904" height="1032" alt="image" src="https://github.com/user-attachments/assets/17c2f69c-15f2-49e4-a933-68472f6c05df" />
<img width="1904" height="1032" alt="image" src="https://github.com/user-attachments/assets/3067ddd7-15ef-4248-95f0-da6713117940" />
<img width="1904" height="1032" alt="image" src="https://github.com/user-attachments/assets/015dce3a-7947-4553-897c-09f1a5e279d4" />




## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
