### PR TITLE
feat: GPU accelerated typing dots animation

### DIFF
--- a/src/plugins/fastTypingAnimation/index.ts
+++ b/src/plugins/fastTypingAnimation/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+import managedStyle from "./styles.css?managed";
+
+export default definePlugin({
+    name: "FastTypingAnimation",
+    authors: [Devs.ThaUnknown],
+    description: "Reaplces the CPU-intensive typing dots animation with a fast fully GPU-bound one.",
+    tags: ["Utility"],
+    patches: [
+        {
+            find: "dotCycle",
+            replacement: {
+                match: /width:2\*(\i)\*3\+\1\/2\*2,height:2\*\1,className:/,
+                replace: "$&'vc-fast-typing-animation '+",
+            }
+        }
+    ],
+    enabledByDefault: true,
+    managedStyle
+});

--- a/src/plugins/fastTypingAnimation/styles.css
+++ b/src/plugins/fastTypingAnimation/styles.css
@@ -9,7 +9,6 @@
 }
 
 @keyframes dot-pulse {
-
   0%,
   50%,
   100% {

--- a/src/plugins/fastTypingAnimation/styles.css
+++ b/src/plugins/fastTypingAnimation/styles.css
@@ -1,0 +1,24 @@
+.vc-fast-typing-animation {
+  circle {
+    will-change: opacity, transform;
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: dot-pulse 1.2s cubic-bezier(.45, 0, .55, 1) infinite backwards;
+    animation-delay: calc((sibling-index() - 1) * 150ms);
+  }
+}
+
+@keyframes dot-pulse {
+
+  0%,
+  50%,
+  100% {
+    opacity: .32;
+    transform: scale(.8)
+  }
+
+  25% {
+    opacity: 1;
+    transform: scale(1)
+  }
+}


### PR DESCRIPTION


## Describe your Changes
expands on the idea of the no typing animation plugin to instead use a GPU bound animation, which makes it a LOT less resource intensive [but not costless]

makes the plugin on by default, since its pretty much impossible to tell them apart now

performance of this can easily be compared by opening chromium devtools > rendering > show paint flashing and show frame stats
## Screenshots (if applicable)

one of these is the original animation, one of them is the GPU one, I don't know which :)

https://github.com/user-attachments/assets/e70f02e3-f971-4748-a802-451c71174eff

https://github.com/user-attachments/assets/fa407443-1e9d-4292-a64c-118dbfe648d4



## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
