### PR TITLE
MemberCount: fix crash when the member list has no groups

### DIFF
--- a/src/plugins/memberCount/MemberCount.tsx
+++ b/src/plugins/memberCount/MemberCount.tsx
@@ -60,7 +60,7 @@ export function MemberCount({ isTooltip, tooltipGuildId }: { isTooltip?: true; t
 
             const { groups } = ChannelMemberStore.getProps(guildId, currentChannel?.id);
 
-            if (groups.length >= 1 || groups[0].id !== "unknown") {
+            if (groups.length >= 1 && groups[0].id !== "unknown") {
                 return groups.reduce(
                     (total, curr) => total + (curr.id === "offline" ? 0 : curr.count),
                     0


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
Also do not use AI in communication, it makes me ill
-->

## Describe your Changes

Closes #4557

In `MemberCount.tsx` (line 63), the condition used `||` instead of `&&`. With an empty groups array, this still evaluated `groups[0].id`, crashing on undefined (the reported issue). With a non-empty array, short-circuiting meant the "unknown" check never ran, so a placeholder `unknown` group was summed as a real count (showing 0) instead of falling back. Switching to `&&` fixes both cases. The function now returns null and the counter correctly falls back to `OnlineMemberCountStore`

## Screenshots (if applicable)

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
