### PR TITLE
InappDownloader: keep attachment downloads in-app

### DIFF
--- a/src/plugins/inappDownloader.desktop/README.md
+++ b/src/plugins/inappDownloader.desktop/README.md
@@ -1,0 +1,7 @@
+# InappDownloader
+
+Crazy concept: no more opening my damn browser for every file download!
+
+Catches Discord's built-in download stuff and saves the attachment in-app instead.
+
+Works for videos, music, images, docs, whatever direct attachment Discord gives you, settings let you use one folder, Downloads, or pick one every time if you want that for some reason.

--- a/src/plugins/inappDownloader.desktop/index.tsx
+++ b/src/plugins/inappDownloader.desktop/index.tsx
@@ -1,0 +1,465 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 .skyade
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { get, set } from "@api/DataStore";
+import { definePluginSettings } from "@api/Settings";
+import { CloudDownloadIcon } from "@components/Icons";
+import { SettingsSection } from "@components/settings/tabs/plugins/components/Common";
+import { Devs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+import definePlugin, { OptionType, PluginNative } from "@utils/types";
+import type { Message } from "@vencord/discord-types";
+import { Button, ChannelStore, Menu, showToast, Text, Toasts, useEffect, useState } from "@webpack/common";
+
+const Native = VencordNative.pluginHelpers.InappDownloader as PluginNative<typeof import("./native")>;
+const logger = new Logger("InappDownloader");
+
+const DIRECTORY_KEY = "InappDownloader_Directory";
+const LEGACY_DIRECTORY_KEY = "DiscordInAppDownloader_Directory";
+const MAX_ATTACHMENTS_PER_ACTION = 25;
+let pluginRunning = false;
+
+type DownloadFolderMode = "specified" | "downloads" | "ask";
+
+const settings = definePluginSettings({
+    downloadFolderMode: {
+        type: OptionType.SELECT,
+        description: "Where to save attachments",
+        options: [
+            { label: "Specified folder", value: "specified", default: true },
+            { label: "System Downloads", value: "downloads" },
+            { label: "Ask every time", value: "ask" },
+        ],
+        onChange() {
+            if (pluginRunning) void updateNativeDownloadInterception();
+        },
+    },
+    specifiedDownloadFolder: {
+        type: OptionType.COMPONENT,
+        component: DownloadFolderSetting,
+    },
+    interceptDownloadButtons: {
+        type: OptionType.BOOLEAN,
+        description: "Intercept Discord desktop attachment downloads",
+        default: true,
+        onChange(enabled: boolean) {
+            if (!pluginRunning) return;
+            if (enabled) installDownloadButtonInterception();
+            else uninstallDownloadButtonInterception();
+            void updateNativeDownloadInterception(enabled);
+        },
+    },
+});
+
+type Attachment = Message["attachments"][number];
+type DownloadableAttachment = Pick<Attachment, "url" | "filename">;
+
+let downloadDirectory: string | undefined;
+let directoryReady: Promise<void> | undefined;
+const activePolls = new Set<string>();
+let originalWindowOpen: typeof window.open | undefined;
+let interceptedWindowOpen: typeof window.open | undefined;
+let documentClickHandler: ((event: MouseEvent) => void) | undefined;
+
+const wait = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+function hasDownloadableAttachments(message: Message) {
+    return message.attachments?.some(attachment =>
+        typeof attachment?.url === "string" && typeof attachment?.filename === "string"
+    ) ?? false;
+}
+
+function getAttachmentFromMessage(message: Message) {
+    return message.attachments
+        .filter(attachment =>
+            typeof attachment?.url === "string" && typeof attachment?.filename === "string"
+        )
+        .slice(0, MAX_ATTACHMENTS_PER_ACTION);
+}
+
+async function loadDirectory() {
+    if (!directoryReady) {
+        directoryReady = get<string>(DIRECTORY_KEY).then(async value => {
+            if (typeof value === "string" && value.length > 0) {
+                downloadDirectory = value;
+                return;
+            }
+
+            const legacyValue = await get<string>(LEGACY_DIRECTORY_KEY);
+            if (typeof legacyValue === "string" && legacyValue.length > 0) {
+                downloadDirectory = legacyValue;
+                await set(DIRECTORY_KEY, legacyValue);
+            }
+        });
+    }
+
+    await directoryReady;
+}
+
+function getDownloadFolderMode(): DownloadFolderMode {
+    const mode = settings.store.downloadFolderMode;
+    return mode === "downloads" || mode === "ask" ? mode : "specified";
+}
+
+function getNativeInterceptionOptions() {
+    const mode = getDownloadFolderMode();
+    return {
+        directory: mode === "specified" ? downloadDirectory : undefined,
+        askEveryTime: mode === "ask",
+    };
+}
+
+async function resolveDownloadDirectory(): Promise<string | undefined | null> {
+    await loadDirectory();
+
+    switch (getDownloadFolderMode()) {
+        case "ask":
+            return Native.chooseDownloadDirectory();
+        case "specified":
+            return downloadDirectory;
+        default:
+            return undefined;
+    }
+}
+
+function getErrorMessage(error: unknown) {
+    if (error instanceof Error && error.message) return error.message;
+    if (error && typeof error === "object" && "message" in error && typeof error.message === "string") {
+        return error.message;
+    }
+    return "Unknown native error";
+}
+
+function describeAttachmentUrl(rawUrl: string) {
+    try {
+        const url = new URL(rawUrl);
+        return `${url.origin}${url.pathname}`;
+    } catch {
+        return "invalid URL";
+    }
+}
+
+function isAttachmentUrl(rawUrl: string) {
+    try {
+        const url = new URL(rawUrl);
+        return url.protocol === "https:" &&
+            (url.hostname === "cdn.discordapp.com" || url.hostname === "media.discordapp.net") &&
+            (url.pathname.includes("/attachments/") || url.pathname.includes("/ephemeral-attachments/"));
+    } catch {
+        return false;
+    }
+}
+
+function filenameFromUrl(rawUrl: string) {
+    try {
+        const name = decodeURIComponent(new URL(rawUrl).pathname.split("/").pop() || "download");
+        return name || "download";
+    } catch {
+        return "download";
+    }
+}
+
+function getElementLabel(element: Element) {
+    return [
+        element.getAttribute("aria-label"),
+        element.getAttribute("data-tooltip-content"),
+        element.getAttribute("title"),
+        element.textContent,
+    ].filter(Boolean).join(" ").toLowerCase();
+}
+
+function isDownloadControl(element: Element) {
+    return element.hasAttribute("download") || /\bdownload\b/.test(getElementLabel(element));
+}
+
+function findAttachmentUrl(element: Element) {
+    let current: Element | null = element;
+    while (current) {
+        for (const attribute of ["href", "data-url", "data-src", "src"]) {
+            const value = current.getAttribute(attribute);
+            if (value && isAttachmentUrl(value)) return value;
+        }
+        current = current.parentElement;
+    }
+    return null;
+}
+
+function installDownloadButtonInterception() {
+    if (documentClickHandler) return;
+
+    documentClickHandler = event => {
+        if (event.button !== 0 || !(event.target instanceof Element)) return;
+
+        const control = event.target.closest<HTMLElement>("button, a, [role=button], [aria-label], [data-tooltip-content], [title]");
+        if (!control || !isDownloadControl(control)) return;
+
+        const url = findAttachmentUrl(control);
+        if (!url) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        void startAttachmentDownload({ url, filename: filenameFromUrl(url) });
+    };
+    document.addEventListener("click", documentClickHandler, true);
+
+    const fallbackOpen = window.open.bind(window);
+    originalWindowOpen = fallbackOpen;
+    const wrappedOpen = (url?: string | URL, target?: string, features?: string) => {
+        const rawUrl = url?.toString();
+        if (rawUrl && isAttachmentUrl(rawUrl)) {
+            void startAttachmentDownload({ url: rawUrl, filename: filenameFromUrl(rawUrl) });
+            return null;
+        }
+        return fallbackOpen(url, target, features);
+    };
+    window.open = wrappedOpen as typeof window.open;
+    interceptedWindowOpen = window.open;
+}
+
+function uninstallDownloadButtonInterception() {
+    if (documentClickHandler) {
+        document.removeEventListener("click", documentClickHandler, true);
+        documentClickHandler = undefined;
+    }
+
+    if (originalWindowOpen && window.open === interceptedWindowOpen) window.open = originalWindowOpen;
+    originalWindowOpen = undefined;
+    interceptedWindowOpen = undefined;
+}
+
+async function updateNativeDownloadInterception(enabled = settings.store.interceptDownloadButtons) {
+    try {
+        if (enabled) await Native.enableDownloadInterception(getNativeInterceptionOptions());
+        else await Native.disableDownloadInterception();
+    } catch (error) {
+        logger.warn("Native download interception is unavailable", getErrorMessage(error));
+    }
+}
+
+async function pickDownloadDirectory() {
+    const selected = await Native.chooseDownloadDirectory();
+    if (!selected) return null;
+
+    downloadDirectory = selected;
+    await set(DIRECTORY_KEY, selected);
+    if (pluginRunning) await updateNativeDownloadInterception();
+    return selected;
+}
+
+async function chooseDownloadDirectory() {
+    try {
+        const selected = await pickDownloadDirectory();
+        if (!selected) return;
+
+        showToast(`Download folder set to ${selected}`, Toasts.Type.SUCCESS);
+    } catch {
+        showToast("Could not choose a download folder", Toasts.Type.FAILURE);
+    }
+}
+
+function DownloadFolderSetting() {
+    const [directory, setDirectory] = useState<string | undefined>(downloadDirectory);
+    const [isChoosing, setIsChoosing] = useState(false);
+
+    useEffect(() => {
+        void loadDirectory().then(() => setDirectory(downloadDirectory));
+    }, []);
+
+    async function handleChoose() {
+        setIsChoosing(true);
+        try {
+            const selected = await pickDownloadDirectory();
+            if (selected) setDirectory(selected);
+        } catch (error) {
+            logger.error("Could not choose a download folder", getErrorMessage(error));
+            showToast("Could not choose a download folder", Toasts.Type.FAILURE);
+        } finally {
+            setIsChoosing(false);
+        }
+    }
+
+    return (
+        <SettingsSection
+            name="Specified folder"
+            id="specifiedDownloadFolder"
+            description="Used when the mode above is set to Specified folder. Defaults to Downloads."
+        >
+            <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                <Text variant="text-sm/normal">
+                    {directory ?? "No folder set; using Downloads."}
+                </Text>
+                <Button onClick={handleChoose} disabled={isChoosing}>
+                    {isChoosing ? "Choosing folder..." : directory ? "Change folder" : "Choose folder"}
+                </Button>
+            </div>
+        </SettingsSection>
+    );
+}
+
+async function monitorDownload(id: string, filename: string) {
+    if (activePolls.has(id)) return;
+    activePolls.add(id);
+
+    try {
+        while (activePolls.has(id)) {
+            const status = await Native.getDownloadStatus(id);
+            if (!status) return;
+
+            if (status.state === "completed") {
+                showToast(`Downloaded ${filename}`, Toasts.Type.SUCCESS);
+                return;
+            }
+
+            if (status.state === "failed") {
+                showToast(`Download failed: ${status.error ?? filename}`, Toasts.Type.FAILURE);
+                return;
+            }
+
+            if (status.state === "cancelled") {
+                showToast(`Cancelled ${filename}`, Toasts.Type.MESSAGE);
+                return;
+            }
+
+            await wait(400);
+        }
+    } catch {
+        showToast(`Could not monitor ${filename}`, Toasts.Type.FAILURE);
+    } finally {
+        activePolls.delete(id);
+    }
+}
+
+async function startAttachmentDownload(
+    attachment: DownloadableAttachment,
+    showStartToast = true,
+    directoryPromise?: Promise<string | undefined | null>,
+) {
+    if (!attachment?.url || !attachment.filename) return false;
+
+    try {
+        const targetDirectory = await (directoryPromise ?? resolveDownloadDirectory());
+        if (targetDirectory === null) return false;
+
+        const started = await Native.startDownload({
+            url: attachment.url,
+            filename: attachment.filename,
+            directory: targetDirectory,
+        });
+
+        if (showStartToast) {
+            showToast(`Downloading ${started.filename}`, Toasts.Type.MESSAGE);
+        }
+
+        void monitorDownload(started.id, started.filename);
+        return true;
+    } catch (error) {
+        const reason = getErrorMessage(error);
+        logger.error("Could not start attachment download", {
+            filename: attachment.filename,
+            location: describeAttachmentUrl(attachment.url),
+            reason,
+        });
+        if (showStartToast) {
+            showToast(`Could not start ${attachment.filename}: ${reason}`, Toasts.Type.FAILURE);
+        }
+        return false;
+    }
+}
+
+async function downloadAttachments(attachments: readonly DownloadableAttachment[]) {
+    const validAttachments = attachments
+        .filter(attachment => attachment?.url && attachment.filename)
+        .slice(0, MAX_ATTACHMENTS_PER_ACTION);
+
+    if (!validAttachments.length) {
+        showToast("No downloadable attachments found", Toasts.Type.FAILURE);
+        return;
+    }
+
+    const directoryPromise = resolveDownloadDirectory();
+    try {
+        if (await directoryPromise === null) return;
+    } catch (error) {
+        logger.error("Could not choose a download folder", getErrorMessage(error));
+        showToast("Could not choose a download folder", Toasts.Type.FAILURE);
+        return;
+    }
+
+    const started = await Promise.all(validAttachments.map(attachment =>
+        startAttachmentDownload(attachment, false, directoryPromise)
+    ));
+    const count = started.filter(Boolean).length;
+
+    if (count > 0) {
+        showToast(`Started ${count} download${count === 1 ? "" : "s"}`, Toasts.Type.MESSAGE);
+    } else {
+        showToast("Could not start the downloads", Toasts.Type.FAILURE);
+    }
+}
+
+const patchMessageContextMenu: NavContextMenuPatchCallback = (children, props) => {
+    const { message } = props as { message?: Message };
+    if (!message || !hasDownloadableAttachments(message)) return;
+
+    const attachments = getAttachmentFromMessage(message);
+    children.push(
+        <Menu.MenuItem
+            id="inapp-downloader"
+            key="inapp-downloader"
+            label={attachments.length === 1 ? "Download attachment" : `Download attachments (${attachments.length})`}
+            icon={CloudDownloadIcon}
+            action={() => downloadAttachments(attachments)}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "InappDownloader",
+    description: "No more opening my browser for stealing memes",
+    tags: ["Media", "Utility"],
+    authors: [Devs.skyade],
+    requiresRestart: true,
+    settings,
+
+    contextMenus: {
+        message: patchMessageContextMenu,
+    },
+
+    messagePopoverButton: {
+        icon: CloudDownloadIcon,
+        render(message: Message) {
+            if (!hasDownloadableAttachments(message)) return null;
+
+            const attachments = getAttachmentFromMessage(message);
+            return {
+                label: attachments.length === 1 ? "Download attachment" : "Download attachments",
+                icon: CloudDownloadIcon,
+                message,
+                channel: ChannelStore.getChannel(message.channel_id),
+                onClick: () => downloadAttachments(attachments),
+            };
+        },
+    },
+
+    toolboxActions: {
+        "Choose download folder": () => { void chooseDownloadDirectory(); },
+    },
+
+    async start() {
+        await loadDirectory();
+        pluginRunning = true;
+        if (settings.store.interceptDownloadButtons) installDownloadButtonInterception();
+        await updateNativeDownloadInterception(settings.store.interceptDownloadButtons);
+    },
+
+    stop() {
+        pluginRunning = false;
+        uninstallDownloadButtonInterception();
+        void Native.disableDownloadInterception();
+        activePolls.clear();
+    },
+});

--- a/src/plugins/inappDownloader.desktop/native.ts
+++ b/src/plugins/inappDownloader.desktop/native.ts
@@ -1,0 +1,384 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 .skyade
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { randomUUID } from "node:crypto";
+import { createWriteStream, existsSync, mkdirSync } from "node:fs";
+import { access, mkdir, rename, rm } from "node:fs/promises";
+import { basename, extname, isAbsolute, join, resolve } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import { app, BrowserWindow, dialog, type IpcMainInvokeEvent } from "electron";
+
+const ALLOWED_HOSTS = new Set(["cdn.discordapp.com", "media.discordapp.net"]);
+const MAX_REDIRECTS = 3;
+const MAX_FILENAME_LENGTH = 180;
+const JOB_RETENTION_MS = 10 * 60 * 1000;
+const DIRECTORY_DIALOG_OPTIONS = {
+    title: "Choose download folder",
+    properties: ["openDirectory", "createDirectory"] as ("openDirectory" | "createDirectory")[],
+};
+
+export type DownloadState = "queued" | "downloading" | "completed" | "cancelled" | "failed";
+
+export interface DownloadRequest {
+    url: string;
+    filename: string;
+    directory?: string;
+}
+
+export interface DownloadInterceptionOptions {
+    directory?: string;
+    askEveryTime?: boolean;
+}
+
+export interface DownloadStatus {
+    id: string;
+    filename: string;
+    state: DownloadState;
+    error?: string;
+}
+
+export interface StartedDownload {
+    id: string;
+    filename: string;
+}
+
+type DownloadHandler = (event: Electron.Event, item: Electron.DownloadItem, webContents: Electron.WebContents) => void;
+
+interface DownloadJob extends DownloadStatus {
+    controller: AbortController;
+    targetPath?: string;
+    partialPath?: string;
+}
+
+interface DownloadInterceptor {
+    directory?: string;
+    askEveryTime: boolean;
+    webContentsId: number;
+    handler: DownloadHandler;
+}
+
+const jobs = new Map<string, DownloadJob>();
+const reservedTargets = new Set<string>();
+const downloadInterceptors = new WeakMap<Electron.Session, DownloadInterceptor>();
+
+function pathKey(path: string) {
+    const normalized = resolve(path);
+    return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function assertAllowedAttachmentUrl(rawUrl: string) {
+    if (typeof rawUrl !== "string" || rawUrl.length > 4096) {
+        throw new Error("Invalid attachment URL");
+    }
+
+    let url: URL;
+    try {
+        url = new URL(rawUrl);
+    } catch {
+        throw new Error("Invalid attachment URL");
+    }
+
+    if (url.protocol !== "https:" || !ALLOWED_HOSTS.has(url.hostname) ||
+        (!url.pathname.includes("/attachments/") && !url.pathname.includes("/ephemeral-attachments/"))) {
+        throw new Error("Only Discord attachment URLs are supported");
+    }
+
+    return url;
+}
+
+function filenameFromUrl(url: URL) {
+    const rawName = url.pathname.split("/").pop() || "download";
+    try {
+        return decodeURIComponent(rawName);
+    } catch {
+        return rawName;
+    }
+}
+
+function sanitiseFilename(input: string, url: URL) {
+    const source = input || filenameFromUrl(url);
+    const slashSafe = source.replaceAll("\\", "/");
+    let filename = basename(slashSafe)
+        .replace(/[<>:"/|?*\u0000-\u001f]/g, "_")
+        .trim()
+        .replace(/[. ]+$/g, "");
+
+    if (!filename || filename === "." || filename === "..") filename = "download";
+    if (/^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i.test(filename)) filename = `_${filename}`;
+
+    if (filename.length > MAX_FILENAME_LENGTH) {
+        const extension = extname(filename);
+        filename = `${filename.slice(0, MAX_FILENAME_LENGTH - extension.length)}${extension}`;
+    }
+
+    return filename;
+}
+
+function resolveDirectory(directory?: string) {
+    if (directory == null || (typeof directory === "string" && directory.trim() === "")) {
+        return app.getPath("downloads");
+    }
+    if (typeof directory !== "string") throw new Error("Download directory must be a string");
+    if (directory.length > 4096 || !isAbsolute(directory)) {
+        throw new Error("Download directory must be an absolute path");
+    }
+
+    return resolve(directory);
+}
+
+async function targetExists(path: string) {
+    try {
+        await access(path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function reserveTarget(directory: string, filename: string) {
+    const extension = extname(filename);
+    const stem = filename.slice(0, filename.length - extension.length);
+
+    for (let index = 0; index < 1000; index++) {
+        const candidateName = index === 0 ? filename : `${stem} (${index})${extension}`;
+        const candidate = join(directory, candidateName);
+        const key = pathKey(candidate);
+
+        if (reservedTargets.has(key) || await targetExists(candidate) || reservedTargets.has(key)) continue;
+
+        reservedTargets.add(key);
+        return candidate;
+    }
+
+    throw new Error("Could not find an unused filename");
+}
+
+function reserveTargetSync(directory: string, filename: string) {
+    const extension = extname(filename);
+    const stem = filename.slice(0, filename.length - extension.length);
+
+    for (let index = 0; index < 1000; index++) {
+        const candidateName = index === 0 ? filename : `${stem} (${index})${extension}`;
+        const candidate = join(directory, candidateName);
+        const key = pathKey(candidate);
+
+        if (reservedTargets.has(key) || existsSync(candidate)) continue;
+
+        reservedTargets.add(key);
+        return candidate;
+    }
+
+    throw new Error("Could not find an unused filename");
+}
+
+async function fetchAttachment(url: URL, signal: AbortSignal) {
+    let currentUrl = url;
+
+    for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
+        const response = await fetch(currentUrl, {
+            redirect: "manual",
+            signal,
+            headers: { Accept: "*/*" },
+        });
+
+        if (response.status < 300 || response.status >= 400) return response;
+
+        const location = response.headers.get("location");
+        if (!location) throw new Error("Redirect without a destination");
+        currentUrl = assertAllowedAttachmentUrl(new URL(location, currentUrl).toString());
+    }
+
+    throw new Error("Too many redirects");
+}
+
+function isAbortError(error: unknown) {
+    return error instanceof Error && (error.name === "AbortError" || /aborted/i.test(error.message));
+}
+
+function publicError(error: unknown) {
+    if (error instanceof Error && /^HTTP \d+$/.test(error.message)) return error.message;
+    return "Network or filesystem error";
+}
+
+function scheduleCleanup(job: DownloadJob) {
+    setTimeout(() => jobs.delete(job.id), JOB_RETENTION_MS);
+}
+
+function isDownloadRequest(request: unknown): request is DownloadRequest {
+    if (!request || typeof request !== "object") return false;
+
+    const candidate = request as Partial<DownloadRequest>;
+    return typeof candidate.url === "string" &&
+        typeof candidate.filename === "string" &&
+        (candidate.directory === undefined || typeof candidate.directory === "string");
+}
+
+function watchDownloadItem(job: DownloadJob, item: Electron.DownloadItem) {
+    const done = (_event: Electron.Event, state: "completed" | "cancelled" | "interrupted") => {
+        job.state = state === "completed" ? "completed" : state === "cancelled" ? "cancelled" : "failed";
+        job.error = state === "interrupted" ? "Download interrupted" : undefined;
+        if (job.targetPath) reservedTargets.delete(pathKey(job.targetPath));
+        scheduleCleanup(job);
+    };
+
+    item.once("done", done);
+}
+
+function chooseDownloadDirectorySync(webContents: Electron.WebContents) {
+    const parent = BrowserWindow.fromWebContents(webContents);
+    const filePaths = parent
+        ? dialog.showOpenDialogSync(parent, DIRECTORY_DIALOG_OPTIONS)
+        : dialog.showOpenDialogSync(DIRECTORY_DIALOG_OPTIONS);
+
+    return filePaths?.[0] ?? null;
+}
+
+function handleElectronDownload(interceptor: DownloadInterceptor, item: Electron.DownloadItem, webContents: Electron.WebContents) {
+    if (webContents.id !== interceptor.webContentsId) return;
+
+    let url: URL;
+    let targetPath: string | undefined;
+    try {
+        url = assertAllowedAttachmentUrl(item.getURL());
+    } catch {
+        return;
+    }
+
+    try {
+        const directory = interceptor.askEveryTime
+            ? chooseDownloadDirectorySync(webContents)
+            : resolveDirectory(interceptor.directory);
+        if (!directory) {
+            item.cancel();
+            return;
+        }
+
+        mkdirSync(directory, { recursive: true });
+        const filename = sanitiseFilename(item.getFilename(), url);
+        targetPath = reserveTargetSync(directory, filename);
+        item.setSavePath(targetPath);
+
+        const job: DownloadJob = {
+            id: randomUUID(),
+            filename,
+            state: "downloading",
+            controller: new AbortController(),
+            targetPath,
+        };
+
+        jobs.set(job.id, job);
+        watchDownloadItem(job, item);
+    } catch {
+        item.cancel();
+        if (targetPath) reservedTargets.delete(pathKey(targetPath));
+    }
+}
+
+async function runDownload(job: DownloadJob, url: URL) {
+    job.state = "downloading";
+
+    try {
+        const response = await fetchAttachment(url, job.controller.signal);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        if (!response.body || !job.targetPath) throw new Error("Empty response");
+
+        job.partialPath = `${job.targetPath}.${job.id}.part`;
+
+        await pipeline(
+            Readable.fromWeb(response.body as unknown as Parameters<typeof Readable.fromWeb>[0]),
+            createWriteStream(job.partialPath, { flags: "wx" }),
+        );
+        await rename(job.partialPath, job.targetPath);
+
+        job.state = "completed";
+    } catch (error) {
+        job.state = isAbortError(error) ? "cancelled" : "failed";
+        job.error = isAbortError(error) ? undefined : publicError(error);
+
+        if (job.partialPath) await rm(job.partialPath, { force: true }).catch(() => { });
+    } finally {
+        if (job.targetPath) reservedTargets.delete(pathKey(job.targetPath));
+        scheduleCleanup(job);
+    }
+}
+
+export async function chooseDownloadDirectory(event: IpcMainInvokeEvent) {
+    const parent = BrowserWindow.fromWebContents(event.sender);
+    const result = parent
+        ? await dialog.showOpenDialog(parent, DIRECTORY_DIALOG_OPTIONS)
+        : await dialog.showOpenDialog(DIRECTORY_DIALOG_OPTIONS);
+
+    return result.canceled ? null : result.filePaths[0] ?? null;
+}
+
+export function enableDownloadInterception(event: IpcMainInvokeEvent, options: DownloadInterceptionOptions = {}) {
+    const { session } = event.sender;
+    const { directory, askEveryTime = false } = options;
+    const existing = downloadInterceptors.get(session);
+    if (existing) {
+        existing.directory = directory;
+        existing.askEveryTime = askEveryTime;
+        existing.webContentsId = event.sender.id;
+        return true;
+    }
+
+    const interception = {} as DownloadInterceptor;
+    interception.directory = directory;
+    interception.askEveryTime = askEveryTime;
+    interception.webContentsId = event.sender.id;
+    interception.handler = (_event, item, webContents) => handleElectronDownload(interception, item, webContents);
+    session.on("will-download", interception.handler);
+    downloadInterceptors.set(session, interception);
+    return true;
+}
+
+export function disableDownloadInterception(event: IpcMainInvokeEvent) {
+    const { session } = event.sender;
+    const interception = downloadInterceptors.get(session);
+    if (!interception) return false;
+
+    session.off("will-download", interception.handler);
+    downloadInterceptors.delete(session);
+    return true;
+}
+
+export async function startDownload(_: IpcMainInvokeEvent, request: DownloadRequest): Promise<StartedDownload> {
+    if (!isDownloadRequest(request)) throw new Error("Invalid download request");
+
+    const url = assertAllowedAttachmentUrl(request.url);
+    const directory = resolveDirectory(request.directory);
+    await mkdir(directory, { recursive: true });
+
+    const filename = sanitiseFilename(request.filename, url);
+    const targetPath = await reserveTarget(directory, filename);
+    const id = randomUUID();
+    const job: DownloadJob = {
+        id,
+        filename,
+        state: "queued",
+            controller: new AbortController(),
+            targetPath,
+    };
+
+    jobs.set(id, job);
+    void runDownload(job, url);
+
+    return { id, filename };
+}
+
+export function getDownloadStatus(_: IpcMainInvokeEvent, id: string): DownloadStatus | null {
+    const job = jobs.get(id);
+    if (!job) return null;
+
+    return {
+        id: job.id,
+        filename: job.filename,
+        state: job.state,
+        error: job.error,
+    };
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -669,6 +669,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Davri: {
         name: "Davri",
         id: 457579346282938368n
+    },
+    skyade: {
+        name: ".skyade",
+        id: 672947463937851432n,
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
Discord opening the browser every time I download an attachment is annoying as hell, this adds `InappDownloader` to keep it in-app.

The only new UI is the plugin settings and a popup toast confirming downloads, so don't got much to show a screenshot for there.