### PR TITLE
WebPWA(fix): don't use discord's dynamic favicon, set notification count on start

### DIFF
--- a/src/Vencord.ts
+++ b/src/Vencord.ts
@@ -18,7 +18,6 @@
 
 // DO NOT REMOVE UNLESS YOU WISH TO FACE THE WRATH OF THE CIRCULAR DEPENDENCY DEMON!!!!!!!
 import "~plugins";
-import "./fixWeirdAppRegionBug.css";
 
 export * as Api from "./api";
 export * as Plugins from "./api/PluginManager";

--- a/src/fixWeirdAppRegionBug.css
+++ b/src/fixWeirdAppRegionBug.css
@@ -1,4 +1,0 @@
-/* Works around a very strange issue where *something* (electron?) will inject body { app-region: drag } when using online themes */
-body {
-    app-region: no-drag;
-}

--- a/src/plugins/webPWA.browser/index.tsx
+++ b/src/plugins/webPWA.browser/index.tsx
@@ -26,6 +26,8 @@ function colorToHex(color: string) {
     return "#" + [...ctx.getImageData(0, 0, 1, 1).data.slice(0, 3)].map(n => n.toString(16).padStart(2, "0")).join("");
 }
 
+const icon = "https://discord.com/assets/favicon.ico";
+
 let linkEl: HTMLLinkElement | undefined;
 async function setManifest() {
     // need to wait for CSS changes to flush
@@ -38,7 +40,6 @@ async function setManifest() {
 
     const endpoint = "https:" + window.GLOBAL_ENV.WEBAPP_ENDPOINT;
     const appUrl = endpoint + "/app"; // URL when PWA launches
-    const icon = document.querySelector<HTMLLinkElement>('link[rel="icon"]')!.href;
     const styles = getComputedStyle(document.body);
     const manifest = {
         id: appUrl,
@@ -122,6 +123,7 @@ export default definePlugin({
         NotificationSettingsStore.addChangeListener(this.setBadge);
         GuildReadStateStore.addChangeListener(this.setBadge);
         RelationshipStore.addChangeListener(this.setBadge);
+        this.setBadge();
 
         if (!IS_USERSCRIPT) {
             // keybinds


### PR DESCRIPTION
## Describe your Changes
Icon was computed dynamically, at a suggestion of some1 from 2 years ago, this is a bad idea because discord does the funny and computes the notif count and renders a custom favicon, 
<img width="136" height="146" alt="image" src="https://github.com/user-attachments/assets/d1245d28-2dd0-4e3d-a39b-7f7f128720ab" />
and its bad and broken

also fixes notis not being set at launch

removes the *allegedly* now unnecessary css fix


## Screenshots (if applicable)

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent. <!-- Don't bother lying, we will know and you will be banned -->
- [x] I understand that if any of the above conditions are not met, this pull request will be closed and I will be banned from future contributions without further warning
