### PR TITLE
MessageLogger: Add setting to toggle deleted attachments logging

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -95,7 +95,7 @@ const settings = definePluginSettings({
     ignoreBots: {
         type: OptionType.BOOLEAN,
         description: "Whether to ignore messages by bots",
-        default: false
+        default: true
     },
     ignoreSelf: {
         type: OptionType.BOOLEAN,

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -81,6 +81,12 @@ const settings = definePluginSettings({
         description: "Whether to log edited messages",
         default: true,
     },
+    logDeletedAttachments: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to log deleted attachments",
+        default: true,
+        restartNeeded: true,
+    },
     inlineEdits: {
         type: OptionType.BOOLEAN,
         description: "Whether to display edit history as part of message content",
@@ -482,6 +488,7 @@ export default definePlugin({
                 // just mark deleted attachments as deleted on MESSAGE_UPDATE
                 {
                     match: /attachments:(\i)\.attachments\?\?\[\],/,
+                    predicate: () => settings.store.logDeletedAttachments,
                     replace: "attachments: $self.handleUpdateAttachments($1),"
                 }
             ]


### PR DESCRIPTION
it can get very noisy with bots and discord deletes attachment CDN links so the images will oftentimes fail to load