### PR TITLE
WebPWA: fix macos styles

### DIFF
--- a/src/plugins/webPWA.browser/styles.css
+++ b/src/plugins/webPWA.browser/styles.css
@@ -9,9 +9,16 @@
         --custom-app-top-bar-height: env(titlebar-area-height, 0px) !important;
     }
 
-    /* position trailing titlebar elements alongside WCO */
-    [data-fullscreen] > [class*="bar_"] [class*="trailing_"] {
-        padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0px));
+
+    /* position trailing/leading titlebar elements alongside WCO */
+    [class*="bar_"] {
+        [class*="leading_"] {
+            padding-left: env(titlebar-area-x, 0);
+        }
+
+        [class*="trailing_"] {
+            padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0));
+        }
     }
 
     /* popout windows like screenshare popout, these properties don't work outside WCO so this is safe */

--- a/src/plugins/webPWA.browser/styles.css
+++ b/src/plugins/webPWA.browser/styles.css
@@ -11,13 +11,13 @@
 
 
     /* position trailing/leading titlebar elements alongside WCO */
-    [class*="bar_"] {
+    [data-fullscreen] > [class*="bar_"] {
         [class*="leading_"] {
-            padding-left: env(titlebar-area-x, 0);
+            padding-left: env(titlebar-area-x, 0px);
         }
 
         [class*="trailing_"] {
-            padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0));
+            padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0px));
         }
     }
 
@@ -27,12 +27,12 @@
             app-region: drag;
 
             [class*="headerBarChildren_"] {
-                padding-left: env(titlebar-area-x, 0);
+                padding-left: env(titlebar-area-x, 0px);
             }
 
             /* position trailing toolbar elements alongside WCO */
             [class*="toolbar_"] {
-                padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0));
+                padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0px));
             }
         }
     }

--- a/src/plugins/webPWA.browser/styles.css
+++ b/src/plugins/webPWA.browser/styles.css
@@ -13,7 +13,7 @@
     /* position trailing/leading titlebar elements alongside WCO */
     [data-fullscreen] > [class*="bar_"] {
         [class*="leading_"] {
-            padding-left: env(titlebar-area-x, 0px);
+            padding-left: env(titlebar-area-x, 0);
         }
 
         [class*="trailing_"] {
@@ -27,7 +27,7 @@
             app-region: drag;
 
             [class*="headerBarChildren_"] {
-                padding-left: env(titlebar-area-x, 0px);
+                padding-left: env(titlebar-area-x, 0);
             }
 
             /* position trailing toolbar elements alongside WCO */

--- a/src/plugins/webPWA.browser/styles.css
+++ b/src/plugins/webPWA.browser/styles.css
@@ -28,7 +28,8 @@
 
             /* position trailing toolbar elements alongside WCO */
             [class*="toolbar_"] {
-                padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0px));
+                padding-left: env(titlebar-area-x, 0);
+                padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0));
             }
         }
     }

--- a/src/plugins/webPWA.browser/styles.css
+++ b/src/plugins/webPWA.browser/styles.css
@@ -26,9 +26,12 @@
         [class*="headerWrapper_"] {
             app-region: drag;
 
+            [class*="headerBarChildren_"] {
+                padding-left: env(titlebar-area-x, 0);
+            }
+
             /* position trailing toolbar elements alongside WCO */
             [class*="toolbar_"] {
-                padding-left: env(titlebar-area-x, 0);
                 padding-right: calc(100vw - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0));
             }
         }


### PR DESCRIPTION
## Describe your Changes
Fixed the titlebar style for OSs with left aligned window controls

## Screenshots (if applicable)
Before (covered) vs after (visible)
<img width="321" height="139" alt="image" src="https://github.com/user-attachments/assets/32ee5deb-1007-4dac-a41e-742f9f38eebf" />
<img width="320" height="133" alt="image" src="https://github.com/user-attachments/assets/23241486-e0db-4711-b741-0969db44a8fb" />
the tabs get additional padding due to .platform-web being present, might have to fix that too if the feature rolls out

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent. <!-- Don't bother lying, we will know and you will be banned -->
- [x] I understand that if any of the above conditions are not met, this pull request will be closed and I will be banned from future contributions without further warning
