### PR TITLE
StreamAudioDevice: select the audio input for screen sharing

### DIFF
--- a/src/plugins/streamAudioDevice.desktop/capture.ts
+++ b/src/plugins/streamAudioDevice.desktop/capture.ts
@@ -1,0 +1,88 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/** Owns only the tracks created for a screen share, never the voice-chat input. */
+export class StreamAudioCapture {
+    private generation = 0;
+    private sessions = new Set<() => void>();
+
+    constructor(private readonly reportError: (message: string) => void) { }
+
+    async capture(
+        display: Promise<MediaStream>,
+        deviceId: string,
+        getUserMedia: (constraints: MediaStreamConstraints) => Promise<MediaStream>
+    ): Promise<MediaStream> {
+        const { generation } = this;
+        const screen = await display;
+        let input: MediaStream | undefined;
+        try {
+            if (generation !== this.generation) throw new Error("Stream Audio was disabled during capture.");
+            const video = screen.getVideoTracks()[0];
+            if (!video || video.readyState === "ended") throw new Error("Screen sharing has already ended.");
+
+            // Stop loopback before opening the input. Never retain it as a fallback.
+            for (const track of screen.getAudioTracks()) {
+                screen.removeTrack(track);
+                track.stop();
+            }
+            input = await getUserMedia({
+                video: false,
+                audio: {
+                    deviceId: { exact: deviceId },
+                    echoCancellation: false,
+                    noiseSuppression: false,
+                    autoGainControl: false
+                }
+            });
+            const audio = input.getAudioTracks()[0];
+            if (generation !== this.generation || screen.getVideoTracks()[0]?.readyState === "ended")
+                throw new Error("Screen sharing ended while opening the audio input.");
+            if (!audio || audio.readyState === "ended") throw new Error("The selected audio input did not provide audio.");
+
+            screen.addTrack(audio);
+            let closed = false;
+            const stopVideo = video.stop;
+            const stopAudio = audio.stop;
+            const cleanup = () => {
+                if (closed) return;
+                closed = true;
+                video.removeEventListener("ended", cleanup);
+                audio.removeEventListener("ended", inputEnded);
+                screen.removeEventListener("inactive", cleanup);
+                if (video.stop === stopVideoAndAudio) video.stop = stopVideo;
+                if (audio.stop === stopVideoAndAudio) audio.stop = stopAudio;
+                this.sessions.delete(cleanup);
+                screen.getTracks().forEach(track => track.stop());
+                input!.getTracks().forEach(track => track.stop());
+            };
+            const inputEnded = () => {
+                cleanup();
+                this.reportError("Stream Audio input disconnected. Restart sharing after selecting an available input.");
+            };
+            // MediaStreamTrack.stop() does not dispatch 'ended'. Handle Discord's
+            // explicit stop as well as the browser's own stop-sharing control.
+            const stopVideoAndAudio = () => cleanup();
+            video.stop = stopVideoAndAudio;
+            audio.stop = stopVideoAndAudio;
+            video.addEventListener("ended", cleanup);
+            audio.addEventListener("ended", inputEnded);
+            screen.addEventListener("inactive", cleanup);
+            this.sessions.add(cleanup);
+            return screen;
+        } catch (error) {
+            screen.getTracks().forEach(track => track.stop());
+            input?.getTracks().forEach(track => track.stop());
+            this.reportError("Could not start Stream Audio. Check the selected input and microphone permission; system audio was not used.");
+            throw error;
+        }
+    }
+
+    stop() {
+        this.generation++;
+        for (const cleanup of [...this.sessions]) cleanup();
+    }
+}

--- a/src/plugins/streamAudioDevice.desktop/index.tsx
+++ b/src/plugins/streamAudioDevice.desktop/index.tsx
@@ -1,0 +1,217 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings, migratePluginSettings } from "@api/Settings";
+import { Heading } from "@components/Heading";
+import { Paragraph } from "@components/Paragraph";
+import { Devs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+import definePlugin, { OptionType } from "@utils/types";
+import { Button, closeModal, MediaEngineStore, Menu, Modal, openModal, Select, showToast, Toasts, useEffect, useState } from "@webpack/common";
+
+import { StreamAudioCapture } from "./capture";
+import { NativeSource, NativeStreamAudio, NativeStreamConnection } from "./nativeCapture";
+
+migratePluginSettings("StreamAudioDevice", "StreamAudio");
+
+const logger = new Logger("StreamAudioDevice");
+const settings = definePluginSettings({
+    audioSource: {
+        type: OptionType.COMPONENT,
+        component: () => <AudioSourceSettings />
+    }
+}).withPrivateSettings<{
+    desktopDeviceId?: string;
+    vesktopDeviceId?: string;
+}>();
+const capture = new StreamAudioCapture(reportError);
+const nativeCapture = new NativeStreamAudio();
+let originalDisplayMedia: MediaDevices["getDisplayMedia"] | undefined;
+let wrappedDisplayMedia: MediaDevices["getDisplayMedia"] | undefined;
+let running = false;
+
+interface InputOption { label: string; value: string; }
+
+function selectedDevice() {
+    return (IS_DISCORD_DESKTOP ? settings.store.desktopDeviceId : settings.store.vesktopDeviceId) ?? "";
+}
+
+function selectDevice(value: string) {
+    if (IS_DISCORD_DESKTOP) settings.store.desktopDeviceId = value;
+    else settings.store.vesktopDeviceId = value;
+}
+
+function reportError(message: string) {
+    logger.error(message);
+    showToast(message, Toasts.Type.FAILURE);
+}
+
+function nativeDevices() {
+    return Object.values(MediaEngineStore.getInputDevices()).filter(device => !device.disabled);
+}
+
+async function listInputs(): Promise<InputOption[]> {
+    if (IS_DISCORD_DESKTOP)
+        return nativeDevices().map(device => ({ label: device.name, value: device.guid || device.id }));
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.filter(device => device.kind === "audioinput" && device.deviceId)
+        .map((device, index) => ({ label: device.label || `Microphone ${index + 1}`, value: device.deviceId }));
+}
+
+function AudioSourceSettings() {
+    settings.use(["desktopDeviceId", "vesktopDeviceId"]);
+    const [inputs, setInputs] = useState<InputOption[]>([]);
+    const [error, setError] = useState("");
+    const [busy, setBusy] = useState(false);
+    useEffect(() => {
+        let mounted = true;
+        let revision = 0;
+        const refresh = async () => {
+            const request = ++revision;
+            try {
+                const devices = await listInputs();
+                if (mounted && request === revision) { setInputs(devices); setError(""); }
+            } catch {
+                if (mounted) setError("Could not list audio inputs. Check microphone access.");
+            }
+        };
+        void refresh();
+        navigator.mediaDevices.addEventListener("devicechange", refresh);
+        if (IS_DISCORD_DESKTOP) MediaEngineStore.addChangeListener(refresh);
+        return () => {
+            mounted = false;
+            navigator.mediaDevices.removeEventListener("devicechange", refresh);
+            if (IS_DISCORD_DESKTOP) MediaEngineStore.removeChangeListener(refresh);
+        };
+    }, []);
+
+    const value = selectedDevice();
+    const options = [{ label: "Discord Default", value: "" }, ...inputs];
+    if (value && !inputs.some(input => input.value === value))
+        options.push({ label: "Selected input (unavailable)", value });
+
+    return <>
+        <Heading tag="h3">Stream Audio</Heading>
+        <Select
+            options={options}
+            placeholder="Discord Default"
+            select={selectDevice}
+            isSelected={option => option === value}
+            serialize={option => option}
+            closeOnSelect
+        />
+        <Paragraph>Choose Discord Default or an audio input such as Wave Link Stream. The input replaces stream audio; your voice-chat microphone stays unchanged. Restart screen sharing after changing this setting.</Paragraph>
+        <Paragraph>For Wave Link, exclude Discord voices from this mix to prevent viewers hearing themselves.</Paragraph>
+        {!IS_DISCORD_DESKTOP && <Button disabled={busy} onClick={async () => {
+            setBusy(true);
+            let permissionStream: MediaStream | undefined;
+            try {
+                permissionStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+                setInputs(await listInputs());
+                setError("");
+            } catch {
+                setError("Microphone access was denied or no input is available.");
+            } finally {
+                permissionStream?.getTracks().forEach(track => track.stop());
+                setBusy(false);
+            }
+        }}>Allow microphone access / refresh inputs</Button>}
+        {error && <Paragraph>{error}</Paragraph>}
+    </>;
+}
+
+function openSettings() {
+    const key = openModal(props => <Modal {...props} title="Stream Audio" actions={[
+        { text: "Done", variant: "primary", onClick: () => closeModal(key) }
+    ]}><AudioSourceSettings /></Modal>);
+}
+
+function checkNativeDevices() {
+    if (nativeCapture.removeUnavailable(new Set(nativeDevices().map(device => device.guid || device.id))))
+        reportError("Stream Audio input disconnected. Select an available input and restart sharing.");
+}
+
+export default definePlugin({
+    name: "StreamAudioDevice",
+    description: "Use a microphone or virtual mix as screen-share audio, independently of your voice-chat microphone",
+    authors: [Devs.Wuerfelhusten],
+    tags: ["Voice", "Media"],
+    searchTerms: ["Wave Link", "microphone", "stream mix", "screenshare"],
+    settings,
+    toolboxActions: { "Stream Audio": openSettings },
+    requiresRestart: true,
+    patches: [
+        {
+            find: "stream-settings-audio-enable",
+            replacement: {
+                match: /(?<=children:\[)(?=\i,\i\?\i:null,\i,\i,\i\])/,
+                replace: "$self.renderMenu(),"
+            }
+        },
+        {
+            find: "createOwnStreamConnectionWithOptions",
+            predicate: () => IS_DISCORD_DESKTOP,
+            group: true,
+            replacement: [
+                {
+                    match: /setGoLiveSource\((\i)\)\{(?=let\{resolution:)/,
+                    replace: "setGoLiveSource($1){$1=$self.prepareNativeSource(this,$1);"
+                },
+                {
+                    match: /clearDesktopSource\(\)\{(?=this\.goLiveSourceIdentifier)/,
+                    replace: "clearDesktopSource(){$self.releaseNative(this);"
+                },
+                {
+                    match: /this\.conn\.destroy\(\i\)/g,
+                    replace: "($self.releaseNative(this),$&)"
+                }
+            ]
+        }
+    ],
+
+    renderMenu: () => <Menu.MenuItem id="vc-stream-audio" label="Stream Audio" action={openSettings} />,
+
+    prepareNativeSource(connection: NativeStreamConnection, source: NativeSource) {
+        if (!running) return source;
+        const device = selectedDevice();
+        try {
+            return nativeCapture.prepare(connection, source, device,
+                !device || nativeDevices().some(input => (input.guid || input.id) === device));
+        } catch (error) {
+            reportError(error instanceof Error ? error.message : "Could not open Stream Audio input.");
+            throw error;
+        }
+    },
+
+    releaseNative: (connection: NativeStreamConnection) => nativeCapture.release(connection),
+
+    start() {
+        running = true;
+        if (IS_DISCORD_DESKTOP) {
+            MediaEngineStore.addChangeListener(checkNativeDevices);
+            return;
+        }
+        originalDisplayMedia = navigator.mediaDevices.getDisplayMedia;
+        const original = originalDisplayMedia;
+        wrappedDisplayMedia = function (this: MediaDevices, options) {
+            const device = selectedDevice();
+            if (!running || !device) return original.call(this, options);
+            // Call synchronously: getDisplayMedia requires transient user activation.
+            return capture.capture(original.call(this, { ...options, audio: false }), device,
+                constraints => navigator.mediaDevices.getUserMedia(constraints));
+        };
+        navigator.mediaDevices.getDisplayMedia = wrappedDisplayMedia;
+    },
+
+    stop() {
+        running = false;
+        capture.stop();
+        nativeCapture.stop();
+        if (IS_DISCORD_DESKTOP) MediaEngineStore.removeChangeListener(checkNativeDevices);
+        if (wrappedDisplayMedia && navigator.mediaDevices.getDisplayMedia === wrappedDisplayMedia)
+            navigator.mediaDevices.getDisplayMedia = originalDisplayMedia!;
+    }
+});

--- a/src/plugins/streamAudioDevice.desktop/nativeCapture.ts
+++ b/src/plugins/streamAudioDevice.desktop/nativeCapture.ts
@@ -1,0 +1,83 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface NativeStreamConnection {
+    context: string;
+    userId: string;
+    streamUserId?: string;
+    conn: {
+        setGoLiveDevices?: (options: { audioInputDeviceId: string; }) => void;
+        clearGoLiveDevices?: () => void;
+        clearDesktopSource?: () => void;
+    };
+    setSoundshareSource(id: number, active: boolean): void;
+}
+
+export interface NativeSource {
+    desktopDescription?: { id: string | null; soundshareId: number; useLoopback: boolean; };
+    cameraDescription?: unknown;
+}
+
+/** Uses the local stream connection, not the engine-wide microphone setter. */
+export class NativeStreamAudio {
+    private sessions = new Map<NativeStreamConnection, string>();
+
+    prepare<T extends NativeSource>(connection: NativeStreamConnection, source: T, deviceId: string, available: boolean): T {
+        if (connection.context !== "stream" || connection.streamUserId !== connection.userId) return source;
+        if (!source.desktopDescription?.id || !deviceId) {
+            this.release(connection);
+            return source;
+        }
+
+        // This capability exists in Discord's camera-stream path. Availability
+        // is checked explicitly because native modules update independently.
+        if (!available || !connection.conn.setGoLiveDevices || !connection.conn.clearGoLiveDevices) {
+            this.release(connection);
+            connection.setSoundshareSource(0, false);
+            connection.conn.clearDesktopSource?.();
+            throw new Error(!available ? "The selected Stream Audio device is unavailable." : "This Discord version does not support the required stream audio interface.");
+        }
+        if (this.sessions.get(connection) !== deviceId) {
+            this.release(connection);
+            connection.setSoundshareSource(0, false);
+            try {
+                connection.conn.setGoLiveDevices({ audioInputDeviceId: deviceId });
+                this.sessions.set(connection, deviceId);
+            } catch (error) {
+                connection.conn.clearGoLiveDevices();
+                connection.conn.clearDesktopSource?.();
+                throw error;
+            }
+        }
+        return {
+            ...source,
+            desktopDescription: { ...source.desktopDescription, soundshareId: 0, useLoopback: false }
+        };
+    }
+
+    release(connection: NativeStreamConnection) {
+        if (!this.sessions.delete(connection)) return;
+        connection.conn.clearGoLiveDevices?.();
+    }
+
+    stop() {
+        for (const connection of [...this.sessions.keys()]) {
+            try { this.release(connection); }
+            finally { connection.conn.clearDesktopSource?.(); }
+        }
+    }
+
+    removeUnavailable(available: Set<string>): boolean {
+        let removed = false;
+        for (const [connection, device] of this.sessions) {
+            if (available.has(device)) continue;
+            this.release(connection);
+            connection.conn.clearDesktopSource?.();
+            removed = true;
+        }
+        return removed;
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -666,6 +666,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "yuna0x0",
         id: 213656926414831616n
     },
+    Wuerfelhusten: {
+        name: "Wuerfelhusten",
+        id: 0n
+    },
     Davri: {
         name: "Davri",
         id: 457579346282938368n

--- a/tests/streamAudio.test.ts
+++ b/tests/streamAudio.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import { StreamAudioCapture } from "../src/plugins/streamAudioDevice.desktop/capture";
+import { NativeStreamAudio, type NativeStreamConnection } from "../src/plugins/streamAudioDevice.desktop/nativeCapture";
+
+class Track extends EventTarget {
+    readyState = "live";
+    constructor(readonly kind: string) { super(); }
+    stop() { this.readyState = "ended"; }
+    disconnect() { this.readyState = "ended"; this.dispatchEvent(new Event("ended")); }
+}
+class Stream extends EventTarget {
+    constructor(private tracks: Track[]) { super(); }
+    getTracks() { return [...this.tracks]; }
+    getVideoTracks() { return this.tracks.filter(t => t.kind === "video"); }
+    getAudioTracks() { return this.tracks.filter(t => t.kind === "audio"); }
+    addTrack(track: Track) { this.tracks.push(track); }
+    removeTrack(track: Track) { this.tracks = this.tracks.filter(t => t !== track); }
+}
+const asStream = (s: Stream) => s as unknown as MediaStream;
+const setup = () => {
+    const video = new Track("video"), loopback = new Track("audio"), input = new Track("audio");
+    const screen = new Stream([video, loopback]);
+    const errors: string[] = [];
+    return { video, loopback, input, screen, errors, capture: new StreamAudioCapture(e => errors.push(e)) };
+};
+
+test("replacement removes loopback, uses the exact device without voice processing, and ends with video", async () => {
+    const { video, loopback, input, screen, capture } = setup();
+    const voiceChat = new Track("audio");
+    await capture.capture(Promise.resolve(asStream(screen)), "wave-link", async constraints => {
+        assert.equal(loopback.readyState, "ended");
+        assert.deepEqual(constraints, { video: false, audio: {
+            deviceId: { exact: "wave-link" }, echoCancellation: false, noiseSuppression: false, autoGainControl: false
+        } });
+        return asStream(new Stream([input]));
+    });
+    assert.deepEqual(screen.getAudioTracks(), [input]);
+    video.stop();
+    assert.equal(input.readyState, "ended");
+    assert.equal(voiceChat.readyState, "live");
+    capture.stop(); // Idempotent after Discord stopped the video.
+});
+
+test("permission failure closes screen and loopback without falling back", async () => {
+    const { video, loopback, screen, capture, errors } = setup();
+    await assert.rejects(capture.capture(Promise.resolve(asStream(screen)), "missing", async () => { throw new Error("denied"); }));
+    assert.equal(video.readyState, "ended");
+    assert.equal(loopback.readyState, "ended");
+    assert.equal(errors.length, 1);
+});
+
+test("unplugging input ends the share and reports the loss", async () => {
+    const { video, input, screen, capture, errors } = setup();
+    await capture.capture(Promise.resolve(asStream(screen)), "mic", async () => asStream(new Stream([input])));
+    input.disconnect();
+    assert.equal(video.readyState, "ended");
+    assert.equal(errors.length, 1);
+});
+
+test("disabling while permission is pending releases late-arriving input", async () => {
+    const { video, input, screen, capture } = setup();
+    let resolve!: (s: MediaStream) => void;
+    const pending = capture.capture(Promise.resolve(asStream(screen)), "mic", () => new Promise(r => { resolve = r; }));
+    await Promise.resolve();
+    capture.stop();
+    resolve(asStream(new Stream([input])));
+    await assert.rejects(pending);
+    assert.equal(input.readyState, "ended");
+    assert.equal(video.readyState, "ended");
+});
+
+test("screen ending while input is pending never returns a live microphone", async () => {
+    const { video, input, screen, capture } = setup();
+    let resolve!: (s: MediaStream) => void;
+    const pending = capture.capture(Promise.resolve(asStream(screen)), "mic", () => new Promise(r => { resolve = r; }));
+    await Promise.resolve();
+    video.stop();
+    resolve(asStream(new Stream([input])));
+    await assert.rejects(pending);
+    assert.equal(input.readyState, "ended");
+});
+
+function nativeSetup() {
+    const calls: unknown[] = [];
+    const connection: NativeStreamConnection = {
+        context: "stream", userId: "self", streamUserId: "self",
+        conn: {
+            setGoLiveDevices: options => { calls.push(options); },
+            clearGoLiveDevices: () => { calls.push("clear-input"); },
+            clearDesktopSource: () => { calls.push("clear-video"); }
+        },
+        setSoundshareSource: (id, active) => { calls.push([id, active]); }
+    };
+    const source = { desktopDescription: { id: "screen:1", soundshareId: 123, useLoopback: true }, quality: { resolution: 1080 } };
+    return { calls, connection, source, capture: new NativeStreamAudio() };
+}
+
+test("native input belongs only to our stream, never voice chat or an incoming stream", () => {
+    const { connection, source, capture, calls } = nativeSetup();
+    connection.context = "default";
+    assert.equal(capture.prepare(connection, source, "mic", true), source);
+    connection.context = "stream";
+    connection.streamUserId = "other-user";
+    assert.equal(capture.prepare(connection, source, "mic", true), source);
+    assert.deepEqual(calls, []);
+});
+
+test("native replacement preserves video source and quality, suppresses loopback, and releases input", () => {
+    const { connection, source, capture, calls } = nativeSetup();
+    const result = capture.prepare(connection, source, "wave-guid", true);
+    assert.equal(result.desktopDescription.id, "screen:1");
+    assert.equal(result.quality, source.quality);
+    assert.equal(result.desktopDescription.useLoopback, false);
+    assert.equal(source.desktopDescription.useLoopback, true);
+    assert.deepEqual(calls, [[0, false], { audioInputDeviceId: "wave-guid" }]);
+    capture.prepare(connection, source, "wave-guid", true);
+    assert.equal(calls.length, 2);
+    capture.release(connection);
+    assert.equal(calls.at(-1), "clear-input");
+});
+
+test("missing native input and unsupported interface fail closed", () => {
+    for (const missingDevice of [true, false]) {
+        const { connection, source, capture, calls } = nativeSetup();
+        if (!missingDevice) delete connection.conn.setGoLiveDevices;
+        assert.throws(() => capture.prepare(connection, source, "mic", !missingDevice));
+        assert.deepEqual(calls, [[0, false], "clear-video"]);
+    }
+});
+
+test("native default passes through and unplugging removes only owned capture", () => {
+    const { connection, source, capture, calls } = nativeSetup();
+    assert.equal(capture.prepare(connection, source, "", true), source);
+    assert.deepEqual(calls, []);
+    capture.prepare(connection, source, "mic", true);
+    assert.equal(capture.removeUnavailable(new Set()), true);
+    assert.deepEqual(calls.slice(-2), ["clear-input", "clear-video"]);
+    assert.equal(capture.removeUnavailable(new Set()), false);
+});
+
+test("source integration patches match the inspected public Discord build", { skip: !process.env.DISCORD_BUNDLE }, () => {
+    const code = readFileSync(process.env.DISCORD_BUNDLE!, "utf8");
+    const patterns = [
+        /setGoLiveSource\(([A-Za-z_$][\w$]*)\)\{(?=let\{resolution:)/,
+        /clearDesktopSource\(\)\{(?=this\.goLiveSourceIdentifier)/,
+        /this\.conn\.destroy\([A-Za-z_$][\w$]*\)/,
+        /(?<=children:\[)(?=[A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\?[A-Za-z_$][\w$]*:null,[A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\])/
+    ];
+    for (const pattern of patterns) assert.ok(pattern.test(code), `No match: ${pattern}`);
+});


### PR DESCRIPTION
Adds **StreamAudioDevice** to select **Discord Default** or any available microphone/virtual audio input for screen-share audio, independently of the voice-chat microphone.

This is **not a bug or performance fix**. It lets users fine-tune exactly what they broadcast using virtual audio-cable or mixing software such as **Elgato Wave Link**.

Vesktop tested successfully with Wave Link; Discord Desktop still needs end-to-end testing. Repository checks and 10 plugin tests pass.
