### PR TITLE
feat: add FlexibleDMs plugin

### DIFF
--- a/src/plugins/flexibleDMs/animation.ts
+++ b/src/plugins/flexibleDMs/animation.ts
@@ -1,0 +1,20 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+const opening = new Set<string>();
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** Mark an explicitly opened folder so only its newly mounted children animate. */
+export function markFolderOpening(id: string) {
+    opening.add(id);
+    clearTimeout(timers.get(id));
+    timers.set(id, setTimeout(() => {
+        opening.delete(id);
+        timers.delete(id);
+    }, 200));
+}
+
+export const isFolderOpening = (id: string | undefined) => !!id && opening.has(id);

--- a/src/plugins/flexibleDMs/components.tsx
+++ b/src/plugins/flexibleDMs/components.tsx
@@ -10,8 +10,9 @@ import { classes } from "@utils/misc";
 import { RenderModalProps } from "@vencord/discord-types";
 import { ChannelStore, ContextMenuApi, FluxDispatcher, IconUtils, Menu, Modal, openModal, React, ReadStateStore, SelectedChannelStore, TextInput, UserStore, useState, useStateFromStores } from "@webpack/common";
 
-import { Folder, Placement, Row } from "./model";
-import { accountId, closeAll, dissolveFolder, drop, editFolder, PrivateChannelSortStore } from "./state";
+import { isFolderOpening, markFolderOpening } from "./animation";
+import { DEFAULT_FOLDER_COLOR, Folder, Placement, Row } from "./model";
+import { accountId, closeAll, dissolveFolder, drop, editFolder, getNativePinnedIds, PrivateChannelSortStore } from "./state";
 
 const DRAG_TYPE = "application/x-vencord-dm-folder";
 let dragging: { id: string; userId: string | undefined; folder: boolean; } | undefined;
@@ -20,7 +21,7 @@ export function clearDrag() {
     dragging = undefined;
 }
 
-const DEFAULT_COLOR = 0x5865f2;
+const DEFAULT_COLOR = parseInt(DEFAULT_FOLDER_COLOR.slice(1), 16);
 const SWATCHES = [
     1752220, 3066993, 3447003, 10181046, 15277667, 15844367, 15105570, 15158332, 9807270, 6323595,
     1146986, 2067276, 2123412, 7419530, 11342935, 12745742, 11027200, 10038562, 9936031, 5533306
@@ -39,7 +40,7 @@ function FolderColorPicker({ color, onChange }: { color: number; onChange(color:
                 <button
                     type="button"
                     className="vc-dmf-color-large"
-                    style={{ backgroundColor: "#5865f2" }}
+                    style={{ backgroundColor: DEFAULT_FOLDER_COLOR }}
                     aria-label="Default color"
                     aria-pressed={color === DEFAULT_COLOR}
                     onClick={() => onChange(DEFAULT_COLOR)}
@@ -139,7 +140,9 @@ function avatar(id: string) {
 }
 
 export function FolderRow({ folder }: { folder: Folder; }) {
-    const active = new Set(PrivateChannelSortStore.getPrivateChannelIds());
+    const userId = useStateFromStores([UserStore], accountId);
+    const activeIds = useStateFromStores([PrivateChannelSortStore], () => PrivateChannelSortStore.getPrivateChannelIds());
+    const active = new Set(activeIds);
     const ids = folder.channels.filter(id => active.has(id));
     const unread = useStateFromStores([ReadStateStore], () => ids.some(id => ReadStateStore.hasUnread(id)));
     const mentions = useStateFromStores([ReadStateStore], () => ids.reduce((sum, id) => sum + ReadStateStore.getMentionCount(id), 0));
@@ -152,11 +155,16 @@ export function FolderRow({ folder }: { folder: Folder; }) {
             aria-expanded={folder.expanded}
             aria-label={`${folder.name}, ${ids.length} chats${unread ? ", unread" : ""}${mentions ? `, ${mentions} mentions` : ""}`}
             title={folder.name}
-            onClick={() => editFolder(folder.id, { expanded: !folder.expanded })}
+            onClick={() => {
+                if (!folder.expanded) markFolderOpening(folder.id);
+                editFolder(folder.id, { expanded: !folder.expanded }, userId);
+            }}
             onKeyDown={e => {
                 if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
                     e.preventDefault();
-                    editFolder(folder.id, { expanded: e.key === "ArrowRight" });
+                    const expanded = e.key === "ArrowRight";
+                    if (expanded && !folder.expanded) markFolderOpening(folder.id);
+                    editFolder(folder.id, { expanded }, userId);
                 }
             }}
             onContextMenu={e => folderMenu(e, folder)}
@@ -194,21 +202,21 @@ export function DragRow({ row, height, children }: React.PropsWithChildren<{ row
         if (dragging.folder && placement === "inside") return ratio < 0.5 ? "before" : "after";
         return placement;
     };
+    const nativePinned = getNativePinnedIds().includes(row.id);
     return (
         <div
-            className={classes("vc-dmf-row", row.parent && "vc-dmf-child", row.folder?.expanded && "vc-dmf-expanded")}
+            className={classes("vc-dmf-row", row.parent && "vc-dmf-child", isFolderOpening(row.parent?.id) && "vc-dmf-opening", row.folder?.expanded && "vc-dmf-expanded")}
             style={{ height, "--vc-dmf-color": (row.parent ?? row.folder)?.color } as React.CSSProperties}
             data-dmf-drop={over ?? undefined}
-            draggable
+            draggable={!nativePinned}
             onDragStartCapture={e => {
-                if ((e.target as HTMLElement).closest("button[aria-label*=Close],input")) {
+                if ((e.target as HTMLElement).closest("[class*=closeButton],input")) {
                     e.preventDefault();
                     return;
                 }
                 dragging = { id: row.id, userId: accountId(), folder: !!row.folder };
                 e.dataTransfer.effectAllowed = "move";
                 e.dataTransfer.setData(DRAG_TYPE, row.id);
-                e.dataTransfer.setData("text/plain", row.folder?.name ?? row.id);
                 e.dataTransfer.setDragImage(e.currentTarget, 24, height / 2);
                 // Override native link/image dragging inside Discord's channel row.
                 e.stopPropagation();

--- a/src/plugins/flexibleDMs/components.tsx
+++ b/src/plugins/flexibleDMs/components.tsx
@@ -1,0 +1,242 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import { FolderIcon } from "@components/Icons";
+import { classes } from "@utils/misc";
+import { RenderModalProps } from "@vencord/discord-types";
+import { ChannelStore, ContextMenuApi, FluxDispatcher, IconUtils, Menu, Modal, openModal, React, ReadStateStore, SelectedChannelStore, TextInput, UserStore, useState, useStateFromStores } from "@webpack/common";
+
+import { Folder, Placement, Row } from "./model";
+import { accountId, closeAll, dissolveFolder, drop, editFolder, PrivateChannelSortStore } from "./state";
+
+const DRAG_TYPE = "application/x-vencord-dm-folder";
+let dragging: { id: string; userId: string | undefined; folder: boolean; } | undefined;
+
+export function clearDrag() {
+    dragging = undefined;
+}
+
+const DEFAULT_COLOR = 0x5865f2;
+const SWATCHES = [
+    1752220, 3066993, 3447003, 10181046, 15277667, 15844367, 15105570, 15158332, 9807270, 6323595,
+    1146986, 2067276, 2123412, 7419530, 11342935, 12745742, 11027200, 10038562, 9936031, 5533306
+];
+
+function FolderColorPicker({ color, onChange }: { color: number; onChange(color: number): void; }) {
+    const hex = `#${color.toString(16).padStart(6, "0")}`;
+    const check = (
+        <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="m5 12 4 4L19 6" fill="none" stroke="currentColor" strokeWidth="3" />
+        </svg>
+    );
+    return (
+        <div className="vc-dmf-colors" role="group" aria-label="Folder Color">
+            <div className="vc-dmf-color-buttons">
+                <button
+                    type="button"
+                    className="vc-dmf-color-large"
+                    style={{ backgroundColor: "#5865f2" }}
+                    aria-label="Default color"
+                    aria-pressed={color === DEFAULT_COLOR}
+                    onClick={() => onChange(DEFAULT_COLOR)}
+                >
+                    {color === DEFAULT_COLOR && check}
+                </button>
+                <label className="vc-dmf-color-large vc-dmf-custom-color" style={{ backgroundColor: hex }} title="Custom color">
+                    <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="m4 16 12-12 4 4L8 20H4Zm10-10 4 4" fill="none" stroke="currentColor" strokeWidth="2" />
+                    </svg>
+                    <input type="color" value={hex} onChange={e => onChange(parseInt(e.target.value.slice(1), 16))} aria-label="Custom folder color" />
+                </label>
+            </div>
+            <div className="vc-dmf-swatches">
+                {SWATCHES.map(value => (
+                    <button
+                        key={value}
+                        type="button"
+                        className="vc-dmf-swatch"
+                        style={{ backgroundColor: `#${value.toString(16).padStart(6, "0")}` }}
+                        aria-label={`Color #${value.toString(16).padStart(6, "0")}`}
+                        aria-pressed={color === value}
+                        onClick={() => onChange(value)}
+                    >
+                        {color === value && check}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function FolderSettings({ folder, modalProps, userId }: { folder: Folder; modalProps: RenderModalProps; userId: string | undefined; }) {
+    const [name, setName] = useState(folder.name);
+    const [color, setColor] = useState(parseInt(folder.color.slice(1), 16));
+    const save = () => {
+        if (!name.trim()) return;
+        editFolder(folder.id, { name: name.trim(), color: `#${color.toString(16).padStart(6, "0")}` }, userId);
+        modalProps.onClose();
+    };
+    return (
+        <Modal
+            {...modalProps}
+            title="Folder Settings"
+            actions={[
+                { text: "Done", variant: "primary", disabled: !name.trim(), onClick: save }
+            ]}
+        >
+            <form className="vc-dmf-settings" onSubmit={e => { e.preventDefault(); save(); }}>
+                <label htmlFor="vc-dmf-name">Folder Name</label>
+                <TextInput id="vc-dmf-name" value={name} onChange={setName} maxLength={100} autoFocus />
+                <span>Folder Color</span>
+                <FolderColorPicker color={color} onChange={setColor} />
+            </form>
+        </Modal>
+    );
+}
+
+export function openFolderSettings(folder: Folder) {
+    const userId = accountId();
+    openModal(modalProps => (
+        <ErrorBoundary message="FlexibleDMs could not open Folder Settings">
+            <FolderSettings folder={folder} modalProps={modalProps} userId={userId} />
+        </ErrorBoundary>
+    ));
+}
+
+function markFolderRead(folder: Folder) {
+    const active = new Set(PrivateChannelSortStore.getPrivateChannelIds());
+    const channels = folder.channels.filter(id => active.has(id) && ReadStateStore.hasUnread(id)).map(channelId => ({
+        channelId,
+        messageId: ReadStateStore.lastMessageId(channelId),
+        readStateType: 0
+    })).filter(c => c.messageId);
+    if (channels.length) FluxDispatcher.dispatch({ type: "BULK_ACK", context: "APP", channels });
+}
+
+function folderMenu(event: React.MouseEvent, folder: Folder) {
+    ContextMenuApi.openContextMenu(event, () => (
+        <Menu.Menu navId="vc-dmf-folder" aria-label="DM Folder" onClose={ContextMenuApi.closeContextMenu}>
+            <Menu.MenuItem id="vc-dmf-read" label="Mark Folder As Read" action={() => markFolderRead(folder)} />
+            <Menu.MenuSeparator />
+            <Menu.MenuItem id="vc-dmf-settings" label="Folder Settings" action={() => openFolderSettings(folder)} />
+            <Menu.MenuItem id="vc-dmf-close-all" label="Close All Folders" action={closeAll} />
+            <Menu.MenuSeparator />
+            <Menu.MenuItem id="vc-dmf-dissolve" label="Ungroup Folder" action={() => dissolveFolder(folder.id)} />
+        </Menu.Menu>
+    ));
+}
+
+function avatar(id: string) {
+    const channel = ChannelStore.getChannel(id);
+    if (!channel) return;
+    const recipient = channel.getRecipientId();
+    if (channel.isDM()) return recipient ? UserStore.getUser(recipient)?.getAvatarURL(undefined, 32, false) : undefined;
+    return IconUtils.getChannelIconURL({ id, icon: channel.icon, size: 32 });
+}
+
+export function FolderRow({ folder }: { folder: Folder; }) {
+    const active = new Set(PrivateChannelSortStore.getPrivateChannelIds());
+    const ids = folder.channels.filter(id => active.has(id));
+    const unread = useStateFromStores([ReadStateStore], () => ids.some(id => ReadStateStore.hasUnread(id)));
+    const mentions = useStateFromStores([ReadStateStore], () => ids.reduce((sum, id) => sum + ReadStateStore.getMentionCount(id), 0));
+    const selected = useStateFromStores([SelectedChannelStore], () => ids.includes(SelectedChannelStore.getChannelId()));
+    useStateFromStores([UserStore, ChannelStore], () => ids.map(id => avatar(id)).join("|"));
+    return (
+        <button
+            type="button"
+            className={classes("vc-dmf-folder", unread && "vc-dmf-unread", selected && "vc-dmf-selected")}
+            aria-expanded={folder.expanded}
+            aria-label={`${folder.name}, ${ids.length} chats${unread ? ", unread" : ""}${mentions ? `, ${mentions} mentions` : ""}`}
+            title={folder.name}
+            onClick={() => editFolder(folder.id, { expanded: !folder.expanded })}
+            onKeyDown={e => {
+                if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+                    e.preventDefault();
+                    editFolder(folder.id, { expanded: e.key === "ArrowRight" });
+                }
+            }}
+            onContextMenu={e => folderMenu(e, folder)}
+        >
+            <span className="vc-dmf-icon" style={{ "--vc-dmf-color": folder.color } as React.CSSProperties} aria-hidden="true">
+                {folder.expanded ? <FolderIcon width={20} height={20} /> : (
+                    <span className="vc-dmf-mosaic">
+                        {ids.slice(0, 4).map(id => {
+                            const src = avatar(id);
+                            return src ? <img key={id} src={src} alt="" draggable={false} /> : <span key={id} className="vc-dmf-avatar-fallback">#</span>;
+                        })}
+                    </span>
+                )}
+            </span>
+            <span className="vc-dmf-nameplate">
+                <span className="vc-dmf-name">{folder.name}</span>
+                <span className="vc-dmf-description">{ids.length} {ids.length === 1 ? "chat" : "chats"}</span>
+            </span>
+            {mentions > 0 && <span className="vc-dmf-badge" aria-hidden="true">{mentions > 99 ? "99+" : mentions}</span>}
+            <svg className={classes("vc-dmf-chevron", folder.expanded && "vc-dmf-chevron-open")} width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="m9 5 7 7-7 7" fill="none" stroke="currentColor" strokeWidth="2" />
+            </svg>
+        </button>
+    );
+}
+
+export function DragRow({ row, height, children }: React.PropsWithChildren<{ row: Row; height: number; }>) {
+    const [over, setOver] = useState<Placement | null>(null);
+    const getPlacement = (event: React.DragEvent<HTMLDivElement>): Placement | null => {
+        if (!dragging || dragging.id === row.id || dragging.userId !== accountId() || !event.dataTransfer.types.includes(DRAG_TYPE)) return null;
+        if (dragging.folder && row.parent) return null;
+        const rect = event.currentTarget.getBoundingClientRect();
+        const ratio = (event.clientY - rect.top) / rect.height;
+        const placement = ratio < 0.25 ? "before" : ratio > 0.75 ? "after" : "inside";
+        if (dragging.folder && placement === "inside") return ratio < 0.5 ? "before" : "after";
+        return placement;
+    };
+    return (
+        <div
+            className={classes("vc-dmf-row", row.parent && "vc-dmf-child", row.folder?.expanded && "vc-dmf-expanded")}
+            style={{ height, "--vc-dmf-color": (row.parent ?? row.folder)?.color } as React.CSSProperties}
+            data-dmf-drop={over ?? undefined}
+            draggable
+            onDragStartCapture={e => {
+                if ((e.target as HTMLElement).closest("button[aria-label*=Close],input")) {
+                    e.preventDefault();
+                    return;
+                }
+                dragging = { id: row.id, userId: accountId(), folder: !!row.folder };
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData(DRAG_TYPE, row.id);
+                e.dataTransfer.setData("text/plain", row.folder?.name ?? row.id);
+                e.dataTransfer.setDragImage(e.currentTarget, 24, height / 2);
+                // Override native link/image dragging inside Discord's channel row.
+                e.stopPropagation();
+            }}
+            onDragEnd={() => { clearDrag(); setOver(null); }}
+            onDragOver={e => {
+                const placement = getPlacement(e);
+                setOver(placement);
+                if (!placement) return;
+                e.preventDefault();
+                e.stopPropagation();
+                e.dataTransfer.dropEffect = "move";
+            }}
+            onDragLeave={e => {
+                if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOver(null);
+            }}
+            onDrop={e => {
+                const placement = getPlacement(e);
+                const source = dragging;
+                clearDrag();
+                setOver(null);
+                if (!placement || !source) return;
+                e.preventDefault();
+                e.stopPropagation();
+                drop(source.id, row.id, placement);
+            }}
+        >
+            {children}
+        </div>
+    );
+}

--- a/src/plugins/flexibleDMs/index.tsx
+++ b/src/plugins/flexibleDMs/index.tsx
@@ -14,11 +14,12 @@ import definePlugin from "@utils/types";
 import { Channel } from "@vencord/discord-types";
 import { Menu, React, ReadStateStore, SelectedChannelStore, useEffect, useMemo, useRef, UserStore, useStateFromStores } from "@webpack/common";
 
+import { markFolderOpening } from "./animation";
 import { clearDrag, DragRow, FolderRow } from "./components";
 import { getRows, Row, withoutPinnedChannels } from "./model";
-import { getDMSection, getPinDmsVersion, getPinnedIds, isDMSectionCollapsed, isPinned } from "./pinDms";
+import { getDMSection, getPinDmsState, getPinnedIds, isDMSectionCollapsed, isPinned } from "./pinDms";
 import { settings } from "./settings";
-import { currentRows, drop, editFolder, getLayout, getMessages, removeFromFolder, start, stop, syncPinnedChats } from "./state";
+import { drop, editFolder, getLayout, getMessages, getNativePinnedIds, PrivateChannelSortStore, removeFromFolder, start, stop, syncPinnedChats } from "./state";
 
 migratePluginSettings("FlexibleDMs", "DMFolders");
 
@@ -30,8 +31,12 @@ interface DMList {
         vcDmfVersion?: string;
         vcDmfSection?: number;
     };
+    renderRow(args: { section: number; row: number; }): React.ReactNode;
+    getRowHeight(section: number, row: number): number;
     renderDM(section: number, row: number): React.ReactNode;
 }
+
+const renderers = new WeakMap<DMList, { version: string | undefined; density: string | undefined; render: DMList["renderRow"]; }>();
 
 const contextMenu: NavContextMenuPatchCallback = (children, { channel }: { channel?: Channel; }) => {
     if (!channel || ![1, 3].includes(channel.type) || isPinned(channel.id)) return;
@@ -80,7 +85,7 @@ export default definePlugin({
                 {
                     // The scroller caches rows separately from the outer DM list.
                     match: /renderRow:this\.renderRow,/,
-                    replace: "renderRow:(...args)=>this.renderRow(...args),vcDmfVersion:this.props.vcDmfVersion,"
+                    replace: "vcDmfVersion:this.props.vcDmfVersion,renderRow:$self.cachedRenderRow(this),"
                 },
                 {
                     match: /(reportAnalytics=.{0,300}?let\{privateChannelIds:)(\i)(,channels:\i\}=this.props;)/,
@@ -96,14 +101,15 @@ export default definePlugin({
             // Keep Alt+Up/Down consistent with manually ordered chat rows.
             find: ".APPLICATION_STORE&&",
             replacement: {
-                match: /\[\.\.\.\i\(\),\.\.\..+?\](?=,)/,
+                // PinDMs may expand the second spread; its plugin lookup brackets are not followed by a comma.
+                match: /(?<=\i=__OVERLAY__\?\i:)\[\.\.\.\i\(\),\.\.\..+?\](?=,)/,
                 replace: "$self.navigationIds($&)"
             }
         },
         {
             find: "=()=>!1,ensureChatIsVisible:",
             replacement: {
-                match: /\i\.\i\.getPrivateChannelIds\(\)/,
+                match: /(?<=\i===\i\.ME\?(?:Vencord\.Plugins\.plugins(?:\.PinDMs|\["PinDMs"\])\.getAllUncollapsedChannels\(\)\.concat\()?)\i\.\i\.getPrivateChannelIds\(\)/,
                 replace: "$self.navigationIds($&)"
             }
         }
@@ -135,9 +141,13 @@ export default definePlugin({
         const previousNavigation = useRef<string | undefined>(undefined);
         const reveal = previousNavigation.current !== navigation;
         const pinned = getPinnedIds();
-        const pinsKey = JSON.stringify([...pinned]);
-        const layout = withoutPinnedChannels(accounts[userId ?? ""] ?? getLayout(), pinned);
+        const nativePinned = getNativePinnedIds().filter(id => ids.includes(id) && !pinned.has(id));
+        const allPinned = new Set([...pinned, ...nativePinned]);
+        const pinsKey = JSON.stringify([...allPinned]);
+        const layout = withoutPinnedChannels(accounts[userId ?? ""] ?? getLayout(), allPinned);
         useEffect(syncPinnedChats, [userId, pinsKey]);
+        const selectedParent = layout.folders.find(f => f.channels.includes(selectedId));
+        if (reveal && selectedParent && !selectedParent.expanded) markFolderOpening(selectedParent.id);
         // Reveal in the same render as navigation before native scrolling runs.
         const visibleLayout = reveal ? {
             ...layout,
@@ -146,14 +156,26 @@ export default definePlugin({
         useEffect(() => {
             previousNavigation.current = navigation;
             const parent = getLayout().folders.find(f => f.channels.includes(selectedId));
-            if (parent && !parent.expanded) editFolder(parent.id, { expanded: true });
+            if (parent && !parent.expanded) {
+                editFolder(parent.id, { expanded: true });
+            }
         }, [navigation]);
         // Include metadata, not just IDs: rename and color edits must invalidate cached rows.
-        const version = JSON.stringify([visibleLayout, keepFoldersOnTop, userId, messagesKey, ids, getPinDmsVersion()]);
+        const version = JSON.stringify([visibleLayout, keepFoldersOnTop, userId, selectedId, messagesKey, ids, getPinDmsState()]);
         return useMemo(() => {
-            const rows = getRows(visibleLayout, ids.filter(id => !pinned.has(id)), getMessages(ids), keepFoldersOnTop);
-            return { privateChannelIds: rows.map(r => r.id), vcDmfRows: rows, vcDmfVersion: version, vcDmfSection: getDMSection() };
+            const rows = getRows(visibleLayout, ids.filter(id => !allPinned.has(id)), getMessages(ids), keepFoldersOnTop);
+            const allRows = [...nativePinned.map(id => ({ id })), ...rows];
+            return { privateChannelIds: allRows.map(r => r.id), vcDmfRows: allRows, vcDmfVersion: version, vcDmfSection: getDMSection() };
         }, [version]);
+    },
+
+    cachedRenderRow(instance: DMList) {
+        let cached = renderers.get(instance);
+        if (!cached || cached.version !== instance.props.vcDmfVersion || cached.density !== instance.props.density) {
+            cached = { version: instance.props.vcDmfVersion, density: instance.props.density, render: args => instance.renderRow(args) };
+            renderers.set(instance, cached);
+        }
+        return cached.render;
     },
 
     renderRow(instance: DMList, { section, row }: { section: number; row: number; }) {
@@ -165,7 +187,7 @@ export default definePlugin({
         const data = instance.props.vcDmfRows?.[row];
         if (!data || data.id !== id) return;
         const { folder } = data;
-        const height = instance.props.density === "compact" ? 40 : instance.props.density === "default" || !instance.props.density ? 44 : 50;
+        const height = instance.getRowHeight(section, row);
         return (
             <ErrorBoundary key={id} message="FlexibleDMs could not render this row">
                 <DragRow row={data} height={height}>
@@ -182,10 +204,18 @@ export default definePlugin({
     },
 
     navigationIds(original: string[]) {
-        const allowed = new Set(original);
-        const pinned = getPinnedIds();
-        // Static destinations and PinDMs categories already have their own order.
-        const prefix = original.filter(id => pinned.has(id) || id.startsWith("/"));
-        return [...prefix, ...currentRows().filter(r => !r.folder && allowed.has(r.id)).map(r => r.id)];
+        // Reorder only known chat slots. Preserve static, guild and unknown IDs in place.
+        // Include collapsed children: navigating to one reveals its folder in useRows.
+        const layout = getLayout();
+        const pinned = new Set([...getPinnedIds(), ...getNativePinnedIds()]);
+        const rows = getRows({ ...layout, folders: layout.folders.map(f => ({ ...f, expanded: true })) },
+            PrivateChannelSortStore.getPrivateChannelIds().filter(id => !pinned.has(id)),
+            getMessages(original), settings.store.keepFoldersOnTop);
+        const counts = new Map<string, number>();
+        for (const id of original) counts.set(id, (counts.get(id) ?? 0) + 1);
+        const ordered = rows.filter(r => !r.folder && counts.has(r.id)).flatMap(r => Array<string>(counts.get(r.id)!).fill(r.id));
+        const known = new Set(ordered);
+        let index = 0;
+        return original.map(id => known.has(id) ? ordered[index++] : id);
     }
 });

--- a/src/plugins/flexibleDMs/index.tsx
+++ b/src/plugins/flexibleDMs/index.tsx
@@ -1,0 +1,191 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { migratePluginSettings, useSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { Channel } from "@vencord/discord-types";
+import { Menu, React, ReadStateStore, SelectedChannelStore, useEffect, useMemo, useRef, UserStore, useStateFromStores } from "@webpack/common";
+
+import { clearDrag, DragRow, FolderRow } from "./components";
+import { getRows, Row, withoutPinnedChannels } from "./model";
+import { getDMSection, getPinDmsVersion, getPinnedIds, isDMSectionCollapsed, isPinned } from "./pinDms";
+import { settings } from "./settings";
+import { currentRows, drop, editFolder, getLayout, getMessages, removeFromFolder, start, stop, syncPinnedChats } from "./state";
+
+migratePluginSettings("FlexibleDMs", "DMFolders");
+
+interface DMList {
+    props: {
+        privateChannelIds: string[];
+        density?: string;
+        vcDmfRows?: Row[];
+        vcDmfVersion?: string;
+        vcDmfSection?: number;
+    };
+    renderDM(section: number, row: number): React.ReactNode;
+}
+
+const contextMenu: NavContextMenuPatchCallback = (children, { channel }: { channel?: Channel; }) => {
+    if (!channel || ![1, 3].includes(channel.type) || isPinned(channel.id)) return;
+    const group = findGroupChildrenByChildId(["close-dm", "leave-channel"], children);
+    if (!group) return;
+    const layout = getLayout();
+    if (!layout.folders.length) return;
+    const parent = layout.folders.find(f => f.channels.includes(channel.id));
+    group.push(
+        <Menu.MenuItem key="vc-dmf-move" id="vc-dmf-move" label="FlexibleDMs">
+            {parent && <Menu.MenuItem id="vc-dmf-remove" label="Remove from Folder" action={() => removeFromFolder(channel.id)} />}
+            {layout.folders.filter(f => f.id !== parent?.id).map(folder => (
+                <Menu.MenuItem
+                    key={folder.id}
+                    id={`vc-dmf-${folder.id}`}
+                    label={`Move to ${folder.name}`}
+                    action={() => drop(channel.id, folder.id, "inside")}
+                />
+            ))}
+        </Menu.MenuItem>
+    );
+};
+
+export default definePlugin({
+    name: "FlexibleDMs",
+    description: "Rearrange DMs and group chats and organize them into collapsible folders.",
+    authors: [Devs.frisk],
+    tags: ["Friends", "Organisation"],
+    searchTerms: ["folders", "reorder", "dm"],
+    settings,
+    patches: [
+        {
+            // Folder IDs belong to this list, not ChannelStore.
+            find: '"dm-quick-launcher"===',
+            group: true,
+            replacement: [
+                {
+                    // Leave the original prop in place so PinDMs can still patch its filter.
+                    match: /(?<=channels:\i,)privateChannelIds:(\i)[^,]*,listRef:\i,/,
+                    replace: "$&...$self.useRows($1),"
+                },
+                {
+                    match: /renderRow(?:",|=)(\i)=>{/,
+                    replace: "$&const vcDmfRow=$self.renderRow(this,$1);if(vcDmfRow!==undefined)return vcDmfRow;"
+                },
+                {
+                    // The scroller caches rows separately from the outer DM list.
+                    match: /renderRow:this\.renderRow,/,
+                    replace: "renderRow:(...args)=>this.renderRow(...args),vcDmfVersion:this.props.vcDmfVersion,"
+                },
+                {
+                    match: /(reportAnalytics=.{0,300}?let\{privateChannelIds:)(\i)(,channels:\i\}=this.props;)/,
+                    replace: "$1$2$3$2=$2.filter(id=>!id.startsWith('dm-folder:'));"
+                },
+                {
+                    match: /scrollToChannel\((\i)\){/,
+                    replace: "$&$1=$self.scrollTarget($1,this.props.vcDmfRows);"
+                }
+            ]
+        },
+        {
+            // Keep Alt+Up/Down consistent with manually ordered chat rows.
+            find: ".APPLICATION_STORE&&",
+            replacement: {
+                match: /\[\.\.\.\i\(\),\.\.\..+?\](?=,)/,
+                replace: "$self.navigationIds($&)"
+            }
+        },
+        {
+            find: "=()=>!1,ensureChatIsVisible:",
+            replacement: {
+                match: /\i\.\i\.getPrivateChannelIds\(\)/,
+                replace: "$self.navigationIds($&)"
+            }
+        }
+    ],
+    contextMenus: {
+        "user-context": contextMenu,
+        "gdm-context": contextMenu
+    },
+    start,
+    stop() {
+        stop();
+        clearDrag();
+    },
+    flux: {
+        LOGOUT: clearDrag,
+        CONNECTION_OPEN() {
+            clearDrag();
+            syncPinnedChats();
+        }
+    },
+
+    useRows(ids: string[]) {
+        useSettings(["plugins.PinDMs.*"]);
+        const { accounts, keepFoldersOnTop } = settings.use(["accounts", "keepFoldersOnTop"]);
+        const userId = useStateFromStores([UserStore], () => UserStore.getCurrentUser()?.id);
+        const selectedId = useStateFromStores([SelectedChannelStore], () => SelectedChannelStore.getChannelId());
+        const messagesKey = useStateFromStores([ReadStateStore], () => ids.map(id => ReadStateStore.lastMessageId(id) ?? "0").join(","), [ids]);
+        const navigation = `${userId}:${selectedId}`;
+        const previousNavigation = useRef<string | undefined>(undefined);
+        const reveal = previousNavigation.current !== navigation;
+        const pinned = getPinnedIds();
+        const pinsKey = JSON.stringify([...pinned]);
+        const layout = withoutPinnedChannels(accounts[userId ?? ""] ?? getLayout(), pinned);
+        useEffect(syncPinnedChats, [userId, pinsKey]);
+        // Reveal in the same render as navigation before native scrolling runs.
+        const visibleLayout = reveal ? {
+            ...layout,
+            folders: layout.folders.map(f => f.channels.includes(selectedId) ? { ...f, expanded: true } : f)
+        } : layout;
+        useEffect(() => {
+            previousNavigation.current = navigation;
+            const parent = getLayout().folders.find(f => f.channels.includes(selectedId));
+            if (parent && !parent.expanded) editFolder(parent.id, { expanded: true });
+        }, [navigation]);
+        // Include metadata, not just IDs: rename and color edits must invalidate cached rows.
+        const version = JSON.stringify([visibleLayout, keepFoldersOnTop, userId, messagesKey, ids, getPinDmsVersion()]);
+        return useMemo(() => {
+            const rows = getRows(visibleLayout, ids.filter(id => !pinned.has(id)), getMessages(ids), keepFoldersOnTop);
+            return { privateChannelIds: rows.map(r => r.id), vcDmfRows: rows, vcDmfVersion: version, vcDmfSection: getDMSection() };
+        }, [version]);
+    },
+
+    renderRow(instance: DMList, { section, row }: { section: number; row: number; }) {
+        if (section !== instance.props.vcDmfSection) return;
+        if (isDMSectionCollapsed()) return null;
+        const id = instance.props.privateChannelIds[row];
+        if (!id) return;
+        // Use the same snapshot as the list IDs, including navigation's reveal.
+        const data = instance.props.vcDmfRows?.[row];
+        if (!data || data.id !== id) return;
+        const { folder } = data;
+        const height = instance.props.density === "compact" ? 40 : instance.props.density === "default" || !instance.props.density ? 44 : 50;
+        return (
+            <ErrorBoundary key={id} message="FlexibleDMs could not render this row">
+                <DragRow row={data} height={height}>
+                    {folder ? <FolderRow folder={folder} /> : instance.renderDM(section, row)}
+                </DragRow>
+            </ErrorBoundary>
+        );
+    },
+
+    scrollTarget(id: string | null, rows?: Row[]) {
+        if (!id) return id;
+        if (rows?.some(r => r.id === id)) return id;
+        return rows?.find(r => r.folder?.channels.includes(id))?.id ?? id;
+    },
+
+    navigationIds(original: string[]) {
+        const allowed = new Set(original);
+        const pinned = getPinnedIds();
+        // Static destinations and PinDMs categories already have their own order.
+        const prefix = original.filter(id => pinned.has(id) || id.startsWith("/"));
+        return [...prefix, ...currentRows().filter(r => !r.folder && allowed.has(r.id)).map(r => r.id)];
+    }
+});

--- a/src/plugins/flexibleDMs/model.ts
+++ b/src/plugins/flexibleDMs/model.ts
@@ -1,0 +1,120 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface Folder {
+    id: string;
+    name: string;
+    color: string;
+    channels: string[];
+    expanded: boolean;
+    naturalOrder?: boolean;
+}
+
+export interface Layout {
+    folders: Folder[];
+    order: string[];
+    seen: Record<string, string>;
+}
+
+export interface Row {
+    id: string;
+    folder?: Folder;
+    parent?: Folder;
+}
+
+export type Placement = "before" | "inside" | "after";
+export const emptyLayout = (): Layout => ({ folders: [], order: [], seen: {} });
+
+function compareIds(a = "0", b = "0") {
+    return a.length - b.length || a.localeCompare(b);
+}
+
+/** Keep closed DMs in saved membership, but only render channels Discord lists. */
+export function getRows(layout: Layout, activeIds: string[], messages: Record<string, string>, keepOnTop: boolean): Row[] {
+    const active = new Set(activeIds);
+    const folders = layout.folders.filter(f => f.channels.some(id => active.has(id)));
+    const parents = new Map(folders.flatMap(f => f.channels.map(id => [id, f] as const)));
+    const byId = new Map(folders.map(f => [f.id, f]));
+    const natural = [...new Set(activeIds.map(id => parents.get(id)?.id ?? id))];
+    const valid = new Set(natural);
+    const saved = layout.order.filter(id => valid.has(id));
+    const savedSet = new Set(saved);
+    const order = [...natural.filter(id => !savedSet.has(id)), ...saved];
+    const activity = new Map<string, string>();
+    for (const id of activeIds) {
+        const last = messages[id];
+        if (!last || compareIds(last, layout.seen[id]) <= 0) continue;
+        const key = parents.get(id)?.id ?? id;
+        if (compareIds(last, activity.get(key)) > 0) activity.set(key, last);
+    }
+    order.sort((a, b) => {
+        if (keepOnTop && byId.has(a) !== byId.has(b)) return byId.has(a) ? -1 : 1;
+        return compareIds(activity.get(b), activity.get(a));
+    });
+    return order.flatMap(id => {
+        const folder = byId.get(id);
+        if (!folder) return [{ id }];
+        return [{ id, folder }, ...(folder.expanded ? (folder.naturalOrder ? activeIds.filter(id => folder.channels.includes(id)) : folder.channels.filter(c => active.has(c))).map(id => ({ id, parent: folder })) : [])];
+    });
+}
+
+export function move(layout: Layout, rows: Row[], sourceId: string, targetId: string, placement: Placement, newId: string): Layout {
+    const next: Layout = JSON.parse(JSON.stringify(layout));
+    const source = rows.find(r => r.id === sourceId);
+    const target = rows.find(r => r.id === targetId);
+    if (!source || !target || sourceId === targetId) return next;
+    if (source.folder && (placement === "inside" || target.parent)) return next;
+    if (target.folder && target.folder.id === source.parent?.id && placement === "inside") return next;
+
+    next.order = rows.filter(r => !r.parent).map(r => r.id);
+    const folder = (id: string) => next.folders.find(f => f.id === id)!;
+    const detach = () => {
+        for (const f of next.folders) f.channels = f.channels.filter(id => id !== sourceId);
+        next.order = next.order.filter(id => id !== sourceId);
+    };
+    const insert = (ids: string[], target: string, id: string, after: boolean) => {
+        ids.splice(ids.indexOf(target) + (after ? 1 : 0), 0, id);
+    };
+
+    detach();
+    if (placement === "inside") {
+        const parent = target.folder ?? target.parent;
+        if (parent) folder(parent.id).channels.push(sourceId);
+        else {
+            const created: Folder = { id: newId, name: "New Folder", color: "#3ba55c", channels: [targetId, sourceId], expanded: false };
+            next.folders.push(created);
+            next.order.splice(next.order.indexOf(targetId), 1, newId);
+        }
+    } else if (target.parent) {
+        const parent = folder(target.parent.id);
+        if (parent.naturalOrder) {
+            const visible = rows.filter(r => r.parent?.id === parent.id && r.id !== sourceId).map(r => r.id);
+            parent.channels = [...visible, ...parent.channels.filter(id => !visible.includes(id))];
+            parent.naturalOrder = false;
+        }
+        insert(parent.channels, targetId, sourceId, placement === "after");
+    } else {
+        insert(next.order, targetId, sourceId, placement === "after");
+    }
+    next.folders = next.folders.filter(f => f.channels.length > 0);
+    const removed = new Set(layout.folders.filter(f => !next.folders.some(n => n.id === f.id)).map(f => f.id));
+    next.order = next.order.filter(id => !removed.has(id));
+    return next;
+}
+
+export function withoutPinnedChannels(layout: Layout, pinned: Set<string>): Layout {
+    if (!layout.folders.some(folder => folder.channels.some(id => pinned.has(id)))) return layout;
+
+    const folders = layout.folders
+        .map(folder => ({ ...folder, channels: folder.channels.filter(id => !pinned.has(id)) }))
+        .filter(folder => folder.channels.length > 0);
+    const removed = new Set(layout.folders.filter(folder => !folders.some(f => f.id === folder.id)).map(folder => folder.id));
+    return { ...layout, folders, order: layout.order.filter(id => !pinned.has(id) && !removed.has(id)) };
+}
+
+export function resetLayoutOrder(layout: Layout): Layout {
+    return { ...layout, order: [], seen: {}, folders: layout.folders.map(folder => ({ ...folder, naturalOrder: true })) };
+}

--- a/src/plugins/flexibleDMs/model.ts
+++ b/src/plugins/flexibleDMs/model.ts
@@ -25,6 +25,8 @@ export interface Row {
     parent?: Folder;
 }
 
+export const DEFAULT_FOLDER_COLOR = "#5865f2";
+
 export type Placement = "before" | "inside" | "after";
 export const emptyLayout = (): Layout => ({ folders: [], order: [], seen: {} });
 
@@ -61,6 +63,15 @@ export function getRows(layout: Layout, activeIds: string[], messages: Record<st
     });
 }
 
+/** Refresh visible order without discarding the slots of temporarily closed chats. */
+export function mergeVisibleOrder(saved: string[], visible: string[]): string[] {
+    const active = new Set(visible);
+    const old = new Set(saved);
+    const existing = visible.filter(id => old.has(id));
+    let index = 0;
+    return [...visible.filter(id => !old.has(id)), ...saved.map(id => active.has(id) ? existing[index++] : id)];
+}
+
 export function move(layout: Layout, rows: Row[], sourceId: string, targetId: string, placement: Placement, newId: string): Layout {
     const next: Layout = JSON.parse(JSON.stringify(layout));
     const source = rows.find(r => r.id === sourceId);
@@ -69,7 +80,7 @@ export function move(layout: Layout, rows: Row[], sourceId: string, targetId: st
     if (source.folder && (placement === "inside" || target.parent)) return next;
     if (target.folder && target.folder.id === source.parent?.id && placement === "inside") return next;
 
-    next.order = rows.filter(r => !r.parent).map(r => r.id);
+    next.order = mergeVisibleOrder(layout.order, rows.filter(r => !r.parent).map(r => r.id));
     const folder = (id: string) => next.folders.find(f => f.id === id)!;
     const detach = () => {
         for (const f of next.folders) f.channels = f.channels.filter(id => id !== sourceId);
@@ -84,7 +95,7 @@ export function move(layout: Layout, rows: Row[], sourceId: string, targetId: st
         const parent = target.folder ?? target.parent;
         if (parent) folder(parent.id).channels.push(sourceId);
         else {
-            const created: Folder = { id: newId, name: "New Folder", color: "#3ba55c", channels: [targetId, sourceId], expanded: false };
+            const created: Folder = { id: newId, name: "New Folder", color: DEFAULT_FOLDER_COLOR, channels: [targetId, sourceId], expanded: false };
             next.folders.push(created);
             next.order.splice(next.order.indexOf(targetId), 1, newId);
         }
@@ -92,7 +103,7 @@ export function move(layout: Layout, rows: Row[], sourceId: string, targetId: st
         const parent = folder(target.parent.id);
         if (parent.naturalOrder) {
             const visible = rows.filter(r => r.parent?.id === parent.id && r.id !== sourceId).map(r => r.id);
-            parent.channels = [...visible, ...parent.channels.filter(id => !visible.includes(id))];
+            parent.channels = mergeVisibleOrder(parent.channels, visible);
             parent.naturalOrder = false;
         }
         insert(parent.channels, targetId, sourceId, placement === "after");

--- a/src/plugins/flexibleDMs/pinDms.ts
+++ b/src/plugins/flexibleDMs/pinDms.ts
@@ -6,21 +6,22 @@
 
 import { isPluginEnabled } from "@api/PluginManager";
 import { settings } from "@plugins/pinDms";
-import { categoryLen } from "@plugins/pinDms/data";
 import { UserStore } from "@webpack/common";
 
-export function getPinnedIds(): Set<string> {
+function getCategories() {
     const userId = UserStore.getCurrentUser()?.id;
-    if (!isPluginEnabled("PinDMs") || !userId) return new Set();
-    return new Set(settings.store.userBasedCategoryList[userId]?.flatMap(category => category.channels));
+    if (!isPluginEnabled("PinDMs") || !userId) return [];
+    return settings.store.userBasedCategoryList[userId] ?? [];
 }
 
+export const getPinnedIds = (): Set<string> => new Set(getCategories().flatMap(category => category.channels));
+
 export const isPinned = (id: string) => getPinnedIds().has(id);
-export const getDMSection = () => 1 + (isPluginEnabled("PinDMs") ? categoryLen() : 0);
+export const getDMSection = () => 1 + getCategories().length;
 export const isDMSectionCollapsed = () => isPluginEnabled("PinDMs") && settings.store.canCollapseDmSection && settings.store.dmSectionCollapsed;
 
-export function getPinDmsVersion() {
+export function getPinDmsState() {
     if (!isPluginEnabled("PinDMs")) return "";
     const { userBasedCategoryList, pinOrder, canCollapseDmSection, dmSectionCollapsed } = settings.store;
-    return JSON.stringify([userBasedCategoryList[UserStore.getCurrentUser()?.id ?? ""], pinOrder, canCollapseDmSection, dmSectionCollapsed]);
+    return [userBasedCategoryList[UserStore.getCurrentUser()?.id ?? ""], pinOrder, canCollapseDmSection, dmSectionCollapsed];
 }

--- a/src/plugins/flexibleDMs/pinDms.ts
+++ b/src/plugins/flexibleDMs/pinDms.ts
@@ -1,0 +1,26 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { isPluginEnabled } from "@api/PluginManager";
+import { settings } from "@plugins/pinDms";
+import { categoryLen } from "@plugins/pinDms/data";
+import { UserStore } from "@webpack/common";
+
+export function getPinnedIds(): Set<string> {
+    const userId = UserStore.getCurrentUser()?.id;
+    if (!isPluginEnabled("PinDMs") || !userId) return new Set();
+    return new Set(settings.store.userBasedCategoryList[userId]?.flatMap(category => category.channels));
+}
+
+export const isPinned = (id: string) => getPinnedIds().has(id);
+export const getDMSection = () => 1 + (isPluginEnabled("PinDMs") ? categoryLen() : 0);
+export const isDMSectionCollapsed = () => isPluginEnabled("PinDMs") && settings.store.canCollapseDmSection && settings.store.dmSectionCollapsed;
+
+export function getPinDmsVersion() {
+    if (!isPluginEnabled("PinDMs")) return "";
+    const { userBasedCategoryList, pinOrder, canCollapseDmSection, dmSectionCollapsed } = settings.store;
+    return JSON.stringify([userBasedCategoryList[UserStore.getCurrentUser()?.id ?? ""], pinOrder, canCollapseDmSection, dmSectionCollapsed]);
+}

--- a/src/plugins/flexibleDMs/settings.tsx
+++ b/src/plugins/flexibleDMs/settings.tsx
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+import { Button } from "@webpack/common";
+
+import { Layout } from "./model";
+import { resetOrder } from "./state";
+
+export const settings = definePluginSettings({
+    keepFoldersOnTop: {
+        type: OptionType.BOOLEAN,
+        displayName: "Always keep folders on top",
+        description: "Keep folders above unpinned DMs, including chats with new messages. PinDMs categories always stay above folders.",
+        default: false
+    },
+    persistence: {
+        type: OptionType.BOOLEAN,
+        displayName: "Persistence",
+        description: "Keep manually arranged chat order after restarting Discord.",
+        default: false
+    },
+    resetOrder: {
+        type: OptionType.COMPONENT,
+        component: () => <Button onClick={resetOrder}>Reset chat order</Button>
+    },
+    accounts: {
+        type: OptionType.CUSTOM,
+        default: {} as Record<string, Layout>,
+        hidden: true
+    }
+});

--- a/src/plugins/flexibleDMs/state.ts
+++ b/src/plugins/flexibleDMs/state.ts
@@ -8,17 +8,27 @@ import { SettingsStore } from "@api/Settings";
 import { findStoreLazy } from "@webpack";
 import { ReadStateStore, UserStore } from "@webpack/common";
 
-import { emptyLayout, Folder, getRows, Layout, move, Placement, resetLayoutOrder, withoutPinnedChannels } from "./model";
+import { emptyLayout, Folder, getRows, Layout, mergeVisibleOrder, move, Placement, resetLayoutOrder, withoutPinnedChannels } from "./model";
 import { getPinnedIds, isPinned } from "./pinDms";
 import { settings } from "./settings";
 
-export const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as { getPrivateChannelIds(): string[]; };
+export const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as {
+    getPrivateChannelIds(): string[];
+    getSortedChannels?(): Array<Array<{ channelId: string; }>>;
+    addChangeListener?(listener: () => void): void;
+    removeChangeListener?(listener: () => void): void;
+};
 export const accountId = () => UserStore.getCurrentUser()?.id;
 export const getLayout = (): Layout => settings.store.accounts[accountId() ?? ""] ?? emptyLayout();
 export const getMessages = (ids: string[]) => Object.fromEntries(ids.map(id => [id, ReadStateStore.lastMessageId(id) ?? "0"]));
+export const getNativePinnedIds = () => PrivateChannelSortStore.getSortedChannels?.()[0]?.map(channel => channel.channelId) ?? [];
+
+function allPinnedIds() {
+    return new Set([...getPinnedIds(), ...getNativePinnedIds()]);
+}
 
 export function currentRows() {
-    const pinned = getPinnedIds();
+    const pinned = allPinnedIds();
     const ids = PrivateChannelSortStore.getPrivateChannelIds().filter(id => !pinned.has(id));
     return getRows(getLayout(), ids, getMessages(ids), settings.store.keepFoldersOnTop);
 }
@@ -39,7 +49,7 @@ export function closeAll() {
 }
 
 export function drop(source: string, target: string, placement: Placement) {
-    if (isPinned(source) || isPinned(target)) return;
+    if (isPinned(source) || isPinned(target) || getNativePinnedIds().includes(source) || getNativePinnedIds().includes(target)) return;
     const rows = currentRows();
     if (!rows.some(r => r.id === target)) {
         const folder = getLayout().folders.find(f => f.id === target);
@@ -69,13 +79,14 @@ export function dissolveFolder(id: string) {
     const layout = getLayout();
     const folder = layout.folders.find(f => f.id === id);
     if (!folder) return;
-    const order = currentRows().filter(r => !r.parent).flatMap(r => r.id === id ? folder.channels : [r.id]);
+    const order = mergeVisibleOrder(layout.order, currentRows().filter(r => !r.parent).map(r => r.id))
+        .flatMap(rowId => rowId === id ? folder.channels : [rowId]);
     save({ ...layout, folders: layout.folders.filter(f => f.id !== id), order, seen: getMessages(PrivateChannelSortStore.getPrivateChannelIds()) });
 }
 
 export function syncPinnedChats() {
     const layout = getLayout();
-    const next = withoutPinnedChannels(layout, getPinnedIds());
+    const next = withoutPinnedChannels(layout, allPinnedIds());
     if (next !== layout) save(next);
 }
 
@@ -91,9 +102,11 @@ export function start() {
         )));
     }
     SettingsStore.addChangeListener("plugins.PinDMs.userBasedCategoryList", syncPinnedChats);
+    PrivateChannelSortStore.addChangeListener?.(syncPinnedChats);
     syncPinnedChats();
 }
 
 export function stop() {
     SettingsStore.removeChangeListener("plugins.PinDMs.userBasedCategoryList", syncPinnedChats);
+    PrivateChannelSortStore.removeChangeListener?.(syncPinnedChats);
 }

--- a/src/plugins/flexibleDMs/state.ts
+++ b/src/plugins/flexibleDMs/state.ts
@@ -1,0 +1,99 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { SettingsStore } from "@api/Settings";
+import { findStoreLazy } from "@webpack";
+import { ReadStateStore, UserStore } from "@webpack/common";
+
+import { emptyLayout, Folder, getRows, Layout, move, Placement, resetLayoutOrder, withoutPinnedChannels } from "./model";
+import { getPinnedIds, isPinned } from "./pinDms";
+import { settings } from "./settings";
+
+export const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as { getPrivateChannelIds(): string[]; };
+export const accountId = () => UserStore.getCurrentUser()?.id;
+export const getLayout = (): Layout => settings.store.accounts[accountId() ?? ""] ?? emptyLayout();
+export const getMessages = (ids: string[]) => Object.fromEntries(ids.map(id => [id, ReadStateStore.lastMessageId(id) ?? "0"]));
+
+export function currentRows() {
+    const pinned = getPinnedIds();
+    const ids = PrivateChannelSortStore.getPrivateChannelIds().filter(id => !pinned.has(id));
+    return getRows(getLayout(), ids, getMessages(ids), settings.store.keepFoldersOnTop);
+}
+
+export function save(layout: Layout, userId = accountId()) {
+    if (!userId || userId !== accountId()) return;
+    settings.store.accounts = JSON.parse(JSON.stringify({ ...settings.store.accounts, [userId]: layout }));
+}
+
+export function editFolder(id: string, update: Partial<Pick<Folder, "name" | "color" | "expanded">>, userId = accountId()) {
+    const layout = getLayout();
+    save({ ...layout, folders: layout.folders.map(f => f.id === id ? { ...f, ...update } : f) }, userId);
+}
+
+export function closeAll() {
+    const layout = getLayout();
+    save({ ...layout, folders: layout.folders.map(f => ({ ...f, expanded: false })) });
+}
+
+export function drop(source: string, target: string, placement: Placement) {
+    if (isPinned(source) || isPinned(target)) return;
+    const rows = currentRows();
+    if (!rows.some(r => r.id === target)) {
+        const folder = getLayout().folders.find(f => f.id === target);
+        if (folder) rows.push({ id: target, folder });
+    }
+    if (!rows.some(r => r.id === source)) {
+        const parent = getLayout().folders.find(f => f.channels.includes(source));
+        if (parent && PrivateChannelSortStore.getPrivateChannelIds().includes(source)) rows.push({ id: source, parent });
+    }
+    const layout = move(getLayout(), rows, source, target, placement, `dm-folder:${crypto.randomUUID()}`);
+    layout.seen = getMessages(PrivateChannelSortStore.getPrivateChannelIds());
+    save(layout);
+}
+
+export function removeFromFolder(channelId: string) {
+    const rows = currentRows();
+    const parent = rows.find(r => r.id === channelId)?.parent ?? getLayout().folders.find(f => f.channels.includes(channelId));
+    if (!parent) return;
+    // A collapsed child is not in rows, so expose it only to the move operation.
+    if (!rows.some(r => r.id === channelId)) rows.push({ id: channelId, parent });
+    const layout = move(getLayout(), rows, channelId, parent.id, "after", "");
+    layout.seen = getMessages(PrivateChannelSortStore.getPrivateChannelIds());
+    save(layout);
+}
+
+export function dissolveFolder(id: string) {
+    const layout = getLayout();
+    const folder = layout.folders.find(f => f.id === id);
+    if (!folder) return;
+    const order = currentRows().filter(r => !r.parent).flatMap(r => r.id === id ? folder.channels : [r.id]);
+    save({ ...layout, folders: layout.folders.filter(f => f.id !== id), order, seen: getMessages(PrivateChannelSortStore.getPrivateChannelIds()) });
+}
+
+export function syncPinnedChats() {
+    const layout = getLayout();
+    const next = withoutPinnedChannels(layout, getPinnedIds());
+    if (next !== layout) save(next);
+}
+
+export function resetOrder() {
+    save(resetLayoutOrder(getLayout()));
+}
+
+export function start() {
+    if (!settings.store.persistence) {
+        // Reset every account, including ones that are not logged in yet.
+        settings.store.accounts = JSON.parse(JSON.stringify(Object.fromEntries(
+            Object.entries(settings.store.accounts).map(([id, layout]) => [id, resetLayoutOrder(layout)])
+        )));
+    }
+    SettingsStore.addChangeListener("plugins.PinDMs.userBasedCategoryList", syncPinnedChats);
+    syncPinnedChats();
+}
+
+export function stop() {
+    SettingsStore.removeChangeListener("plugins.PinDMs.userBasedCategoryList", syncPinnedChats);
+}

--- a/src/plugins/flexibleDMs/style.css
+++ b/src/plugins/flexibleDMs/style.css
@@ -1,0 +1,252 @@
+.vc-dmf-row {
+    position: relative;
+    box-sizing: border-box;
+    flex-shrink: 0;
+}
+
+.vc-dmf-folder {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: calc(100% - 16px);
+    height: calc(100% - 2px);
+    margin: 1px 8px;
+    padding: 0 8px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--text-secondary, #b5bac1);
+    font-family: var(--font-primary);
+    text-align: left;
+    cursor: pointer;
+}
+
+.vc-dmf-folder:hover {
+    background: var(--background-modifier-hover, var(--background-mod-subtle, rgb(255 255 255 / 6%)));
+    color: var(--text-primary, #f2f3f5);
+}
+
+.vc-dmf-folder:focus-visible {
+    outline: 2px solid var(--focus-primary);
+    outline-offset: -2px;
+}
+
+.vc-dmf-selected {
+    background: var(--background-modifier-selected, var(--background-mod-subtle, rgb(255 255 255 / 8%)));
+}
+
+.vc-dmf-unread::before {
+    content: "";
+    position: absolute;
+    left: 2px;
+    width: 4px;
+    height: 8px;
+    border-radius: 4px;
+    background: var(--text-primary, #f2f3f5);
+}
+
+.vc-dmf-icon {
+    display: grid;
+    place-items: center;
+    flex: 0 0 32px;
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--vc-dmf-color) 22%, transparent);
+    color: var(--vc-dmf-color);
+}
+
+.vc-dmf-mosaic {
+    display: grid;
+    grid-template-columns: repeat(2, 12px);
+    grid-template-rows: repeat(2, 12px);
+    gap: 2px;
+}
+
+.vc-dmf-mosaic img,
+.vc-dmf-avatar-fallback {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.vc-dmf-avatar-fallback {
+    display: grid;
+    place-items: center;
+    background: var(--vc-dmf-color);
+    color: white;
+    font-size: 10px;
+}
+
+.vc-dmf-nameplate {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-width: 0;
+    gap: 1px;
+}
+
+.vc-dmf-name {
+    overflow: hidden;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 20px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vc-dmf-unread .vc-dmf-name {
+    color: var(--text-primary, #f2f3f5);
+    font-weight: 600;
+}
+
+.vc-dmf-description {
+    color: var(--text-muted);
+    font-size: 12px;
+    line-height: 14px;
+}
+
+.vc-dmf-chevron {
+    flex-shrink: 0;
+    transition: transform 150ms ease;
+}
+
+.vc-dmf-chevron-open {
+    transform: rotate(90deg);
+}
+
+.vc-dmf-badge {
+    border-radius: 8px;
+    padding: 1px 5px;
+    background: var(--status-danger);
+    color: white;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.vc-dmf-child {
+    animation: vc-dmf-reveal 150ms ease-out;
+    margin-left: 16px;
+    border-left: 2px solid color-mix(in srgb, var(--vc-dmf-color) 50%, transparent);
+    background: color-mix(in srgb, var(--vc-dmf-color) 6%, transparent);
+}
+
+.vc-dmf-row[data-dmf-drop="inside"] {
+    border-radius: 8px;
+    outline: 2px solid var(--brand-500);
+    outline-offset: -3px;
+    background: var(--background-modifier-selected, var(--background-mod-subtle, rgb(255 255 255 / 8%)));
+}
+
+.vc-dmf-row[data-dmf-drop="before"]::before,
+.vc-dmf-row[data-dmf-drop="after"]::after {
+    content: "";
+    position: absolute;
+    z-index: 2;
+    right: 8px;
+    left: 8px;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--brand-500);
+    pointer-events: none;
+}
+
+.vc-dmf-row[data-dmf-drop="before"]::before {
+    top: 0;
+}
+
+.vc-dmf-row[data-dmf-drop="after"]::after {
+    bottom: 0;
+}
+
+.vc-dmf-settings {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 8px 0;
+    color: var(--text-primary);
+}
+
+@keyframes vc-dmf-reveal {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+    .vc-dmf-child {
+        animation: none;
+    }
+
+    .vc-dmf-chevron {
+        transition: none;
+    }
+}
+
+.vc-dmf-colors {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.vc-dmf-color-buttons {
+    display: flex;
+    gap: 10px;
+}
+
+.vc-dmf-color-large,
+.vc-dmf-swatch {
+    display: grid;
+    place-items: center;
+    padding: 0;
+    border: 0;
+    color: white;
+    cursor: pointer;
+}
+
+.vc-dmf-color-large {
+    width: 70px;
+    height: 50px;
+    border-radius: 8px;
+}
+
+.vc-dmf-custom-color {
+    position: relative;
+}
+
+.vc-dmf-custom-color input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+}
+
+
+.vc-dmf-swatches {
+    display: grid;
+    grid-template-columns: repeat(10, 20px);
+    gap: 10px;
+}
+
+.vc-dmf-swatch {
+    width: 20px;
+    height: 20px;
+    border-radius: 8px;
+}
+
+.vc-dmf-custom-color:focus-within,
+.vc-dmf-color-large:focus-visible,
+.vc-dmf-swatch:focus-visible {
+    outline: 2px solid var(--focus-primary, #00a8fc);
+    outline-offset: 2px;
+}

--- a/src/plugins/flexibleDMs/style.css
+++ b/src/plugins/flexibleDMs/style.css
@@ -126,10 +126,13 @@
 }
 
 .vc-dmf-child {
-    animation: vc-dmf-reveal 150ms ease-out;
     margin-left: 16px;
     border-left: 2px solid color-mix(in srgb, var(--vc-dmf-color) 50%, transparent);
     background: color-mix(in srgb, var(--vc-dmf-color) 6%, transparent);
+}
+
+.vc-dmf-child.vc-dmf-opening {
+    animation: vc-dmf-reveal 150ms ease-out;
 }
 
 .vc-dmf-row[data-dmf-drop="inside"] {
@@ -182,7 +185,7 @@
 
 
 @media (prefers-reduced-motion: reduce) {
-    .vc-dmf-child {
+    .vc-dmf-child.vc-dmf-opening {
         animation: none;
     }
 

--- a/src/plugins/pinDms/data.ts
+++ b/src/plugins/pinDms/data.ts
@@ -23,7 +23,9 @@ export async function init() {
     const userId = UserStore.getCurrentUser()?.id;
     if (userId == null) return;
 
-    currentUserCategories = settings.store.userBasedCategoryList[userId] ??= [];
+    settings.store.userBasedCategoryList[userId] ??= [];
+    // Read it back through the proxy so a new account gets settings notifications too.
+    currentUserCategories = settings.store.userBasedCategoryList[userId];
     forceUpdateDms?.();
 }
 

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -83,8 +83,8 @@ export default definePlugin({
                     replace: "privateChannelIds:$1.filter(c=>!$self.isPinned(c))"
                 },
                 {
-                    // Insert the pinned channels to sections
-                    match: /(?<=,)sections:\[\i,Math\.max\(\i\.length,1\)\]/,
+                    // Keep the native anchor, accepting only FlexibleDMs' known render wrapper.
+                    match: /(?<=renderRow:(?:this\.renderRow|Vencord\.Plugins\.plugins(?:\.FlexibleDMs|\["FlexibleDMs"\])\.cachedRenderRow\(this\)),)sections:\[\i,Math\.max\(\i\.length,1\)\]/,
                     replace: "...$self.makeProps(this,{$&})"
                 },
 
@@ -141,8 +141,8 @@ export default definePlugin({
         {
             find: ".APPLICATION_STORE&&",
             replacement: {
-                // channelIds = __OVERLAY__ ? stuff : [...getStaticPaths(),...channelIds)]
-                match: /(?<=\[\.\.\.\i\(\),\.\.\.)\i/,
+                // Keep the overlay branch anchor, with an optional FlexibleDMs wrapper.
+                match: /(?<=\i=__OVERLAY__\?\i:(?:Vencord\.Plugins\.plugins(?:\.FlexibleDMs|\["FlexibleDMs"\])\.navigationIds\()?\[\.\.\.\i\(\),\.\.\.)\i/,
                 // ....concat(pins).concat(toArray(channelIds).filter(c => !isPinned(c)))
                 replace: "$self.getAllUncollapsedChannels().concat($&.filter(c=>!$self.isPinned(c)))"
             }
@@ -152,7 +152,8 @@ export default definePlugin({
         {
             find: "=()=>!1,ensureChatIsVisible:",
             replacement: {
-                match: /\i\.\i\.getPrivateChannelIds\(\)/,
+                // Match the DM branch even when FlexibleDMs wraps its channel IDs.
+                match: /(?<=\i===\i\.ME\?(?:Vencord\.Plugins\.plugins(?:\.FlexibleDMs|\["FlexibleDMs"\])\.navigationIds\()?)\i\.\i\.getPrivateChannelIds\(\)/,
                 replace: "$self.getAllUncollapsedChannels().concat($&.filter(c=>!$self.isPinned(c)))"
             }
         },

--- a/src/plugins/pinDms/index.tsx
+++ b/src/plugins/pinDms/index.tsx
@@ -84,7 +84,7 @@ export default definePlugin({
                 },
                 {
                     // Insert the pinned channels to sections
-                    match: /(?<=renderRow:this\.renderRow,)sections:\[.+?1\)]/,
+                    match: /(?<=,)sections:\[\i,Math\.max\(\i\.length,1\)\]/,
                     replace: "...$self.makeProps(this,{$&})"
                 },
 
@@ -142,7 +142,7 @@ export default definePlugin({
             find: ".APPLICATION_STORE&&",
             replacement: {
                 // channelIds = __OVERLAY__ ? stuff : [...getStaticPaths(),...channelIds)]
-                match: /(?<=\i=__OVERLAY__\?\i:\[\.\.\.\i\(\),\.\.\.)\i/,
+                match: /(?<=\[\.\.\.\i\(\),\.\.\.)\i/,
                 // ....concat(pins).concat(toArray(channelIds).filter(c => !isPinned(c)))
                 replace: "$self.getAllUncollapsedChannels().concat($&.filter(c=>!$self.isPinned(c)))"
             }
@@ -152,7 +152,7 @@ export default definePlugin({
         {
             find: "=()=>!1,ensureChatIsVisible:",
             replacement: {
-                match: /(?<=\i===\i\.ME\?)\i\.\i\.getPrivateChannelIds\(\)/,
+                match: /\i\.\i\.getPrivateChannelIds\(\)/,
                 replace: "$self.getAllUncollapsedChannels().concat($&.filter(c=>!$self.isPinned(c)))"
             }
         },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -666,6 +666,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "yuna0x0",
         id: 213656926414831616n
     },
+    frisk: {
+        name: "frisk",
+        id: 337643611741224961n
+    },
     Davri: {
         name: "Davri",
         id: 457579346282938368n


### PR DESCRIPTION
## Describe your Changes
Makes chats (DMs, GCs) behave like servers do.
Allows you to rearrange them however you want, or group them into customizable folders.

## Screenshots (if applicable)
Folders can be given any name or color, and behaves like any server folder would.
<img width="365" height="214" alt="{657C0C95-A73F-4DEE-BAD6-3BD0166A13A5}" src="https://github.com/user-attachments/assets/346189d2-c595-4009-8c24-e172ea10aae9" />
_unread indicators too_

## Dragging and organization.
<img width="800" height="600" alt="c8b72113-698d-4ccf-9723-8116adc55726-render-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/ec0ccfc5-c3e4-4da3-9982-28db31f55c7a" />

## Grouping, customization and ungrouping.
<img width="800" height="450" alt="2542ea64-6614-4223-aa91-c9fccc2e28dd-render-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/163b6e37-ff33-4486-b347-49d3a8a98972" />


been using this privately for a minute so most edge cases should already have been addressed, only just decided to contribute in case anyone else wants to use it. Compatible with PinDMs, lmk if I missed anything.

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [X] This pull request was written by me, and not an AI agent. <!-- Don't bother lying, we will know and you will be banned -->
- [X] I understand that if any of the above conditions are not met, this pull request will be closed and I will be banned from future contributions without further warning
