### PR TITLE
TTLMap: clear previous timer on set

### DIFF
--- a/src/utils/TTLMap.ts
+++ b/src/utils/TTLMap.ts
@@ -15,6 +15,9 @@ export class TTLMap<K, V> extends Map<K, V> {
     }
 
     public set(key: K, value: V) {
+        const timer = this._timers.get(key);
+        if (timer) clearTimeout(timer);
+
         const timeoutId = setTimeout(() => {
             this.delete(key);
             this.onExpire?.(key, value);


### PR DESCRIPTION
## Describe your Changes
calling set on an existing key didn't clear the old timeout, so the entry would get deleted early when the previous timer fired. this just clears the existing timer before setting the new one.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
