### PR TITLE
feat(plugin): Custom Status Rotation

### DIFF
--- a/src/plugins/customStatusRotator/index.tsx
+++ b/src/plugins/customStatusRotator/index.tsx
@@ -10,7 +10,7 @@ import { getUserSettingLazy } from "@api/UserSettings";
 import definePlugin, { OptionType } from "@utils/types";
 
 const StatusSettings = getUserSettingLazy<string>("status", "status")!;
-const CustomStatusSettings = getUserSettingLazy<{ text: string, emojiId: string | undefined, expiresAtMs: undefined | bigint; }>("status", "customStatus")!;
+const CustomStatusSettings = getUserSettingLazy<{ text: string, emojiId: string | undefined, expiresAtMs: undefined | number; }>("status", "customStatus")!;
 
 const statusMap: string[] = [];
 let currentPosition: number = 0;

--- a/src/plugins/customStatusRotator/index.tsx
+++ b/src/plugins/customStatusRotator/index.tsx
@@ -7,6 +7,7 @@
 import { showNotification } from "@api/Notifications";
 import { definePluginSettings } from "@api/Settings";
 import { getUserSettingLazy } from "@api/UserSettings";
+import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
 const StatusSettings = getUserSettingLazy<string>("status", "status")!;
@@ -97,7 +98,6 @@ function setPresence() {
         expiresAtMs: undefined
     });
 
-
     thread = setTimeout(() => {
         currentPosition += 1;
         setPresence();
@@ -112,10 +112,7 @@ export default definePlugin({
     tags: ["Customisation", "Activity"],
     requiresRestart: true,
     authors: [
-        {
-            name: "xslbrst",
-            id: 1136216090725339206n,
-        }
+        Devs.xslbrst
     ],
 
     settings,

--- a/src/plugins/customStatusRotator/index.tsx
+++ b/src/plugins/customStatusRotator/index.tsx
@@ -11,7 +11,7 @@ import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
 const StatusSettings = getUserSettingLazy<string>("status", "status")!;
-const CustomStatusSettings = getUserSettingLazy<{ text: string, emojiId: string | undefined, expiresAtMs: undefined | number; }>("status", "customStatus")!;
+const CustomStatusSettings = getUserSettingLazy<{ text: string | null, emojiId?: string | undefined, expiresAtMs?: undefined | number; }>("status", "customStatus")!;
 
 const statusMap: string[] = [];
 let currentPosition: number = 0;
@@ -51,9 +51,12 @@ const settings = definePluginSettings({
     },
     statusDuration: {
         type: OptionType.NUMBER,
-        description: "How long should each status be displayed for? (in seconds)",
-        default: 60,
-        restartNeeded: true
+        description: "How long should each status be displayed for? (in seconds, minimum is 600)",
+        default: 300,
+        restartNeeded: true,
+        isValid: (value: number) => {
+            return value >= 600;
+        },
     }
 });
 
@@ -106,7 +109,7 @@ function setPresence() {
 }
 
 export default definePlugin({
-    name: "CustomStatusRotator",
+    name: "CustomStatusRotation",
     description: "Allows you to set a different rotation of statuses.",
     dependencies: ["UserSettingsAPI"],
     tags: ["Customisation", "Activity"],

--- a/src/plugins/customStatusRotator/index.tsx
+++ b/src/plugins/customStatusRotator/index.tsx
@@ -1,0 +1,134 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { showNotification } from "@api/Notifications";
+import { definePluginSettings } from "@api/Settings";
+import { getUserSettingLazy } from "@api/UserSettings";
+import definePlugin, { OptionType } from "@utils/types";
+
+const StatusSettings = getUserSettingLazy<string>("status", "status")!;
+const CustomStatusSettings = getUserSettingLazy<{ text: string, emojiId: string | undefined, expiresAtMs: undefined | bigint; }>("status", "customStatus")!;
+
+const statusMap: string[] = [];
+let currentPosition: number = 0;
+let thread: NodeJS.Timeout | undefined;
+
+const settings = definePluginSettings({
+    enabled: {
+        type: OptionType.BOOLEAN,
+        description: "Should this plugin be active?",
+        restartNeeded: true
+    },
+    statusesToRotate: {
+        type: OptionType.STRING,
+        multiline: true,
+        description: "Allows you to setup a string of custom statuses. (seperate using a semi-colon (;)).",
+        restartNeeded: true
+    },
+    status: {
+        type: OptionType.SELECT,
+        options: [
+            {
+                label: "Online",
+                value: "online",
+                default: true
+            },
+            {
+                label: "Do Not Disturb",
+                value: "dnd",
+            },
+            {
+                label: "Idle",
+                value: "idle",
+            },
+        ],
+        description: "Which presence should be selected when rotating your statuses?",
+        restartNeeded: true
+    },
+    statusDuration: {
+        type: OptionType.NUMBER,
+        description: "How long should each status be displayed for? (in seconds)",
+        default: 60,
+        restartNeeded: true
+    }
+});
+
+function evaluateSelectedStatuses(): [boolean, any] {
+    const strings = settings.store.statusesToRotate;
+    if (!strings) return [false, "No statuses were set, skipping."];
+    const split = strings.split(";");
+
+    for (const string of split) {
+        if (string.length < 1) continue;
+        statusMap.push(string);
+    }
+
+    return [true, undefined];
+}
+
+function setPresence() {
+    const [success, message] = evaluateSelectedStatuses();
+    if (!success) return showNotification({
+        title: "Presence Rotator Error",
+        body: message,
+        dismissOnClick: true,
+    });
+
+    if (thread) { // in-case a thread exists for some reason
+        clearTimeout(thread);
+        thread = undefined;
+    }
+
+    const statusString = statusMap[currentPosition];
+
+    const selectedPresenceStatus = settings.store.status;
+    const statusRotaDuration = settings.store.statusDuration;
+
+    if (StatusSettings.getSetting() !== selectedPresenceStatus) {
+        StatusSettings.updateSetting(selectedPresenceStatus);
+    }
+
+    CustomStatusSettings.updateSetting({
+        text: statusString,
+        emojiId: undefined,
+        expiresAtMs: undefined
+    });
+
+
+    thread = setTimeout(() => {
+        currentPosition += 1;
+        setPresence();
+        thread = undefined;
+    }, statusRotaDuration * 1000);
+}
+
+export default definePlugin({
+    name: "CustomStatusRotator",
+    description: "Allows you to set a different rotation of statuses.",
+    dependencies: ["UserSettingsAPI"],
+    tags: ["Customisation", "Activity"],
+    requiresRestart: true,
+    authors: [
+        {
+            name: "xslbrst",
+            id: 1136216090725339206n,
+        }
+    ],
+
+    settings,
+
+    start() {
+        if (!settings.store.enabled) return;
+        setPresence();
+    },
+    stop() {
+        if (!settings.store.enabled) return;
+        if (thread) {
+            clearTimeout(thread);
+            thread = undefined;
+        }
+    },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -655,8 +655,8 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         id: 383365021415243776n
     },
     paige: {
-         name: "paige",
-         id: 1375697625864601650n
+        name: "paige",
+        id: 1375697625864601650n
     },
     jax: {
         name: "jax",
@@ -668,7 +668,11 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     },
     Davri: {
         name: "Davri",
-        id: 457579346282938368n
+        id: 457579346282938368n,
+    },
+    xslbrst: {
+        name: "xslbrst",
+        id: 1136216090725339206n,
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
## Describe your Changes

You are now able to setup a custom status rotation which will change your status in a given interval
> the interval is customization to the user however the minimum value is 600 seconds (or 10 minutes) to prevent spamming
> you can customize which status you want selected while the rotation is active

## Screenshots (if applicable)

<img width="1026" height="893" alt="image" src="https://github.com/user-attachments/assets/bb85ce2e-b65a-4f7c-b3ae-e526097878f0" />

<img width="464" height="308" alt="image" src="https://github.com/user-attachments/assets/220ed87a-ec8f-48e9-b75a-7d87710586a9" />


## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
