### PR TITLE
WebKeybinds: Re-add missing CTRL+, keybind

### DIFF
--- a/src/plugins/webKeybinds.web/index.ts
+++ b/src/plugins/webKeybinds.web/index.ts
@@ -19,6 +19,7 @@
 import { definePluginSettings } from "@api/Settings";
 import { Devs, IS_MAC } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
+import { SettingsRouter } from "@webpack/common";
 
 
 const settings = definePluginSettings({
@@ -63,6 +64,26 @@ export default definePlugin({
             predicate: () => settings.store.showNavigationButtons,
         }
     ],
+
+    start() {
+        document.addEventListener("keydown", this.onKey);
+    },
+
+    stop() {
+        document.removeEventListener("keydown", this.onKey);
+    },
+
+    onKey(e: KeyboardEvent) {
+        const hasCtrl = e.ctrlKey || (e.metaKey && IS_MAC);
+
+        // Cmd+, is a native shortcut on macos (Vesktop/src/main/mainWindow.ts)
+        const hasNativeShortcut = IS_VESKTOP && IS_MAC;
+
+        if (hasCtrl && e.key === "," && !hasNativeShortcut) {
+            e.preventDefault();
+            SettingsRouter.openUserSettings();
+        }
+    },
 
     getBlockedKeybinds() {
         // Zoom shortcuts, allowing these would cause unpredictable zooming behavior on macos


### PR DESCRIPTION
## Describe your Changes
Added back the ctrl+, shortcut which I accidentally removed in a previous PR.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
