### PR TITLE
Feat (Plugin): Add scheduled status plugin

### DIFF
--- a/src/plugins/scheduledStatus/SettingsPanel.tsx
+++ b/src/plugins/scheduledStatus/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2024 Vendicated and contributors
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/plugins/scheduledStatus/SettingsPanel.tsx
+++ b/src/plugins/scheduledStatus/SettingsPanel.tsx
@@ -1,0 +1,330 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles.css";
+
+import { Button } from "@components/Button";
+import { Card } from "@components/Card";
+import { Divider } from "@components/Divider";
+import { ErrorCard } from "@components/ErrorCard";
+import { Flex } from "@components/Flex";
+import { FormSwitch } from "@components/FormSwitch";
+import { HeadingSecondary } from "@components/Heading";
+import { DeleteIcon, PencilIcon } from "@components/Icons";
+import { Margins } from "@components/margins";
+import { Paragraph } from "@components/Paragraph";
+import { Span } from "@components/Span";
+import { Switch } from "@components/Switch";
+import { classes } from "@utils/misc";
+import { React, Select, TextInput, useEffect, useState } from "@webpack/common";
+
+import { evaluate, getActiveRuleId, settings } from ".";
+import {
+    DAY_NAMES,
+    DAYS,
+    DEFAULT_STATUS_OPTIONS,
+    DefaultStatusType,
+    findConflict,
+    formatDays,
+    isRuleActive,
+    ScheduleRule,
+    STATUS_OPTIONS,
+    statusName,
+    StatusType
+} from "./types";
+
+function DayPicker({ selected, onChange }: { selected: number[]; onChange(d: number[]): void; }) {
+    const toggle = (v: number) =>
+        onChange(selected.includes(v) ? selected.filter(d => d !== v) : [...selected, v]);
+
+    return (
+        <section>
+            <Flex style={{ justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+                <Span size="sm" weight="medium">Days</Span>
+                <div className="vc-scheduledStatus-pills">
+                    <Button variant="secondary" size="min" onClick={() => onChange([0, 1, 2, 3, 4])}>Weekdays</Button>
+                    <Button variant="secondary" size="min" onClick={() => onChange([5, 6])}>Weekends</Button>
+                    <Button variant="secondary" size="min" onClick={() => onChange([0, 1, 2, 3, 4, 5, 6])}>All</Button>
+                    <Button variant="secondary" size="min" onClick={() => onChange([])}>Clear</Button>
+                </div>
+            </Flex>
+            <div className="vc-scheduledStatus-pills">
+                {DAYS.map(d => (
+                    <button
+                        key={d.value}
+                        type="button"
+                        className={classes("vc-scheduledStatus-pill", selected.includes(d.value) && "vc-scheduledStatus-pill-on")}
+                        onClick={() => toggle(d.value)}
+                        title={d.long}
+                    >
+                        {d.short}
+                    </button>
+                ))}
+            </div>
+        </section>
+    );
+}
+
+function TimePicker({ start, end, onStart, onEnd }: {
+    start: string; end: string;
+    onStart(v: string): void; onEnd(v: string): void;
+}) {
+    return (
+        <div className="vc-scheduledStatus-timeRow">
+            <section>
+                <Span size="sm" weight="medium">Start</Span>
+                <input type="time" className="vc-scheduledStatus-timeInput" value={start} onChange={e => onStart(e.currentTarget.value)} />
+            </section>
+            <section>
+                <Span size="sm" weight="medium">End</Span>
+                <input type="time" className="vc-scheduledStatus-timeInput" value={end} onChange={e => onEnd(e.currentTarget.value)} />
+            </section>
+        </div>
+    );
+}
+
+export function SettingsPanel() {
+    const [, setTick] = useState(0);
+    const rerender = () => setTick(t => t + 1);
+    useEffect(() => {
+        const id = setInterval(rerender, 10_000);
+        return () => clearInterval(id);
+    }, []);
+
+    const rules: ScheduleRule[] = settings.store.schedules ?? [];
+    const now = new Date();
+    const activeId = getActiveRuleId();
+    const activeRule = rules.find(r => r.id === activeId || (activeId == null && isRuleActive(r, now)));
+
+    const [days, setDays] = useState<number[]>([0]);
+    const [startTime, setStartTime] = useState("08:00");
+    const [endTime, setEndTime] = useState("17:00");
+    const [status, setStatus] = useState<StatusType>("dnd");
+    const [name, setName] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [editId, setEditId] = useState<string | null>(null);
+
+    function save(next: ScheduleRule[]) {
+        settings.store.schedules = next;
+        rerender();
+        evaluate();
+    }
+
+    function addRule() {
+        setError(null);
+        if (!days.length) return setError("Select at least one day.");
+        if (!startTime || !endTime) return setError("Set a start and end time.");
+
+        const rule: ScheduleRule = {
+            id: crypto.randomUUID(),
+            name: name.trim() || `${statusName(status)} (${startTime} – ${endTime})`,
+            enabled: true,
+            days: [...days],
+            startTime,
+            endTime,
+            status,
+        };
+
+        const conflict = findConflict(rule, rules);
+        if (conflict) {
+            return setError(`Overlaps with "${conflict.rule.name}" on ${DAY_NAMES[conflict.day]}`);
+        }
+
+        save([...rules, rule]);
+        setName("");
+        setError(null);
+    }
+
+    function updateRule(idx: number, updated: ScheduleRule) {
+        setError(null);
+        if (updated.enabled) {
+            const conflict = findConflict(updated, rules, updated.id);
+            if (conflict) {
+                return setError(`"${updated.name}" overlaps with "${conflict.rule.name}" on ${DAY_NAMES[conflict.day]}`);
+            }
+        }
+        const next = [...rules];
+        next[idx] = updated;
+        save(next);
+    }
+
+    function deleteRule(idx: number) {
+        if (rules[idx].id === editId) setEditId(null);
+        save(rules.filter((_, i) => i !== idx));
+    }
+
+    return (
+        <Flex flexDirection="column" gap="1em">
+            <section>
+                <HeadingSecondary>Add Time Slot</HeadingSecondary>
+                <Flex flexDirection="column" gap="0.75em" className={Margins.top8}>
+                    <DayPicker selected={days} onChange={d => { setDays(d); setError(null); }} />
+
+                    <TimePicker
+                        start={startTime} end={endTime}
+                        onStart={v => { setStartTime(v); setError(null); }}
+                        onEnd={v => { setEndTime(v); setError(null); }}
+                    />
+
+                    <section>
+                        <Span size="sm" weight="medium">Status</Span>
+                        <Select
+                            options={STATUS_OPTIONS}
+                            isSelected={v => v === status}
+                            select={v => setStatus(v as StatusType)}
+                            serialize={String}
+                            closeOnSelect
+                        />
+                    </section>
+
+                    <section>
+                        <Span size="sm" weight="medium">Name (optional)</Span>
+                        <TextInput placeholder="e.g. Work, Gaming, Sleep" value={name} onChange={setName} />
+                    </section>
+
+                    {error && (
+                        <ErrorCard>
+                            <Paragraph size="sm" weight="medium">⚠️ {error}</Paragraph>
+                        </ErrorCard>
+                    )}
+
+                    <Flex style={{ justifyContent: "flex-end" }}>
+                        <Button onClick={addRule}>Add</Button>
+                    </Flex>
+                </Flex>
+            </section>
+
+            <Divider />
+
+            <section>
+                <HeadingSecondary>Schedules ({rules.length})</HeadingSecondary>
+
+                {rules.length === 0 ? (
+                    <Card className={Margins.top8}>
+                        <Paragraph size="sm" style={{ textAlign: "center" }}>No schedules yet</Paragraph>
+                    </Card>
+                ) : (
+                    <Flex flexDirection="column" gap="0.5em" className={Margins.top8}>
+                        {rules.map((rule, idx) => {
+                            const active = activeRule?.id === rule.id && rule.enabled;
+                            const editing = editId === rule.id;
+
+                            return (
+                                <React.Fragment key={rule.id}>
+                                    <Card className={classes("vc-scheduledStatus-card", active && "vc-scheduledStatus-card-active")}>
+                                        <Switch checked={rule.enabled} onChange={v => updateRule(idx, { ...rule, enabled: v })} />
+                                        <div className="vc-scheduledStatus-info">
+                                            <Flex style={{ alignItems: "center", gap: 6 }}>
+                                                <span className={`vc-scheduledStatus-dot vc-scheduledStatus-dot-${rule.status}`} />
+                                                <Span size="md" weight="semibold">{rule.name}</Span>
+                                                {active && <span className="vc-scheduledStatus-badge">Active</span>}
+                                            </Flex>
+                                            <Span size="xs">
+                                                {formatDays(rule.days)} · {rule.startTime} – {rule.endTime} · {statusName(rule.status)}
+                                            </Span>
+                                        </div>
+                                        <Button variant="secondary" size="iconOnly" onClick={() => setEditId(editing ? null : rule.id)}>
+                                            <PencilIcon aria-label="Edit" width={20} height={20} />
+                                        </Button>
+                                        <Button variant="dangerSecondary" size="iconOnly" onClick={() => deleteRule(idx)}>
+                                            <DeleteIcon aria-label="Delete" width={20} height={20} />
+                                        </Button>
+                                    </Card>
+
+                                    {editing && (
+                                        <Card defaultPadding>
+                                            <Flex flexDirection="column" gap="0.75em">
+                                                <section>
+                                                    <Span size="sm" weight="medium">Name</Span>
+                                                    <TextInput value={rule.name} onChange={v => updateRule(idx, { ...rule, name: v })} />
+                                                </section>
+                                                <section>
+                                                    <Span size="sm" weight="medium">Status</Span>
+                                                    <Select
+                                                        options={STATUS_OPTIONS}
+                                                        isSelected={v => v === rule.status}
+                                                        select={v => updateRule(idx, { ...rule, status: v as StatusType })}
+                                                        serialize={String}
+                                                        closeOnSelect
+                                                    />
+                                                </section>
+                                                <DayPicker selected={rule.days} onChange={d => updateRule(idx, { ...rule, days: d })} />
+                                                <TimePicker
+                                                    start={rule.startTime} end={rule.endTime}
+                                                    onStart={v => updateRule(idx, { ...rule, startTime: v })}
+                                                    onEnd={v => updateRule(idx, { ...rule, endTime: v })}
+                                                />
+                                                <Flex style={{ justifyContent: "flex-end" }}>
+                                                    <Button variant="secondary" size="small" onClick={() => setEditId(null)}>Done</Button>
+                                                </Flex>
+                                            </Flex>
+                                        </Card>
+                                    )}
+                                </React.Fragment>
+                            );
+                        })}
+                    </Flex>
+                )}
+            </section>
+
+            {rules.length > 0 && (<>
+                <Divider />
+                <section>
+                    <HeadingSecondary>Weekly Overview</HeadingSecondary>
+                    <Flex flexDirection="column" gap="0.5em" className={Margins.top8}>
+                        {DAYS.map(d => {
+                            const slots = rules
+                                .filter(r => r.enabled && r.days.includes(d.value))
+                                .sort((a, b) => a.startTime.localeCompare(b.startTime));
+
+                            return (
+                                <Card key={d.value} className="vc-scheduledStatus-weekCard">
+                                    <Span size="sm" weight="semibold">{d.long}</Span>
+                                    {slots.length === 0 ? (
+                                        <Span size="xs">—</Span>
+                                    ) : (
+                                        <Flex style={{ gap: 6, flexWrap: "wrap" }}>
+                                            {slots.map(s => (
+                                                <span key={s.id} className="vc-scheduledStatus-slotPill">
+                                                    <span className={`vc-scheduledStatus-dot vc-scheduledStatus-dot-${s.status}`} />
+                                                    {s.startTime} – {s.endTime}
+                                                </span>
+                                            ))}
+                                        </Flex>
+                                    )}
+                                </Card>
+                            );
+                        })}
+                    </Flex>
+                </section>
+            </>)}
+
+            <Divider />
+
+            <section>
+                <HeadingSecondary>Options</HeadingSecondary>
+                <div className={Margins.top8}>
+                    <Span size="sm" weight="medium">Fallback status</Span>
+                    <Select
+                        options={DEFAULT_STATUS_OPTIONS}
+                        isSelected={v => v === (settings.store.defaultStatus ?? "previous")}
+                        select={v => { settings.store.defaultStatus = v as DefaultStatusType; rerender(); evaluate(); }}
+                        serialize={String}
+                        closeOnSelect
+                    />
+                </div>
+                <FormSwitch
+                    title="Toast Notifications"
+                    description="Show a toast when status changes due to a schedule"
+                    value={settings.store.notifyOnChange ?? true}
+                    onChange={v => { settings.store.notifyOnChange = v; rerender(); }}
+                    className={Margins.top16}
+                    hideBorder
+                />
+            </section>
+        </Flex>
+    );
+}

--- a/src/plugins/scheduledStatus/SettingsPanel.tsx
+++ b/src/plugins/scheduledStatus/SettingsPanel.tsx
@@ -21,7 +21,7 @@ import { Switch } from "@components/Switch";
 import { classes } from "@utils/misc";
 import { React, Select, TextInput, useEffect, useState } from "@webpack/common";
 
-import { evaluate, getActiveRuleId, settings } from ".";
+import { evaluate, settings } from ".";
 import {
     DAY_NAMES,
     DAYS,
@@ -56,6 +56,8 @@ function DayPicker({ selected, onChange }: { selected: number[]; onChange(d: num
                     <button
                         key={d.value}
                         type="button"
+                        aria-pressed={selected.includes(d.value)}
+                        aria-label={d.long}
                         className={classes("vc-scheduledStatus-pill", selected.includes(d.value) && "vc-scheduledStatus-pill-on")}
                         onClick={() => toggle(d.value)}
                         title={d.long}
@@ -96,8 +98,7 @@ export function SettingsPanel() {
 
     const rules: ScheduleRule[] = settings.store.schedules ?? [];
     const now = new Date();
-    const activeId = getActiveRuleId();
-    const activeRule = rules.find(r => r.id === activeId || (activeId == null && isRuleActive(r, now)));
+    const activeRule = rules.find(r => isRuleActive(r, now));
 
     const [days, setDays] = useState<number[]>([0]);
     const [startTime, setStartTime] = useState("08:00");
@@ -110,7 +111,7 @@ export function SettingsPanel() {
     function save(next: ScheduleRule[]) {
         settings.store.schedules = next;
         rerender();
-        evaluate();
+        evaluate().catch(console.error);
     }
 
     function addRule() {
@@ -218,7 +219,7 @@ export function SettingsPanel() {
                                         <Switch checked={rule.enabled} onChange={v => updateRule(idx, { ...rule, enabled: v })} />
                                         <div className="vc-scheduledStatus-info">
                                             <Flex style={{ alignItems: "center", gap: 6 }}>
-                                                <span className={`vc-scheduledStatus-dot vc-scheduledStatus-dot-${rule.status}`} />
+                                                <span aria-hidden="true" className={`vc-scheduledStatus-dot vc-scheduledStatus-dot-${rule.status}`} />
                                                 <Span size="md" weight="semibold">{rule.name}</Span>
                                                 {active && <span className="vc-scheduledStatus-badge">Active</span>}
                                             </Flex>
@@ -289,7 +290,7 @@ export function SettingsPanel() {
                                         <Flex style={{ gap: 6, flexWrap: "wrap" }}>
                                             {slots.map(s => (
                                                 <span key={s.id} className="vc-scheduledStatus-slotPill">
-                                                    <span className={`vc-scheduledStatus-dot vc-scheduledStatus-dot-${s.status}`} />
+                                                    <span aria-hidden="true" className={`vc-scheduledStatus-dot vc-scheduledStatus-dot-${s.status}`} />
                                                     {s.startTime} – {s.endTime}
                                                 </span>
                                             ))}
@@ -311,7 +312,7 @@ export function SettingsPanel() {
                     <Select
                         options={DEFAULT_STATUS_OPTIONS}
                         isSelected={v => v === (settings.store.defaultStatus ?? "previous")}
-                        select={v => { settings.store.defaultStatus = v as DefaultStatusType; rerender(); evaluate(); }}
+                        select={v => { settings.store.defaultStatus = v as DefaultStatusType; rerender(); evaluate().catch(console.error); }}
                         serialize={String}
                         closeOnSelect
                     />

--- a/src/plugins/scheduledStatus/index.tsx
+++ b/src/plugins/scheduledStatus/index.tsx
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2024 Vendicated and contributors
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/plugins/scheduledStatus/index.tsx
+++ b/src/plugins/scheduledStatus/index.tsx
@@ -31,10 +31,6 @@ let lastApplied: string | null = null;
 let savedStatus: string | null = null;
 let activeRuleId: string | null = null;
 
-export function getActiveRuleId() {
-    return activeRuleId;
-}
-
 function getStatus() {
     try { return StatusSettings?.getSetting?.(); }
     catch { return undefined; }
@@ -47,44 +43,48 @@ function onSettingsChange() {
 }
 
 export async function evaluate(manual = false) {
-    const status = getStatus();
-    if (!status) return;
+    try {
+        const status = getStatus();
+        if (!status) return;
 
-    const rules: ScheduleRule[] = settings.store.schedules ?? [];
-    const now = new Date();
-    const active = rules.find(r => isRuleActive(r, now));
+        const rules: ScheduleRule[] = settings.store.schedules ?? [];
+        const now = new Date();
+        const active = rules.find(r => isRuleActive(r, now));
 
-    if (active) {
-        if (activeRuleId == null && !savedStatus) savedStatus = status;
-        activeRuleId = active.id;
+        if (active) {
+            if (activeRuleId == null && !savedStatus) savedStatus = status;
+            activeRuleId = active.id;
 
-        if (status !== active.status) {
-            lastApplied = active.status;
-            await StatusSettings.updateSetting(active.status);
+            if (status !== active.status) {
+                lastApplied = active.status;
+                await StatusSettings.updateSetting(active.status);
 
-            if (settings.store.notifyOnChange || manual)
-                showToast(`Set to ${statusName(active.status)} (${active.name})`, Toasts.Type.SUCCESS);
+                if (settings.store.notifyOnChange || manual)
+                    showToast(`Set to ${statusName(active.status)} (${active.name})`, Toasts.Type.SUCCESS);
+            } else if (manual) {
+                showToast(`Already ${statusName(active.status)} (${active.name})`, Toasts.Type.MESSAGE);
+            }
+        } else if (activeRuleId != null) {
+            activeRuleId = null;
+            const def = settings.store.defaultStatus ?? "previous";
+            let restore: string | null = null;
+
+            if (def === "previous") restore = savedStatus ?? "online";
+            else if (def !== "keep") restore = def;
+
+            if (restore && status !== restore) {
+                lastApplied = restore;
+                await StatusSettings.updateSetting(restore);
+
+                if (settings.store.notifyOnChange || manual)
+                    showToast(`Restored to ${statusName(restore)}`, Toasts.Type.MESSAGE);
+            }
+            savedStatus = null;
         } else if (manual) {
-            showToast(`Already ${statusName(active.status)} (${active.name})`, Toasts.Type.MESSAGE);
+            showToast("No active schedule right now.", Toasts.Type.MESSAGE);
         }
-    } else if (activeRuleId != null) {
-        activeRuleId = null;
-        const def = settings.store.defaultStatus ?? "previous";
-        let restore: string | null = null;
-
-        if (def === "previous") restore = savedStatus ?? "online";
-        else if (def !== "keep") restore = def;
-
-        if (restore && status !== restore) {
-            lastApplied = restore;
-            await StatusSettings.updateSetting(restore);
-
-            if (settings.store.notifyOnChange || manual)
-                showToast(`Restored to ${statusName(restore)}`, Toasts.Type.MESSAGE);
-        }
-        savedStatus = null;
-    } else if (manual) {
-        showToast("No active schedule right now.", Toasts.Type.MESSAGE);
+    } catch (e) {
+        console.error(e);
     }
 }
 
@@ -99,8 +99,8 @@ export default definePlugin({
     start() {
         savedStatus = getStatus() ?? null;
         UserSettingsProtoStore.addChangeListener(onSettingsChange);
-        evaluate();
-        checkInterval = setInterval(evaluate, 15_000);
+        evaluate().catch(console.error);
+        checkInterval = setInterval(() => { evaluate().catch(console.error); }, 15_000);
     },
 
     stop() {
@@ -112,7 +112,7 @@ export default definePlugin({
         UserSettingsProtoStore.removeChangeListener(onSettingsChange);
 
         if (activeRuleId && savedStatus && (settings.store.defaultStatus ?? "previous") === "previous") {
-            StatusSettings.updateSetting(savedStatus);
+            StatusSettings.updateSetting(savedStatus).catch(console.error);
         }
 
         activeRuleId = null;

--- a/src/plugins/scheduledStatus/index.tsx
+++ b/src/plugins/scheduledStatus/index.tsx
@@ -1,0 +1,122 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { getUserSettingLazy } from "@api/UserSettings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { showToast, Toasts, UserSettingsProtoStore } from "@webpack/common";
+
+import { SettingsPanel } from "./SettingsPanel";
+import { DefaultStatusType, isRuleActive, ScheduleRule, statusName } from "./types";
+
+const StatusSettings = getUserSettingLazy<string>("status", "status")!;
+
+export const settings = definePluginSettings({
+    settingsPanel: {
+        type: OptionType.COMPONENT,
+        component: SettingsPanel,
+    },
+}).withPrivateSettings<{
+    schedules: ScheduleRule[];
+    defaultStatus: DefaultStatusType;
+    notifyOnChange: boolean;
+}>();
+
+let checkInterval: ReturnType<typeof setInterval> | null = null;
+let lastApplied: string | null = null;
+let savedStatus: string | null = null;
+let activeRuleId: string | null = null;
+
+export function getActiveRuleId() {
+    return activeRuleId;
+}
+
+function getStatus() {
+    try { return StatusSettings?.getSetting?.(); }
+    catch { return undefined; }
+}
+
+function onSettingsChange() {
+    const status = getStatus();
+    if (!status || status === lastApplied) return;
+    if (!activeRuleId) savedStatus = status;
+}
+
+export async function evaluate(manual = false) {
+    const status = getStatus();
+    if (!status) return;
+
+    const rules: ScheduleRule[] = settings.store.schedules ?? [];
+    const now = new Date();
+    const active = rules.find(r => isRuleActive(r, now));
+
+    if (active) {
+        if (activeRuleId == null && !savedStatus) savedStatus = status;
+        activeRuleId = active.id;
+
+        if (status !== active.status) {
+            lastApplied = active.status;
+            await StatusSettings.updateSetting(active.status);
+
+            if (settings.store.notifyOnChange || manual)
+                showToast(`Set to ${statusName(active.status)} (${active.name})`, Toasts.Type.SUCCESS);
+        } else if (manual) {
+            showToast(`Already ${statusName(active.status)} (${active.name})`, Toasts.Type.MESSAGE);
+        }
+    } else if (activeRuleId != null) {
+        activeRuleId = null;
+        const def = settings.store.defaultStatus ?? "previous";
+        let restore: string | null = null;
+
+        if (def === "previous") restore = savedStatus ?? "online";
+        else if (def !== "keep") restore = def;
+
+        if (restore && status !== restore) {
+            lastApplied = restore;
+            await StatusSettings.updateSetting(restore);
+
+            if (settings.store.notifyOnChange || manual)
+                showToast(`Restored to ${statusName(restore)}`, Toasts.Type.MESSAGE);
+        }
+        savedStatus = null;
+    } else if (manual) {
+        showToast("No active schedule right now.", Toasts.Type.MESSAGE);
+    }
+}
+
+export default definePlugin({
+    name: "ScheduledStatus",
+    description: "Automatically changes your status based on scheduled times and days of the week",
+    authors: [Devs.DaintyDust],
+    tags: ["Activity", "Utility"],
+    dependencies: ["UserSettingsAPI"],
+    settings,
+
+    start() {
+        savedStatus = getStatus() ?? null;
+        UserSettingsProtoStore.addChangeListener(onSettingsChange);
+        evaluate();
+        checkInterval = setInterval(evaluate, 15_000);
+    },
+
+    stop() {
+        if (checkInterval) {
+            clearInterval(checkInterval);
+            checkInterval = null;
+        }
+
+        UserSettingsProtoStore.removeChangeListener(onSettingsChange);
+
+        if (activeRuleId && savedStatus && (settings.store.defaultStatus ?? "previous") === "previous") {
+            StatusSettings.updateSetting(savedStatus);
+        }
+
+        activeRuleId = null;
+        savedStatus = null;
+        lastApplied = null;
+    },
+});

--- a/src/plugins/scheduledStatus/styles.css
+++ b/src/plugins/scheduledStatus/styles.css
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2024 Vendicated and contributors
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/plugins/scheduledStatus/styles.css
+++ b/src/plugins/scheduledStatus/styles.css
@@ -1,0 +1,122 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+.vc-scheduledStatus-card {
+    padding: 0.5em;
+    padding-left: 1em;
+    display: grid;
+    grid-template-columns: auto 1fr min-content min-content;
+    align-items: center;
+    gap: 0.5em;
+}
+
+.vc-scheduledStatus-card-active {
+    border-color: var(--brand-500) !important;
+}
+
+.vc-scheduledStatus-pills {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+.vc-scheduledStatus-pill {
+    padding: 6px 12px;
+    border-radius: 16px;
+    border: 1px solid var(--border-subtle);
+    background: var(--card-background-default);
+    color: var(--text-muted);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.15s, color 0.15s;
+}
+
+.vc-scheduledStatus-pill:hover {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+}
+
+.vc-scheduledStatus-pill-on {
+    background: var(--brand-500);
+    border-color: var(--brand-500);
+    color: #fff;
+}
+
+.vc-scheduledStatus-timeRow {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.vc-scheduledStatus-timeInput {
+    background: var(--input-background, var(--background-tertiary));
+    color: var(--text-normal);
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm, 4px);
+    padding: 8px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    color-scheme: dark;
+    width: 100%;
+    box-sizing: border-box;
+    outline: none;
+}
+
+.vc-scheduledStatus-timeInput:focus {
+    border-color: var(--brand-500);
+}
+
+.vc-scheduledStatus-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.vc-scheduledStatus-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.vc-scheduledStatus-dot-online { background: var(--status-positive, #23a55a); }
+.vc-scheduledStatus-dot-idle { background: var(--status-warning, #f0b232); }
+.vc-scheduledStatus-dot-dnd { background: var(--status-danger, #f23f43); }
+.vc-scheduledStatus-dot-invisible { background: var(--status-invisible, #80848e); }
+
+.vc-scheduledStatus-badge {
+    display: inline-flex;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    background: var(--brand-500);
+    color: #fff;
+}
+
+.vc-scheduledStatus-slotPill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: var(--radius-sm, 4px);
+    background: var(--card-background-default);
+    border: 1px solid var(--border-subtle);
+    font-size: 12px;
+    color: var(--text-normal);
+}
+
+.vc-scheduledStatus-weekCard {
+    padding: 0.5em 1em;
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    align-items: center;
+    gap: 0.5em;
+}

--- a/src/plugins/scheduledStatus/styles.css
+++ b/src/plugins/scheduledStatus/styles.css
@@ -61,7 +61,7 @@
     padding: 8px 12px;
     font-size: 14px;
     font-family: inherit;
-    color-scheme: dark;
+    color-scheme: light dark;
     width: 100%;
     box-sizing: border-box;
     outline: none;

--- a/src/plugins/scheduledStatus/types.ts
+++ b/src/plugins/scheduledStatus/types.ts
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2024 Vendicated and contributors
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/plugins/scheduledStatus/types.ts
+++ b/src/plugins/scheduledStatus/types.ts
@@ -1,0 +1,130 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export type StatusType = "online" | "idle" | "dnd" | "invisible";
+export type DefaultStatusType = "previous" | "keep" | StatusType;
+
+export interface ScheduleRule {
+    id: string;
+    name: string;
+    enabled: boolean;
+    days: number[];
+    startTime: string;
+    endTime: string;
+    status: StatusType;
+}
+
+export const DAYS = [
+    { short: "Mon", long: "Monday", value: 0 },
+    { short: "Tue", long: "Tuesday", value: 1 },
+    { short: "Wed", long: "Wednesday", value: 2 },
+    { short: "Thu", long: "Thursday", value: 3 },
+    { short: "Fri", long: "Friday", value: 4 },
+    { short: "Sat", long: "Saturday", value: 5 },
+    { short: "Sun", long: "Sunday", value: 6 },
+] as const;
+
+export const DAY_NAMES: Record<number, string> = {
+    0: "Monday", 1: "Tuesday", 2: "Wednesday", 3: "Thursday",
+    4: "Friday", 5: "Saturday", 6: "Sunday",
+};
+
+export const STATUS_OPTIONS = [
+    { label: "Online", value: "online" as StatusType },
+    { label: "Idle", value: "idle" as StatusType },
+    { label: "Do Not Disturb", value: "dnd" as StatusType },
+    { label: "Invisible", value: "invisible" as StatusType },
+];
+
+export const DEFAULT_STATUS_OPTIONS = [
+    { label: "Restore Previous", value: "previous" as DefaultStatusType },
+    { label: "Keep Current", value: "keep" as DefaultStatusType },
+    ...STATUS_OPTIONS,
+];
+
+function timeToMinutes(t: string) {
+    const [h, m] = t.split(":").map(Number);
+    return (h || 0) * 60 + (m || 0);
+}
+
+function jsToDay(jsDay: number) {
+    return (jsDay + 6) % 7;
+}
+
+function getRuleIntervals(rule: ScheduleRule) {
+    const intervals: { day: number; start: number; end: number; }[] = [];
+    if (!rule.days.length) return intervals;
+
+    const start = timeToMinutes(rule.startTime);
+    const end = timeToMinutes(rule.endTime);
+
+    for (const d of rule.days) {
+        if (start < end) {
+            intervals.push({ day: d, start, end });
+        } else if (start > end) {
+            intervals.push({ day: d, start, end: 1440 });
+            intervals.push({ day: (d + 1) % 7, start: 0, end });
+        } else {
+            intervals.push({ day: d, start: 0, end: 1440 });
+        }
+    }
+    return intervals;
+}
+
+export function findConflict(rule: ScheduleRule, rules: ScheduleRule[], ignoreId?: string) {
+    const intervals = getRuleIntervals(rule);
+
+    for (const existing of rules) {
+        if (existing.id === ignoreId || !existing.enabled) continue;
+
+        for (const a of intervals) {
+            for (const b of getRuleIntervals(existing)) {
+                if (a.day === b.day && Math.max(a.start, b.start) < Math.min(a.end, b.end)) {
+                    return { rule: existing, day: a.day };
+                }
+            }
+        }
+    }
+    return null;
+}
+
+export function isRuleActive(rule: ScheduleRule, now = new Date()) {
+    if (!rule.enabled || !rule.days.length) return false;
+
+    const day = jsToDay(now.getDay());
+    const mins = now.getHours() * 60 + now.getMinutes();
+    const start = timeToMinutes(rule.startTime);
+    const end = timeToMinutes(rule.endTime);
+
+    if (start < end)
+        return rule.days.includes(day) && mins >= start && mins < end;
+
+    if (start > end) {
+        if (rule.days.includes(day) && mins >= start) return true;
+        if (rule.days.includes((day + 6) % 7) && mins < end) return true;
+        return false;
+    }
+
+    return rule.days.includes(day);
+}
+
+export function formatDays(days: number[]) {
+    if (!days.length) return "No days";
+    if (days.length === 7) return "Every day";
+    if (days.length === 5 && [0, 1, 2, 3, 4].every(d => days.includes(d))) return "Weekdays";
+    if (days.length === 2 && [5, 6].every(d => days.includes(d))) return "Weekends";
+
+    const order = [...days].sort();
+    return order.map(d => DAY_NAMES[d]?.slice(0, 3)).join(", ");
+}
+
+const STATUS_NAMES: Record<string, string> = {
+    online: "Online", idle: "Idle", dnd: "Do Not Disturb", invisible: "Invisible"
+};
+
+export function statusName(s: string) {
+    return STATUS_NAMES[s] ?? s;
+}

--- a/src/plugins/scheduledStatus/types.ts
+++ b/src/plugins/scheduledStatus/types.ts
@@ -117,7 +117,7 @@ export function formatDays(days: number[]) {
     if (days.length === 5 && [0, 1, 2, 3, 4].every(d => days.includes(d))) return "Weekdays";
     if (days.length === 2 && [5, 6].every(d => days.includes(d))) return "Weekends";
 
-    const order = [...days].sort();
+    const order = [...days].sort((a, b) => a - b);
     return order.map(d => DAY_NAMES[d]?.slice(0, 3)).join(", ");
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -669,7 +669,11 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Davri: {
         name: "Davri",
         id: 457579346282938368n
-    }
+    },
+    DaintyDust: {
+        name: "DaintyDust",
+        id: 749898979013296139n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Describe your Changes

I created this plugin to schedule your status. so if your at school and want to keep discord open, it could automatically set your status to "Do not disturb"

You can create different schedules for different times slots in the day and week.

## Screenshots (if applicable)

<img width="684" height="789" alt="image" src="https://github.com/user-attachments/assets/d09719a9-791e-47e0-8e0e-bb4cc20fd8f7" />



## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent. <!-- Don't bother lying, we will know and you will be banned -->
- [x] I understand that if any of the above conditions are not met, this pull request will be closed and I will be banned from future contributions without further warning
