### PR TITLE
feat: add Voice Messages In-Background plugin

### DIFF
--- a/src/plugins/voiceMessagesInBackground/index.tsx
+++ b/src/plugins/voiceMessagesInBackground/index.tsx
@@ -1,0 +1,58 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { migratePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+import { handlePlaybackRateUpdate, stopPlayback, useBackgroundPlayback } from "./playback";
+import { VoiceMessagesInBackgroundPlayer } from "./player";
+
+interface PlaybackRateUpdate {
+    playbackType: string;
+    rate: number;
+}
+
+const WrappedVoiceMessagesInBackgroundPlayer = ErrorBoundary.wrap(VoiceMessagesInBackgroundPlayer, { noop: true });
+
+migratePluginSettings("VoiceMessagesInBackground", "Voice Messages In-Background");
+
+export default definePlugin({
+    name: "VoiceMessagesInBackground",
+    description: "Keeps voice messages playing across chats with a synchronized mini player.",
+    authors: [Devs.ELJoOker],
+    tags: ["Voice", "Media", "Chat"],
+
+    patches: [
+        {
+            find: "#{intl::PAUSE_VOICE_MESSAGE_A11Y_LABEL}",
+            replacement: {
+                match: /(?<=\i>0\),\[(\i),(\i)\].{0,50}useState\(!1\).{0,10})(\[\i,\i\]=)(\i\.useState\(!1\))(?=.{0,100}\("none"\))/,
+                replace: "$3$self.useBackgroundPlayback($4,$1,arguments[0]?.src,arguments[0]?.playbackCacheKey,$2)"
+            }
+        },
+        {
+            find: "Missing channel in Channel.renderHeaderToolbar",
+            replacement: {
+                match: /(?<=renderHeaderToolbar"\);let (\i)=\[\];)/,
+                replace: "$1.push($self.renderPlayer());"
+            }
+        }
+    ],
+
+    flux: {
+        MEDIA_PLAYBACK_RATE_UPDATE({ playbackType, rate }: PlaybackRateUpdate) {
+            if (playbackType === "voice_message") handlePlaybackRateUpdate(rate);
+        }
+    },
+
+    renderPlayer: () => <WrappedVoiceMessagesInBackgroundPlayer key="vc-vmib-player" />,
+    useBackgroundPlayback,
+    stop: stopPlayback
+});

--- a/src/plugins/voiceMessagesInBackground/playback.ts
+++ b/src/plugins/voiceMessagesInBackground/playback.ts
@@ -1,0 +1,380 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { FluxDispatcher, SelectedChannelStore, useEffect, useRef } from "@webpack/common";
+import type { Dispatch, SetStateAction } from "react";
+
+type NativePlayingState = [boolean, Dispatch<SetStateAction<boolean>>];
+
+interface ActivePlayback {
+    attached: boolean;
+    cacheKey?: string;
+    channelId?: string;
+    duration: number;
+    paused: boolean;
+    player: HTMLAudioElement;
+    position: number;
+    setNativePlaying?: Dispatch<SetStateAction<boolean>>;
+    setNativePosition?: Dispatch<SetStateAction<number>>;
+    speed: number;
+    src: string;
+    updatedAt: number;
+}
+
+export interface PlaybackSnapshot {
+    channelId?: string;
+    duration: number;
+    paused: boolean;
+    position: number;
+    speed: number;
+    src: string;
+}
+
+let active: ActivePlayback | undefined;
+let lastCacheSync = 0;
+let voicePlaybackSpeed = 1;
+
+const NATIVE_END_EPSILON = 0.001;
+const playbackListeners = new Set<() => void>();
+
+function notifyPlayback() {
+    playbackListeners.forEach(listener => listener());
+}
+
+export function subscribePlayback(listener: () => void) {
+    playbackListeners.add(listener);
+    return () => {
+        playbackListeners.delete(listener);
+    };
+}
+
+function samePlayback(current: ActivePlayback, src: string, cacheKey?: string) {
+    return current.src === src && (!cacheKey || !current.cacheKey || current.cacheKey === cacheKey);
+}
+
+function clampPosition(current: ActivePlayback, position: number) {
+    if (!Number.isFinite(position)) return 0;
+
+    const safePosition = Math.max(0, position);
+    return current.duration > 0 ? Math.min(safePosition, current.duration) : safePosition;
+}
+
+function playbackPosition(current: ActivePlayback) {
+    const playerPosition = current.player.currentTime;
+    if (current.player.readyState > 0 && Number.isFinite(playerPosition)) {
+        return clampPosition(current, playerPosition);
+    }
+
+    if (current.paused) return current.position;
+    return clampPosition(current, current.position + (Date.now() - current.updatedAt) / 1000 * current.speed);
+}
+
+function updatePosition(current: ActivePlayback, position: number) {
+    current.position = clampPosition(current, position);
+    current.updatedAt = Date.now();
+}
+
+function isAtEnd(current: ActivePlayback, position: number) {
+    return current.duration > 0 && position >= current.duration - NATIVE_END_EPSILON;
+}
+
+function seekPlayer(current: ActivePlayback, position: number) {
+    if (current.player.readyState === 0) return;
+
+    try {
+        current.player.currentTime = clampPosition(current, position);
+    } catch { }
+}
+
+function playPlayer(current: ActivePlayback) {
+    try {
+        void current.player.play().catch(() => {
+            if (active === current && !current.paused) stopPlayback();
+        });
+    } catch {
+        if (active === current && !current.paused) stopPlayback();
+    }
+}
+
+function syncPlaybackCache(current: ActivePlayback, force = false) {
+    if (!current.cacheKey || current.duration <= 0) return;
+
+    const now = Date.now();
+    if (!force && now - lastCacheSync < 1000) return;
+    lastCacheSync = now;
+    FluxDispatcher.dispatch({
+        type: "MEDIA_PLAYBACK_POSITION_UPDATE",
+        cacheKey: current.cacheKey,
+        position: playbackPosition(current),
+        duration: current.duration
+    });
+}
+
+export function stopPlayback() {
+    const current = active;
+    if (!current) return;
+
+    active = undefined;
+    current.setNativePlaying?.(false);
+    current.setNativePosition?.(0);
+    current.player.onloadedmetadata = null;
+    current.player.ondurationchange = null;
+    current.player.ontimeupdate = null;
+    current.player.onended = null;
+    current.player.onerror = null;
+    current.player.pause();
+
+    if (current.cacheKey) {
+        FluxDispatcher.dispatch({
+            type: "MEDIA_PLAYBACK_POSITION_UPDATE",
+            cacheKey: current.cacheKey,
+            position: 0,
+            duration: Math.max(current.duration, 1)
+        });
+    }
+
+    notifyPlayback();
+}
+
+function createBackgroundPlayback(src: string, cacheKey: string | undefined, position: number) {
+    stopPlayback();
+
+    const player = new Audio();
+    player.preload = "auto";
+    player.muted = true;
+    player.playbackRate = voicePlaybackSpeed;
+
+    const current: ActivePlayback = active = {
+        attached: true,
+        cacheKey,
+        channelId: SelectedChannelStore.getChannelId(),
+        duration: 0,
+        paused: false,
+        player,
+        position: Math.max(0, position),
+        speed: voicePlaybackSpeed,
+        src,
+        updatedAt: Date.now()
+    };
+
+    const updateDuration = () => {
+        if (active !== current || !Number.isFinite(player.duration) || player.duration <= 0) return;
+
+        current.duration = player.duration;
+        updatePosition(current, current.position);
+        seekPlayer(current, current.position);
+        syncPlaybackCache(current, true);
+        if (current.paused && isAtEnd(current, current.position)) {
+            stopPlayback();
+        } else {
+            notifyPlayback();
+        }
+    };
+
+    player.onloadedmetadata = updateDuration;
+    player.ondurationchange = updateDuration;
+    player.ontimeupdate = () => {
+        if (active !== current) return;
+
+        updatePosition(current, player.currentTime);
+        syncPlaybackCache(current);
+    };
+    player.onended = () => {
+        if (active === current) stopPlayback();
+    };
+    player.onerror = () => {
+        if (active === current) stopPlayback();
+    };
+    player.src = src;
+
+    lastCacheSync = 0;
+    notifyPlayback();
+    return current;
+}
+
+function syncPlayerToNative(current: ActivePlayback, position: number, force = false) {
+    const playerPosition = current.player.currentTime;
+    if (force || !Number.isFinite(playerPosition) || Math.abs(playerPosition - position) > 0.25) {
+        seekPlayer(current, position);
+    }
+}
+
+function playFromNative(
+    src: string,
+    cacheKey: string | undefined,
+    position: number,
+    setNativePlaying: Dispatch<SetStateAction<boolean>>,
+    setNativePosition: Dispatch<SetStateAction<number>>
+) {
+    const current = active && samePlayback(active, src, cacheKey)
+        ? active
+        : createBackgroundPlayback(src, cacheKey, position);
+
+    current.attached = true;
+    current.cacheKey = cacheKey;
+    current.paused = false;
+    current.setNativePlaying = setNativePlaying;
+    current.setNativePosition = setNativePosition;
+    updatePosition(current, position);
+    current.player.muted = true;
+    current.player.playbackRate = current.speed;
+    syncPlayerToNative(current, position, true);
+    playPlayer(current);
+    syncPlaybackCache(current, true);
+    notifyPlayback();
+}
+
+function pauseFromNative(src: string, cacheKey: string | undefined, position: number) {
+    const current = active;
+    if (!current || !samePlayback(current, src, cacheKey) || !current.attached) return;
+
+    if (current.player.ended || isAtEnd(current, position)) {
+        stopPlayback();
+        return;
+    }
+
+    updatePosition(current, position);
+    current.paused = true;
+    current.player.pause();
+    seekPlayer(current, current.position);
+    syncPlaybackCache(current, true);
+    notifyPlayback();
+}
+
+export function useBackgroundPlayback(
+    nativeState: NativePlayingState,
+    nativePosition: number,
+    src: string,
+    cacheKey: string | undefined,
+    setNativePosition: Dispatch<SetStateAction<number>>
+) {
+    const [nativePlaying, setNativePlaying] = nativeState;
+    const nativePlayingRef = useRef(nativePlaying);
+    const nativePositionRef = useRef(nativePosition);
+    nativePlayingRef.current = nativePlaying;
+    nativePositionRef.current = nativePosition;
+
+    useEffect(() => {
+        const current = active;
+        if (current && samePlayback(current, src, cacheKey) && !current.attached) {
+            const position = playbackPosition(current);
+            const playing = !current.paused;
+            updatePosition(current, position);
+            current.attached = true;
+            current.setNativePlaying = setNativePlaying;
+            current.setNativePosition = setNativePosition;
+            current.player.muted = true;
+            syncPlayerToNative(current, position, true);
+            playing ? playPlayer(current) : current.player.pause();
+            nativePlayingRef.current = playing;
+            nativePositionRef.current = position;
+            setNativePosition(position);
+            setNativePlaying(playing);
+            syncPlaybackCache(current, true);
+            notifyPlayback();
+        }
+
+        return () => {
+            const current = active;
+            if (!current || !samePlayback(current, src, cacheKey) || current.setNativePlaying !== setNativePlaying) return;
+
+            updatePosition(current, nativePositionRef.current);
+            current.attached = false;
+            current.paused = !nativePlayingRef.current;
+            current.setNativePlaying = undefined;
+            current.setNativePosition = undefined;
+            syncPlayerToNative(current, current.position, true);
+            current.player.muted = false;
+            current.paused ? current.player.pause() : playPlayer(current);
+            syncPlaybackCache(current, true);
+            notifyPlayback();
+        };
+    }, [cacheKey, setNativePlaying, setNativePosition, src]);
+
+    useEffect(() => {
+        nativePlayingRef.current
+            ? playFromNative(src, cacheKey, nativePositionRef.current, setNativePlaying, setNativePosition)
+            : pauseFromNative(src, cacheKey, nativePositionRef.current);
+    }, [cacheKey, nativePlaying, setNativePlaying, setNativePosition, src]);
+
+    useEffect(() => {
+        const current = active;
+        if (!current || !samePlayback(current, src, cacheKey) || current.setNativePosition !== setNativePosition) return;
+
+        updatePosition(current, nativePositionRef.current);
+        syncPlayerToNative(current, nativePositionRef.current);
+        syncPlaybackCache(current);
+    }, [cacheKey, nativePosition, setNativePosition, src]);
+
+    return nativeState;
+}
+
+export function getPlaybackSnapshot(): PlaybackSnapshot | undefined {
+    const current = active;
+    if (!current) return;
+
+    return {
+        channelId: current.channelId,
+        duration: current.duration,
+        paused: current.paused,
+        position: playbackPosition(current),
+        speed: current.speed,
+        src: current.src
+    };
+}
+
+export function togglePlayback() {
+    const current = active;
+    if (!current) return;
+
+    if (current.attached && current.setNativePlaying) {
+        current.setNativePlaying(current.paused);
+        return;
+    }
+
+    updatePosition(current, playbackPosition(current));
+    current.paused = !current.paused;
+    current.paused ? current.player.pause() : playPlayer(current);
+    syncPlaybackCache(current, true);
+    notifyPlayback();
+}
+
+export function seekPlayback(position: number) {
+    const current = active;
+    if (!current) return;
+
+    updatePosition(current, position);
+    seekPlayer(current, current.position);
+    current.setNativePosition?.(current.position);
+    syncPlaybackCache(current, true);
+    notifyPlayback();
+}
+
+export function setPlaybackSpeed(speed: number) {
+    const current = active;
+    if (!current) return;
+
+    updatePosition(current, playbackPosition(current));
+    current.speed = speed;
+    current.player.playbackRate = speed;
+    FluxDispatcher.dispatch({
+        type: "MEDIA_PLAYBACK_RATE_UPDATE",
+        playbackType: "voice_message",
+        rate: speed
+    });
+    notifyPlayback();
+}
+
+export function handlePlaybackRateUpdate(speed: number) {
+    voicePlaybackSpeed = speed;
+    const current = active;
+    if (!current || current.speed === speed) return;
+
+    updatePosition(current, playbackPosition(current));
+    current.speed = speed;
+    current.player.playbackRate = speed;
+    notifyPlayback();
+}

--- a/src/plugins/voiceMessagesInBackground/player.tsx
+++ b/src/plugins/voiceMessagesInBackground/player.tsx
@@ -1,0 +1,161 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Button } from "@components/Button";
+import { Microphone } from "@components/Icons";
+import { classNameFactory } from "@utils/css";
+import { LazyComponent } from "@utils/lazyReact";
+import { formatDuration } from "@utils/text";
+import { ChannelRouter, ChannelStore, SelectedChannelStore, Slider, Tooltip, useEffect, useState, useStateFromStores } from "@webpack/common";
+
+import { getPlaybackSnapshot, seekPlayback, setPlaybackSpeed, stopPlayback, subscribePlayback, togglePlayback } from "./playback";
+
+const cl = classNameFactory("vc-vmib-");
+const SPEEDS = [0.5, 0.75, 1, 1.25, 1.5, 2];
+
+const SeekBar = LazyComponent(() => {
+    const SliderClass = Slider.$$vencordGetWrappedComponent();
+
+    return class SeekBar extends SliderClass {
+        static getDerivedStateFromProps(props: any, state: any) {
+            const newState = super.getDerivedStateFromProps!(props, state);
+            if (newState) newState.value = props.initialValue;
+
+            return newState;
+        }
+    };
+});
+
+function PlayPauseIcon({ paused }: { paused: boolean; }) {
+    return (
+        <svg viewBox="0 0 24 24" width={18} height={18} aria-hidden="true">
+            <path fill="currentColor" d={paused ? "M8 5v14l11-7Z" : "M6 5h4v14H6Zm8 0h4v14h-4Z"} />
+        </svg>
+    );
+}
+
+function CloseIcon() {
+    return (
+        <svg viewBox="0 0 24 24" width={16} height={16} aria-hidden="true">
+            <path fill="currentColor" d="m6.7 5.3 5.3 5.29 5.3-5.3 1.4 1.42-5.29 5.3 5.3 5.29-1.42 1.4-5.3-5.29-5.29 5.3-1.4-1.42 5.29-5.3-5.3-5.29Z" />
+        </svg>
+    );
+}
+
+function time(seconds: number) {
+    return formatDuration(Math.max(0, seconds) * 1000);
+}
+
+export function VoiceMessagesInBackgroundPlayer() {
+    const selectedChannelId = useStateFromStores(
+        [SelectedChannelStore],
+        () => SelectedChannelStore.getChannelId()
+    );
+    const [snapshot, setSnapshot] = useState(getPlaybackSnapshot);
+
+    useEffect(() => subscribePlayback(() => setSnapshot(getPlaybackSnapshot())), []);
+    useEffect(() => {
+        if (!snapshot || snapshot.paused || snapshot.channelId === selectedChannelId) return;
+
+        const update = () => setSnapshot(getPlaybackSnapshot());
+        update();
+        const interval = setInterval(update, 50);
+        return () => clearInterval(interval);
+    }, [selectedChannelId, snapshot?.channelId, snapshot?.paused, snapshot?.src]);
+
+    const channel = useStateFromStores(
+        [ChannelStore],
+        () => snapshot?.channelId ? ChannelStore.getChannel(snapshot.channelId) : undefined,
+        [snapshot?.channelId]
+    );
+
+    if (!snapshot || snapshot.channelId === selectedChannelId) return null;
+
+    const channelName = channel?.name ?? "Direct message";
+    const duration = Math.max(snapshot.duration, snapshot.position, 1);
+    const position = Math.min(snapshot.position, duration);
+    const nextSpeed = SPEEDS[(SPEEDS.findIndex(speed => speed === snapshot.speed) + 1) % SPEEDS.length];
+
+    return (
+        <div className={cl("player", { playing: !snapshot.paused })} aria-label="Voice Messages In-Background player">
+            <div className={cl("voice-icon")}>
+                <Microphone width={17} height={17} />
+            </div>
+            <Tooltip text={snapshot.paused ? "Resume voice message" : "Pause voice message"}>
+                {tooltipProps => (
+                    <Button
+                        {...tooltipProps}
+                        aria-label={snapshot.paused ? "Resume voice message" : "Pause voice message"}
+                        className={cl("control")}
+                        size="iconOnly"
+                        variant="none"
+                        onClick={togglePlayback}
+                    >
+                        <PlayPauseIcon paused={snapshot.paused} />
+                    </Button>
+                )}
+            </Tooltip>
+            <Button
+                aria-label={`Return to ${channelName}`}
+                className={cl("origin")}
+                disabled={!snapshot.channelId}
+                size="min"
+                variant="none"
+                onClick={() => snapshot.channelId && ChannelRouter.transitionToChannel(snapshot.channelId)}
+            >
+                <span className={cl("origin-copy")}>
+                    <span className={cl("title")}>Voice message</span>
+                    <span className={cl("channel")}>{channelName}</span>
+                </span>
+            </Button>
+            <div className={cl("timeline")}>
+                <span className={cl("time")}>{time(position)}</span>
+                <SeekBar
+                    aria-label="Voice message position"
+                    asValueChanges={seekPlayback}
+                    className={cl("seek")}
+                    handleSize={10}
+                    hideBubble
+                    initialValue={position}
+                    maxValue={duration}
+                    minValue={0}
+                    mini
+                    onValueChange={seekPlayback}
+                    onValueRender={time}
+                />
+                <span className={cl("time")}>{time(snapshot.duration)}</span>
+            </div>
+            <Tooltip text="Change playback speed">
+                {tooltipProps => (
+                    <Button
+                        {...tooltipProps}
+                        aria-label={`Playback speed ${snapshot.speed} times`}
+                        className={cl("speed")}
+                        size="min"
+                        variant="none"
+                        onClick={() => setPlaybackSpeed(nextSpeed)}
+                    >
+                        {snapshot.speed}×
+                    </Button>
+                )}
+            </Tooltip>
+            <Tooltip text="Close voice message player">
+                {tooltipProps => (
+                    <Button
+                        {...tooltipProps}
+                        aria-label="Close voice message player"
+                        className={cl("control", "close")}
+                        size="iconOnly"
+                        variant="none"
+                        onClick={stopPlayback}
+                    >
+                        <CloseIcon />
+                    </Button>
+                )}
+            </Tooltip>
+        </div>
+    );
+}

--- a/src/plugins/voiceMessagesInBackground/style.css
+++ b/src/plugins/voiceMessagesInBackground/style.css
@@ -1,0 +1,180 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+.vc-vmib-player {
+    position: relative;
+    display: flex;
+    flex: 0 1 560px;
+    align-items: center;
+    gap: 4px;
+    min-width: 330px;
+    max-width: min(560px, 48vw);
+    height: 36px;
+    margin: 0 6px;
+    padding: 0 5px;
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md, 10px);
+    background: var(--background-surface-high);
+    box-shadow: var(--shadow-low);
+    color: var(--text-default);
+    animation: vc-vmib-enter 180ms ease-out;
+}
+
+.vc-vmib-player::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background: var(--brand-500);
+}
+
+.vc-vmib-voice-icon {
+    position: relative;
+    display: grid;
+    flex: 0 0 28px;
+    width: 28px;
+    height: 28px;
+    margin-left: 2px;
+    place-items: center;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--brand-500) 18%, transparent);
+    color: var(--brand-500);
+}
+
+.vc-vmib-player-playing .vc-vmib-voice-icon::after {
+    content: "";
+    position: absolute;
+    inset: -2px;
+    border: 2px solid color-mix(in srgb, var(--brand-500) 45%, transparent);
+    border-radius: 50%;
+    animation: vc-vmib-pulse 1.4s ease-out infinite;
+}
+
+.vc-vmib-control {
+    flex: 0 0 28px;
+    width: 28px;
+    height: 28px;
+}
+
+.vc-vmib-origin {
+    flex: 0 1 112px;
+    justify-content: flex-start;
+    min-width: 76px;
+    padding: 2px 5px;
+}
+
+.vc-vmib-origin-copy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.15;
+}
+
+.vc-vmib-title,
+.vc-vmib-channel {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.vc-vmib-title {
+    color: var(--text-default);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.vc-vmib-channel {
+    color: var(--text-muted);
+    font-size: 10px;
+}
+
+.vc-vmib-timeline {
+    display: flex;
+    flex: 1 1 220px;
+    align-items: center;
+    gap: 7px;
+    min-width: 120px;
+}
+
+.vc-vmib-seek {
+    flex: 1 1 auto;
+    min-width: 80px;
+}
+
+.vc-vmib-time {
+    min-width: 34px;
+    color: var(--text-muted);
+    font-family: var(--font-code);
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+}
+
+.vc-vmib-speed {
+    flex: 0 0 auto;
+    min-width: 34px;
+    color: var(--brand-500);
+    font-weight: 700;
+}
+
+.vc-vmib-close {
+    color: var(--interactive-normal);
+}
+
+@keyframes vc-vmib-enter {
+    from {
+        opacity: 0;
+        transform: translateY(-4px) scale(.98);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes vc-vmib-pulse {
+    from {
+        opacity: .65;
+        transform: scale(.85);
+    }
+
+    to {
+        opacity: 0;
+        transform: scale(1.25);
+    }
+}
+
+@media (width <= 1050px) {
+    .vc-vmib-player {
+        max-width: 410px;
+    }
+
+    .vc-vmib-origin {
+        display: none;
+    }
+}
+
+@media (width <= 760px) {
+    .vc-vmib-player {
+        min-width: 235px;
+        max-width: 300px;
+    }
+
+    .vc-vmib-time:last-child,
+    .vc-vmib-voice-icon {
+        display: none;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .vc-vmib-player,
+    .vc-vmib-player-playing .vc-vmib-voice-icon::after {
+        animation: none;
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -669,6 +669,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     Davri: {
         name: "Davri",
         id: 457579346282938368n
+    },
+    ELJoOker: {
+        name: "ELJoOker",
+        id: 605894319408283678n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
## Describe your Changes

Adds `VoiceMessagesInBackground`, which keeps voice messages playing while navigating between chats and exposes a synchronized mini player in the channel toolbar.

The mini player supports live progress, seeking, play/pause, playback speed, closing playback, and returning to the source channel. Returning to the original chat restores Discord's voice-message UI at the current position. The UI is injected through React patches and does not query or mutate Discord's DOM tree.

Validated with:

- `pnpm test`
- `pnpm testWeb`

## Screenshots (if applicable)

<img width="867" height="230" alt="Voice Messages In-Background mini player" src="https://github.com/user-attachments/assets/cc2c7ade-ed0c-4be1-97df-f55cbedb5278" />

## Checklist before submitting

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent