### PR TITLE
feat: Add StreamRecover plugin

### DIFF
--- a/src/plugins/streamRecover/index.ts
+++ b/src/plugins/streamRecover/index.ts
@@ -1,0 +1,57 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { FluxDispatcher } from "@webpack/common";
+
+const VIDEO_GUARD_EXPERIMENT = "2026-08-video-guard";
+
+function dispatchExperimentOverride(variantId: number) {
+    FluxDispatcher.dispatch({
+        type: "APEX_EXPERIMENT_OVERRIDE_CREATE",
+        experimentName: VIDEO_GUARD_EXPERIMENT,
+        variantId
+    });
+}
+
+export default definePlugin({
+    name: "StreamRecover",
+    description: "Re-enable the Go Live / Screen Share button blocked in Brazil by ANPD",
+    authors: [Devs.Kalebinhoo],
+
+    patches: [
+        {
+            find: "Object.defineProperties(this,{isDeveloper",
+            replacement: {
+                match: /(?<={isDeveloper:\{[^}]+?,get:\(\)=>)\i/,
+                replace: "true"
+            }
+        },
+        {
+            find: 'type:"user",revision',
+            replacement: {
+                match: /!(\i)(?=&&"CONNECTION_OPEN")/,
+                replace: "!($1=true)"
+            }
+        },
+        {
+            find: "}getServerAssignment(",
+            replacement: {
+                match: /}getServerAssignment\((\i),\i,\i\){/,
+                replace: "$&if($1==null)return;"
+            }
+        }
+    ],
+
+    start() {
+        dispatchExperimentOverride(-1);
+    },
+
+    stop() {
+        dispatchExperimentOverride(0);
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -669,6 +669,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Davri: {
         name: "Davri",
         id: 457579346282938368n
+    },
+    Kalebinhoo: {
+        name: "Kalebinhoo",
+        id: 1373658983704825989n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
## Summary
This PR adds the StreamRecover plugin that re-enables the Go Live / Screen Share button blocked in Brazil by ANPD.

## What this plugin does
- Disables the 2026-08-video-guard experiment that blocks video features in Brazil
- Modifies experiment checks in the Discord client
- Removes the UI restriction on the Go Live button

## Technical details
The plugin uses Vencord patches to:
1. Force isDeveloper to access experiments
2. Disable experiment checks during CONNECTION_OPEN
3. Fix potential crashes with getServerAssignment
4. Dispatch an override to disable the video guard experiment

## Testing
- [x] Plugin builds successfully
- [x] Lint passes
- [x] Plugin loads in Discord

## Notes
This plugin only removes the client-side restriction. The server-side block remains active. Users may need a SOCKS5 proxy outside Brazil for full functionality.